### PR TITLE
Add Google Calendar agenda integration

### DIFF
--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -18,5 +18,11 @@
   },
   "wifi": {
     "preferredInterface": "wlan0"
+  },
+  "calendar": {
+    "enabled": false,
+    "icsUrl": "https://calendar.google.com/calendar/ical/tu_id_privado/basic.ics",
+    "maxEvents": 3,
+    "notifyMinutesBefore": 15
   }
 }

--- a/backend/services/calendar.py
+++ b/backend/services/calendar.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime, time as dt_time, timedelta, timezone
+from time import monotonic
+from typing import Dict, List, Optional, Tuple
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from .config import CalendarConfig
+
+
+class CalendarServiceError(Exception):
+    """Generic calendar service error."""
+
+
+@dataclass
+class ParsedCalendarEvent:
+    title: str
+    start: datetime
+    end: Optional[datetime]
+    all_day: bool
+
+
+class CalendarService:
+    """Fetch and cache events from a remote iCalendar feed."""
+
+    def __init__(self) -> None:
+        self._client = httpx.AsyncClient(timeout=10.0)
+        self._cache: Dict[str, Tuple[float, List[ParsedCalendarEvent]]] = {}
+        self._timezone = datetime.now().astimezone().tzinfo or timezone.utc
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def events_for_today(self, config: Optional[CalendarConfig]) -> List[ParsedCalendarEvent]:
+        if not config or not config.enabled or not config.icsUrl:
+            return []
+
+        today = datetime.now(tz=self._timezone).date()
+        cache_key = f"{config.icsUrl}|{today.isoformat()}"
+        cached = self._cache.get(cache_key)
+        now_monotonic = monotonic()
+        if cached and now_monotonic - cached[0] < 300:
+            return cached[1]
+
+        try:
+            response = await self._client.get(str(config.icsUrl), headers={"Cache-Control": "no-cache"})
+            response.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - network failure path
+            raise CalendarServiceError("No se pudo descargar el calendario") from exc
+
+        events = self._parse_ics(response.text)
+        filtered = self._filter_for_day(events, today)
+        filtered.sort(key=lambda event: event.start)
+        limit = max(1, min(config.maxEvents or 3, 10))
+        limited = filtered[:limit]
+        self._cache[cache_key] = (now_monotonic, limited)
+        return limited
+
+    def _filter_for_day(self, events: List[ParsedCalendarEvent], day: date) -> List[ParsedCalendarEvent]:
+        matches: List[ParsedCalendarEvent] = []
+        for event in events:
+            start_local = event.start.astimezone(self._timezone)
+            end_local = event.end.astimezone(self._timezone) if event.end else None
+            if event.all_day:
+                start_date = start_local.date()
+                end_date = (
+                    (end_local - timedelta(days=1)).date() if end_local else start_date
+                )
+            else:
+                start_date = start_local.date()
+                end_date = end_local.date() if end_local else start_date
+
+            if start_date <= day <= end_date:
+                matches.append(event)
+        return matches
+
+    def _parse_ics(self, payload: str) -> List[ParsedCalendarEvent]:
+        events: List[ParsedCalendarEvent] = []
+        for raw_event in self._extract_event_blocks(payload):
+            parsed = self._parse_event_block(raw_event)
+            if parsed:
+                events.append(parsed)
+        return events
+
+    def _extract_event_blocks(self, payload: str) -> List[List[str]]:
+        lines = self._unfold(payload)
+        blocks: List[List[str]] = []
+        current: List[str] = []
+        inside = False
+        for line in lines:
+            if line == "BEGIN:VEVENT":
+                current = []
+                inside = True
+                continue
+            if line == "END:VEVENT" and inside:
+                blocks.append(current.copy())
+                inside = False
+                current = []
+                continue
+            if inside:
+                current.append(line)
+        return blocks
+
+    def _parse_event_block(self, lines: List[str]) -> Optional[ParsedCalendarEvent]:
+        fields: Dict[str, Tuple[Dict[str, str], str]] = {}
+        for line in lines:
+            if ":" not in line:
+                continue
+            key_part, value = line.split(":", 1)
+            key_parts = key_part.split(";")
+            name = key_parts[0].upper()
+            params: Dict[str, str] = {}
+            for param in key_parts[1:]:
+                if "=" in param:
+                    p_key, p_value = param.split("=", 1)
+                    params[p_key.upper()] = p_value
+            fields[name] = (params, value)
+
+        if "SUMMARY" not in fields or "DTSTART" not in fields:
+            return None
+
+        summary = fields["SUMMARY"][1]
+        dtstart_params, dtstart_value = fields["DTSTART"]
+        dtend_params, dtend_value = fields.get("DTEND", ({}, ""))
+
+        all_day = dtstart_params.get("VALUE") == "DATE"
+        try:
+            start_dt = self._parse_datetime(dtstart_value, dtstart_params.get("TZID"), all_day)
+        except ValueError:
+            return None
+        end_dt = None
+        if dtend_value:
+            try:
+                end_dt = self._parse_datetime(dtend_value, dtend_params.get("TZID"), all_day)
+            except ValueError:
+                end_dt = None
+        elif all_day:
+            end_dt = start_dt + timedelta(days=1)
+
+        return ParsedCalendarEvent(title=summary, start=start_dt, end=end_dt, all_day=all_day)
+
+    def _parse_datetime(self, value: str, tzid: Optional[str], all_day: bool) -> datetime:
+        if all_day:
+            day = datetime.strptime(value, "%Y%m%d").date()
+            return datetime.combine(day, dt_time.min, tzinfo=self._timezone)
+
+        is_utc = value.endswith("Z")
+        raw_value = value[:-1] if is_utc else value
+        dt = self._try_parse_datetime(raw_value)
+        if is_utc:
+            dt = dt.replace(tzinfo=timezone.utc)
+        elif tzid:
+            try:
+                dt = dt.replace(tzinfo=ZoneInfo(tzid))
+            except Exception:  # pragma: no cover - unknown timezone
+                dt = dt.replace(tzinfo=self._timezone)
+        else:
+            dt = dt.replace(tzinfo=self._timezone)
+        return dt.astimezone(self._timezone)
+
+    def _try_parse_datetime(self, value: str) -> datetime:
+        for fmt in ("%Y%m%dT%H%M%S", "%Y%m%dT%H%M"):
+            try:
+                return datetime.strptime(value, fmt)
+            except ValueError:
+                continue
+        raise ValueError(f"Formato de fecha desconocido: {value}")
+
+    def _unfold(self, payload: str) -> List[str]:
+        lines = payload.splitlines()
+        unfolded: List[str] = []
+        for line in lines:
+            if line.startswith(" ") or line.startswith("\t"):
+                if unfolded:
+                    unfolded[-1] += line[1:]
+            else:
+                unfolded.append(line.strip())
+        return unfolded

--- a/dash-ui/src/App.tsx
+++ b/dash-ui/src/App.tsx
@@ -9,6 +9,7 @@ import SettingsPanel from './components/SettingsPanel';
 import { DashboardConfigProvider, useDashboardConfig } from './context/DashboardConfigContext';
 import { DEFAULT_BACKGROUND_INTERVAL, DEFAULT_THEME, THEME_STORAGE_KEY, powerSave } from './services/config';
 import { THEME_MAP, type ThemeKey } from './styles/theme';
+import CalendarPeek from './components/CalendarPeek';
 
 function resolveInitialTheme(): ThemeKey {
   if (typeof window === 'undefined') return DEFAULT_THEME;
@@ -79,9 +80,10 @@ const AppContent = () => {
       footer={<ThemeSelector theme={theme} onChange={handleThemeChange} />}
     >
       <BackgroundRotator powerSave={powerSave} intervalMinutes={backgroundInterval} />
-      <div className="relative z-10 flex flex-col gap-10 items-center justify-center h-full px-8">
+      <div className="relative z-10 flex h-full flex-col items-center justify-center gap-8 px-8">
         <Clock />
         <Weather />
+        <CalendarPeek />
       </div>
       <SettingsPanel open={settingsOpen} onClose={() => setSettingsOpen(false)} />
     </Layout>

--- a/dash-ui/src/components/CalendarPeek.tsx
+++ b/dash-ui/src/components/CalendarPeek.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Calendar, Bell } from 'lucide-react';
+import { fetchTodayEvents, type CalendarEvent } from '../services/calendar';
+import { useDashboardConfig } from '../context/DashboardConfigContext';
+
+const REFRESH_INTERVAL = 5 * 60 * 1000; // 5 minutes
+
+const CalendarPeek = () => {
+  const { config } = useDashboardConfig();
+  const calendarPrefs = config?.calendar;
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const enabled = Boolean(calendarPrefs?.enabled && calendarPrefs?.icsConfigured);
+
+  useEffect(() => {
+    if (!enabled) {
+      setEvents([]);
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchTodayEvents();
+        if (!cancelled) {
+          setEvents(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          console.warn('No se pudo sincronizar calendario', err);
+          setError('Sin respuesta del calendario');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load().catch(() => {
+      // handled via error state
+    });
+
+    const interval = window.setInterval(() => {
+      load().catch(() => {
+        // handled via error state
+      });
+    }, REFRESH_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [enabled, calendarPrefs?.maxEvents, calendarPrefs?.notifyMinutesBefore]);
+
+  const todayLabel = useMemo(
+    () =>
+      new Date().toLocaleDateString('es-ES', {
+        weekday: 'short',
+        day: 'numeric',
+        month: 'short',
+      }),
+    []
+  );
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <aside className="w-full max-w-md rounded-3xl border border-white/10 bg-black/40 p-4 text-slate-100 shadow-xl shadow-emerald-500/10 backdrop-blur">
+      <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.3em] text-slate-300/70">
+        <span className="flex items-center gap-2">
+          <Calendar className="h-4 w-4" aria-hidden />
+          Agenda
+        </span>
+        <span>{todayLabel}</span>
+      </div>
+      <div className="mt-3 space-y-3 text-sm">
+        {loading && <p className="text-slate-300/60">Sincronizando…</p>}
+        {!loading && error && <p className="text-rose-300">{error}</p>}
+        {!loading && !error && events.length === 0 && (
+          <p className="text-slate-300/60">Nada programado para hoy.</p>
+        )}
+        {!loading && !error &&
+          events.map((event) => (
+            <article
+              key={`${event.title}-${event.start}`}
+              className={`flex items-start justify-between rounded-2xl border border-white/5 bg-white/5 px-3 py-2 transition ${
+                event.notify ? 'ring-2 ring-emerald-400/80' : 'ring-1 ring-white/5'
+              }`}
+            >
+              <div>
+                <h3 className="text-sm font-semibold leading-tight text-slate-100">{event.title}</h3>
+                <p className="text-xs text-slate-300/70">{formatEventTime(event)}</p>
+              </div>
+              {event.notify && <Bell className="mt-1 h-4 w-4 flex-shrink-0 text-emerald-300" aria-hidden />}
+            </article>
+          ))}
+      </div>
+    </aside>
+  );
+};
+
+function formatEventTime(event: CalendarEvent): string {
+  if (event.allDay) {
+    return 'Todo el día';
+  }
+  const start = new Date(event.start);
+  const startLabel = start.toLocaleTimeString('es-ES', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  if (!event.end) {
+    return startLabel;
+  }
+  const end = new Date(event.end);
+  const endLabel = end.toLocaleTimeString('es-ES', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  return `${startLabel} – ${endLabel}`;
+}
+
+export default CalendarPeek;

--- a/dash-ui/src/services/calendar.ts
+++ b/dash-ui/src/services/calendar.ts
@@ -1,0 +1,13 @@
+import { apiRequest } from './config';
+
+export interface CalendarEvent {
+  title: string;
+  start: string;
+  end?: string | null;
+  allDay: boolean;
+  notify: boolean;
+}
+
+export async function fetchTodayEvents(): Promise<CalendarEvent[]> {
+  return await apiRequest<CalendarEvent[]>('/calendar/today');
+}

--- a/dash-ui/src/services/config.ts
+++ b/dash-ui/src/services/config.ts
@@ -21,6 +21,7 @@ export interface WeatherConfig {
   lon?: number;
   city?: string;
   units?: 'metric' | 'imperial';
+  apiKey?: string;
 }
 
 export interface ThemeConfig {
@@ -40,12 +41,21 @@ export interface WifiConfig {
   preferredInterface?: string;
 }
 
+export interface CalendarConfig {
+  enabled?: boolean;
+  icsUrl?: string;
+  maxEvents?: number;
+  notifyMinutesBefore?: number;
+  icsConfigured?: boolean;
+}
+
 export interface DashboardConfig {
   weather?: WeatherConfig;
   theme?: ThemeConfig;
   background?: BackgroundConfig;
   tts?: TTSConfig;
   wifi?: WifiConfig;
+  calendar?: CalendarConfig;
 }
 
 export type ConfigUpdate = Partial<DashboardConfig>;

--- a/dash-ui/tsconfig.json
+++ b/dash-ui/tsconfig.json
@@ -10,7 +10,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": false,

--- a/dash-ui/tsconfig.node.json
+++ b/dash-ui/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]


### PR DESCRIPTION
## Summary
- add calendar configuration schema, service and `/api/calendar/today` endpoint to the backend
- include calendar defaults in the sample config file and adjust TypeScript settings for bundler resolution
- surface a calendar tab in the settings panel and render a subtle agenda widget fed by the new API

## Testing
- npm run build
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e7841f62f883269ff963e49930f8af