### PR TITLE
Add day info backend service and UI widget

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -51,6 +51,7 @@ La mini-web de configuración está en `/setup`. Los endpoints REST principales:
 - `GET /api/network/status`, `GET /api/wifi/scan`, `POST /api/wifi/connect`
 - `POST /api/location/override` (geolocalización desde el navegador)
 - `GET /api/time/sync_status` para comprobar `systemd-timesyncd`
+- `GET /api/day/brief` para efemérides, santoral y festivos
 
 ### Tormentas y Radar (AEMET)
 
@@ -66,6 +67,19 @@ La mini-web de configuración está en `/setup`. Los endpoints REST principales:
 - Notas:
   - Actualmente no existen datos JSON públicos fiables de rayos; se usa una heurística basada en precipitación y descriptores de tormenta.
   - Preparado para integrar rayos cuando haya fuente estable (respetando la configuración experimental).
+
+### Efemérides, Santoral y Festivos
+
+- Endpoint: `GET /api/day/brief?date=YYYY-MM-DD` (fecha opcional, por defecto hoy).
+- Fuentes empleadas:
+  - Wikipedia (API REST "On This Day") para efemérides históricas.
+  - Wikipedia (sección de santoral) con fallback local `backend/data/santoral_es.json`.
+  - [Nager.Date](https://date.nager.at) para festivos nacionales y autonómicos de España.
+  - `config.json` para patrón local configurable.
+- Caché: `backend/storage/cache/dayinfo_YYYY-MM-DD.json` (TTL 24h) para limitar peticiones remotas.
+- Limitaciones:
+  - Los festivos regionales dependen de los códigos `counties` que expone la API de Nager.Date.
+  - El patrón local sólo se resuelve si coincide con la fecha configurada (`config.patron`).
 
 ## Cachés y almacenamiento
 

--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -34,5 +34,17 @@
     "icsUrl": "https://calendar.google.com/calendar/ical/tu_id_privado/basic.ics",
     "maxEvents": 3,
     "notifyMinutesBefore": 15
+  },
+  "locale": {
+    "country": "ES",
+    "autonomousCommunity": "Comunitat Valenciana",
+    "province": "Castellón",
+    "city": "Vila-real"
+  },
+  "patron": {
+    "city": "Vila-real",
+    "name": "Sant Pasqual Baylón",
+    "month": 5,
+    "day": 17
   }
 }

--- a/backend/config/config.json
+++ b/backend/config/config.json
@@ -34,5 +34,17 @@
     "icsUrl": "https://calendar.google.com/calendar/ical/tu_id_privado/basic.ics",
     "maxEvents": 3,
     "notifyMinutesBefore": 15
+  },
+  "locale": {
+    "country": "ES",
+    "autonomousCommunity": "Comunitat Valenciana",
+    "province": "Castellón",
+    "city": "Vila-real"
+  },
+  "patron": {
+    "city": "Vila-real",
+    "name": "Sant Pasqual Baylón",
+    "month": 5,
+    "day": 17
   }
 }

--- a/backend/config/schema.json
+++ b/backend/config/schema.json
@@ -48,6 +48,26 @@
       "properties": {
         "preferredInterface": { "type": "string" }
       }
+    },
+    "locale": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "country": { "type": "string", "minLength": 2 },
+        "autonomousCommunity": { "type": "string" },
+        "province": { "type": "string" },
+        "city": { "type": "string" }
+      }
+    },
+    "patron": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "city": { "type": "string" },
+        "name": { "type": "string" },
+        "month": { "type": "integer", "minimum": 1, "maximum": 12 },
+        "day": { "type": "integer", "minimum": 1, "maximum": 31 }
+      }
     }
   }
 }

--- a/backend/data/santoral_es.json
+++ b/backend/data/santoral_es.json
@@ -1,0 +1,76 @@
+{
+  "1": {
+    "1": ["Santa María, Madre de Dios", "San Manuel"],
+    "2": ["San Basilio Magno", "San Gregorio Nacianceno"],
+    "6": ["Epifanía del Señor", "San Andrés Corsini"],
+    "17": ["San Antonio Abad"]
+  },
+  "2": {
+    "2": ["La Presentación del Señor"],
+    "11": ["Nuestra Señora de Lourdes"],
+    "14": ["San Valentín"],
+    "28": ["San Leandro de Sevilla"]
+  },
+  "3": {
+    "17": ["San Patricio"],
+    "19": ["San José", "San José, esposo de la Virgen María"],
+    "25": ["La Anunciación del Señor"]
+  },
+  "4": {
+    "4": ["San Isidoro de Sevilla"],
+    "23": ["San Jorge"],
+    "25": ["San Marcos Evangelista"],
+    "30": ["San Pío V"]
+  },
+  "5": {
+    "1": ["San José Obrero"],
+    "3": ["San Felipe apóstol", "Santiago el Menor"],
+    "15": ["San Isidro Labrador"],
+    "17": ["San Pascual Baylón"],
+    "31": ["La Visitación de la Virgen María"]
+  },
+  "6": {
+    "13": ["San Antonio de Padua"],
+    "24": ["Natividad de San Juan Bautista"],
+    "29": ["San Pedro y San Pablo"]
+  },
+  "7": {
+    "16": ["Nuestra Señora del Carmen"],
+    "22": ["Santa María Magdalena"],
+    "25": ["Santiago Apóstol"],
+    "26": ["San Joaquín y Santa Ana"]
+  },
+  "8": {
+    "4": ["San Juan María Vianney"],
+    "10": ["San Lorenzo"],
+    "15": ["Asunción de la Virgen"],
+    "24": ["San Bartolomé"]
+  },
+  "9": {
+    "8": ["Natividad de la Virgen María"],
+    "12": ["El Dulce Nombre de María"],
+    "15": ["Nuestra Señora de los Dolores"],
+    "29": ["San Miguel, San Gabriel y San Rafael"]
+  },
+  "10": {
+    "1": ["Santa Teresa del Niño Jesús"],
+    "4": ["San Francisco de Asís"],
+    "12": ["Virgen del Pilar"],
+    "31": ["Todos los Santos"],
+    "13": ["San Eduardo el Confesor"]
+  },
+  "11": {
+    "1": ["Todos los Santos"],
+    "2": ["Conmemoración de los Fieles Difuntos"],
+    "11": ["San Martín de Tours"],
+    "25": ["Santa Catalina de Alejandría"]
+  },
+  "12": {
+    "6": ["San Nicolás de Bari"],
+    "8": ["Inmaculada Concepción"],
+    "13": ["Santa Lucía"],
+    "25": ["Navidad del Señor"],
+    "26": ["San Esteban"],
+    "31": ["San Silvestre"]
+  }
+}

--- a/backend/services/config.py
+++ b/backend/services/config.py
@@ -88,6 +88,20 @@ class CalendarConfig(BaseModel):
         populate_by_name = True
 
 
+class LocaleConfig(BaseModel):
+    country: Optional[str] = None
+    autonomousCommunity: Optional[str] = None
+    province: Optional[str] = None
+    city: Optional[str] = None
+
+
+class PatronConfig(BaseModel):
+    city: Optional[str] = None
+    name: Optional[str] = None
+    month: Optional[int] = Field(default=None, ge=1, le=12)
+    day: Optional[int] = Field(default=None, ge=1, le=31)
+
+
 class AppConfig(BaseModel):
     aemet: Optional[AemetConfig] = None
     weather: Optional[WeatherConfig] = None
@@ -97,6 +111,8 @@ class AppConfig(BaseModel):
     tts: Optional[TTSConfig] = None
     wifi: Optional[WifiConfig] = None
     calendar: Optional[CalendarConfig] = None
+    locale: Optional[LocaleConfig] = None
+    patron: Optional[PatronConfig] = None
 
     def public_view(self) -> Dict[str, Any]:
         return {
@@ -134,6 +150,16 @@ class AppConfig(BaseModel):
                     "icsConfigured": bool(self.calendar.icsUrl) if self.calendar else False,
                 }
                 if self.calendar
+                else {}
+            ),
+            "locale": (self.locale.dict() if self.locale else {}),
+            "patron": (
+                {
+                    key: value
+                    for key, value in (self.patron.dict() if self.patron else {}).items()
+                    if key in {"city", "name", "month", "day"}
+                }
+                if self.patron
                 else {}
             ),
         }
@@ -187,6 +213,8 @@ def update_config(payload: Dict[str, Any]) -> AppConfig:
         "tts": {"voice", "volume"},
         "wifi": {"preferredInterface"},
         "calendar": {"enabled", "icsUrl", "maxEvents", "notifyMinutesBefore"},
+        "locale": {"country", "autonomousCommunity", "province", "city"},
+        "patron": {"city", "name", "month", "day"},
     }
 
     sanitized: Dict[str, Any] = {}

--- a/backend/services/dayinfo.py
+++ b/backend/services/dayinfo.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+import unicodedata
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+import httpx
+
+from .config import AppConfig, read_config
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CACHE_DIR = PROJECT_ROOT / "storage" / "cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+CACHE_TTL_SECONDS = 24 * 60 * 60
+
+SANTORAL_FALLBACK_PATH = PROJECT_ROOT / "data" / "santoral_es.json"
+
+HTTP_TIMEOUT = httpx.Timeout(10.0, connect=10.0, read=10.0)
+HTTP_HEADERS = {"User-Agent": "PantallaDash/1.0 (+https://github.com/pantalla-dash)"}
+
+MONTH_NAMES = {
+    1: "enero",
+    2: "febrero",
+    3: "marzo",
+    4: "abril",
+    5: "mayo",
+    6: "junio",
+    7: "julio",
+    8: "agosto",
+    9: "septiembre",
+    10: "octubre",
+    11: "noviembre",
+    12: "diciembre",
+}
+
+SPANISH_REGIONS = {
+    "ES-AN": "Andalucía",
+    "ES-AR": "Aragón",
+    "ES-AS": "Principado de Asturias",
+    "ES-CN": "Canarias",
+    "ES-CB": "Cantabria",
+    "ES-CL": "Castilla y León",
+    "ES-CM": "Castilla-La Mancha",
+    "ES-CT": "Cataluña",
+    "ES-EX": "Extremadura",
+    "ES-GA": "Galicia",
+    "ES-IB": "Islas Baleares",
+    "ES-RI": "La Rioja",
+    "ES-MD": "Comunidad de Madrid",
+    "ES-MC": "Región de Murcia",
+    "ES-NC": "Comunidad Foral de Navarra",
+    "ES-PV": "País Vasco",
+    "ES-VC": "Comunitat Valenciana",
+    "ES-CE": "Ceuta",
+    "ES-ML": "Melilla",
+}
+
+_NAGER_CACHE: dict[int, list[dict[str, Any]]] = {}
+_SANTORAL_FALLBACK: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class LocaleConfig:
+    country: Optional[str] = None
+    autonomousCommunity: Optional[str] = None
+    province: Optional[str] = None
+    city: Optional[str] = None
+
+
+@dataclass
+class PatronConfig:
+    city: Optional[str] = None
+    name: Optional[str] = None
+    month: Optional[int] = None
+    day: Optional[int] = None
+
+
+def get_day_info(target_date: date) -> Dict[str, Any]:
+    """Return historical efemerides, santoral and holidays for a date."""
+
+    cached = _load_cache(target_date)
+    if cached is not None:
+        return cached
+
+    config = read_config()
+    locale_cfg = _extract_locale(config)
+    patron_cfg = _extract_patron(config)
+
+    result: Dict[str, Any] = {
+        "date": target_date.isoformat(),
+        "efemerides": [],
+        "santoral": [],
+        "holiday": {"is_holiday": False, "source": "nager.date", "scope": None, "region": None, "name": None},
+        "patron": None,
+    }
+
+    try:
+        result["efemerides"] = _fetch_wikipedia_efemerides(target_date.day, target_date.month)
+    except Exception as exc:  # pragma: no cover - dependent on remote API
+        logger.warning("No se pudieron obtener efemérides de Wikipedia: %s", exc)
+
+    try:
+        santoral_entries = _fetch_wikipedia_santoral(target_date.day, target_date.month)
+        if not santoral_entries:
+            raise ValueError("Respuesta de santoral vacía")
+        result["santoral"] = santoral_entries
+    except Exception as exc:  # pragma: no cover - dependent on remote API
+        logger.warning("Fallo en santoral de Wikipedia: %s", exc)
+        fallback = _from_local_santoral_fallback(target_date.day, target_date.month)
+        if fallback:
+            result["santoral"] = fallback
+
+    try:
+        result["holiday"] = _resolve_today_holiday(target_date, locale_cfg)
+    except Exception as exc:  # pragma: no cover - dependent on remote API
+        logger.warning("No se pudo resolver festivo: %s", exc)
+        result["holiday"] = {"is_holiday": False, "scope": None, "region": None, "name": None, "source": "nager.date"}
+
+    patron = _resolve_patron(target_date, patron_cfg)
+    if patron:
+        result["patron"] = patron
+
+    _store_cache(target_date, result)
+    return result
+
+
+def _load_cache(target_date: date) -> Optional[Dict[str, Any]]:
+    path = CACHE_DIR / f"dayinfo_{target_date.isoformat()}.json"
+    if not path.exists():
+        return None
+    try:
+        age = time.time() - path.stat().st_mtime
+        if age > CACHE_TTL_SECONDS:
+            return None
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.debug("Caché de dayinfo inválida en %s: %s", path, exc)
+        return None
+
+
+def _store_cache(target_date: date, payload: Dict[str, Any]) -> None:
+    path = CACHE_DIR / f"dayinfo_{target_date.isoformat()}.json"
+    try:
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2)
+    except OSError as exc:
+        logger.warning("No se pudo escribir la caché de dayinfo: %s", exc)
+
+
+def _http_get_json(url: str, *, params: Optional[dict[str, Any]] = None) -> Any:
+    last_exc: Optional[Exception] = None
+    for attempt in range(2):
+        try:
+            response = httpx.get(url, params=params, timeout=HTTP_TIMEOUT, headers=HTTP_HEADERS)
+            response.raise_for_status()
+            return response.json()
+        except (httpx.TimeoutException, httpx.HTTPError) as exc:
+            last_exc = exc
+            if attempt == 0:
+                time.sleep(0.5)
+            else:
+                raise
+    raise RuntimeError("Unreachable") from last_exc
+
+
+def _fetch_wikipedia_efemerides(day: int, month: int) -> List[Dict[str, Any]]:
+    url = f"https://es.wikipedia.org/api/rest_v1/feed/onthisday/events/{month:02d}/{day:02d}"
+    payload = _http_get_json(url)
+    events = payload.get("events") if isinstance(payload, dict) else None
+    if not isinstance(events, list):
+        return []
+
+    filtered = [event for event in events if isinstance(event, dict) and event.get("text")]
+    filtered.sort(key=lambda item: item.get("year", 0))
+
+    if len(filtered) <= 5:
+        selected = filtered
+    else:
+        candidate_indices = {0, len(filtered) - 1}
+        thirds = [len(filtered) // 3, len(filtered) // 2, (2 * len(filtered)) // 3]
+        candidate_indices.update(index for index in thirds if 0 <= index < len(filtered))
+        selected = [filtered[i] for i in sorted(candidate_indices)[:5]]
+
+    result: List[Dict[str, Any]] = []
+    for event in selected:
+        text = str(event.get("text", "")).strip()
+        if not text:
+            continue
+        year = event.get("year")
+        try:
+            year_value = int(year)
+        except (TypeError, ValueError):
+            year_value = None
+        result.append({"text": text, "year": year_value, "source": "wikipedia"})
+    return result[:5]
+
+
+def _fetch_wikipedia_santoral(day: int, month: int) -> List[Dict[str, Any]]:
+    month_name = MONTH_NAMES.get(month)
+    if not month_name:
+        return []
+    page = f"{day} de {month_name}"
+
+    sections_payload = _http_get_json(
+        "https://es.wikipedia.org/w/api.php",
+        params={
+            "action": "parse",
+            "format": "json",
+            "page": page,
+            "prop": "sections",
+            "redirects": 1,
+        },
+    )
+    sections = sections_payload.get("parse", {}).get("sections", []) if isinstance(sections_payload, dict) else []
+    section_index = None
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        title = str(section.get("line", "")).lower()
+        if "santoral" in title or "onom" in title:
+            section_index = section.get("index")
+            break
+    if section_index is None:
+        return []
+
+    santoral_payload = _http_get_json(
+        "https://es.wikipedia.org/w/api.php",
+        params={
+            "action": "parse",
+            "format": "json",
+            "page": page,
+            "prop": "wikitext",
+            "section": section_index,
+            "redirects": 1,
+        },
+    )
+    wikitext = santoral_payload.get("parse", {}).get("wikitext", {}).get("*", "") if isinstance(santoral_payload, dict) else ""
+    if not wikitext:
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for line in wikitext.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("*"):
+            continue
+        cleaned = _clean_wiki_line(stripped.lstrip("*").strip())
+        if cleaned:
+            entries.append({"name": cleaned, "source": "wikipedia"})
+        if len(entries) >= 5:
+            break
+    return entries
+
+
+def _clean_wiki_line(text: str) -> str:
+    text = re.sub(r"<ref[^>]*?>.*?</ref>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<.*?>", "", text)
+    text = re.sub(r"\{\{.*?\}\}", "", text)
+    text = re.sub(r"\[\[(?:[^\]|]*\|)?([^\]]+)\]\]", r"\1", text)
+    text = text.replace("'''", "").replace("''", "")
+    text = text.strip("-–—· ")
+    return text.strip()
+
+
+def _from_local_santoral_fallback(day: int, month: int) -> List[Dict[str, Any]]:
+    global _SANTORAL_FALLBACK
+    if _SANTORAL_FALLBACK is None:
+        try:
+            with SANTORAL_FALLBACK_PATH.open("r", encoding="utf-8") as fh:
+                _SANTORAL_FALLBACK = json.load(fh)
+        except FileNotFoundError:
+            logger.info("Santoral local no disponible en %s", SANTORAL_FALLBACK_PATH)
+            _SANTORAL_FALLBACK = {}
+        except json.JSONDecodeError as exc:
+            logger.warning("Santoral local corrupto: %s", exc)
+            _SANTORAL_FALLBACK = {}
+    month_data = {}
+    if isinstance(_SANTORAL_FALLBACK, dict):
+        month_data = _SANTORAL_FALLBACK.get(str(month), {})
+    if not isinstance(month_data, dict):
+        return []
+    candidates = month_data.get(str(day), [])
+    if not isinstance(candidates, list):
+        return []
+    result = []
+    for name in candidates[:5]:
+        if isinstance(name, str) and name.strip():
+            result.append({"name": name.strip(), "source": "local"})
+    return result
+
+
+def _fetch_nager_holidays(year: int) -> list[dict[str, Any]]:
+    if year in _NAGER_CACHE:
+        return _NAGER_CACHE[year]
+    url = f"https://date.nager.at/api/v3/PublicHolidays/{year}/ES"
+    payload = _http_get_json(url)
+    if not isinstance(payload, list):
+        holidays: list[dict[str, Any]] = []
+    else:
+        holidays = [item for item in payload if isinstance(item, dict)]
+    _NAGER_CACHE[year] = holidays
+    return holidays
+
+
+def _resolve_today_holiday(target_date: date, locale_cfg: LocaleConfig) -> Dict[str, Any]:
+    holidays = _fetch_nager_holidays(target_date.year)
+    iso = target_date.isoformat()
+    match = next((item for item in holidays if item.get("date") == iso), None)
+    if not match:
+        return {"is_holiday": False, "scope": None, "region": None, "name": None, "source": "nager.date"}
+
+    counties = match.get("counties") if isinstance(match, dict) else None
+    scope = "national"
+    region = None
+    if counties:
+        scope = "regional"
+        region = _match_region(counties, locale_cfg)
+        if region is None and isinstance(counties, list) and counties:
+            region = SPANISH_REGIONS.get(counties[0], counties[0])
+    elif not match.get("global", True):
+        scope = "regional"
+        region = locale_cfg.autonomousCommunity
+
+    return {
+        "is_holiday": True,
+        "name": match.get("localName") or match.get("name"),
+        "scope": scope,
+        "region": region,
+        "source": "nager.date",
+    }
+
+
+def _match_region(counties: Iterable[str], locale_cfg: LocaleConfig) -> Optional[str]:
+    target = locale_cfg.autonomousCommunity
+    if not target:
+        return None
+    normalized_target = _normalize_str(target)
+    for code in counties:
+        if not isinstance(code, str):
+            continue
+        name = SPANISH_REGIONS.get(code)
+        if name and _normalize_str(name) == normalized_target:
+            return name
+    return None
+
+
+def _normalize_str(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode("ascii")
+    return normalized.lower().strip()
+
+
+def _resolve_patron(target_date: date, patron_cfg: PatronConfig | None) -> Optional[Dict[str, Any]]:
+    if not patron_cfg or patron_cfg.month is None or patron_cfg.day is None:
+        return None
+    if patron_cfg.month == target_date.month and patron_cfg.day == target_date.day:
+        return {
+            "place": patron_cfg.city,
+            "name": patron_cfg.name,
+            "source": "config",
+        }
+    return None
+
+
+def _extract_locale(config: AppConfig) -> LocaleConfig:
+    locale = getattr(config, "locale", None)
+    if locale is None:
+        return LocaleConfig()
+    return LocaleConfig(
+        country=getattr(locale, "country", None),
+        autonomousCommunity=getattr(locale, "autonomousCommunity", None),
+        province=getattr(locale, "province", None),
+        city=getattr(locale, "city", None),
+    )
+
+
+def _extract_patron(config: AppConfig) -> PatronConfig | None:
+    patron = getattr(config, "patron", None)
+    if patron is None:
+        return None
+    return PatronConfig(
+        city=getattr(patron, "city", None),
+        name=getattr(patron, "name", None),
+        month=getattr(patron, "month", None),
+        day=getattr(patron, "day", None),
+    )
+
+
+__all__ = ["get_day_info"]

--- a/dash-ui/src/App.tsx
+++ b/dash-ui/src/App.tsx
@@ -5,6 +5,7 @@ import Clock from './components/Clock';
 import Weather from './components/Weather';
 import WeatherBrief from './components/WeatherBrief';
 import CalendarPeek from './components/CalendarPeek';
+import DayStrip from './components/DayStrip';
 import StormOverlay from './components/StormOverlay';
 import SceneEffects from './components/SceneEffects';
 import FpsMeter from './components/FpsMeter';
@@ -60,7 +61,10 @@ const DashboardLayout = () => {
             </div>
             <WeatherBrief />
           </div>
-          <CalendarPeek />
+          <div className="flex h-full flex-col gap-3">
+            <CalendarPeek />
+            <DayStrip />
+          </div>
         </div>
       </div>
       <StormOverlay />

--- a/dash-ui/src/components/DayStrip.tsx
+++ b/dash-ui/src/components/DayStrip.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react';
+import { CalendarDays, Landmark } from 'lucide-react';
+import { fetchDayBrief, type DayInfoPayload } from '../services/dayinfo';
+
+const REFRESH_INTERVAL = 12 * 60 * 60 * 1000; // 12 horas
+
+const DayStrip = () => {
+  const [info, setInfo] = useState<DayInfoPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | undefined;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchDayBrief();
+        if (!cancelled) {
+          setInfo(data);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError('Sin información del día');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+    timer = window.setInterval(() => {
+      void load();
+    }, REFRESH_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      if (timer) {
+        window.clearInterval(timer);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const handleEsc = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => {
+      window.removeEventListener('keydown', handleEsc);
+    };
+  }, [open]);
+
+  const headline = getHeadline(info, loading, error);
+  const holidayBadge = getHolidayBadge(info);
+  const patronBadge = getPatronBadge(info);
+
+  const handleToggle = () => {
+    if (!info) return;
+    setOpen((prev) => !prev);
+  };
+
+  return (
+    <aside
+      className="relative rounded-3xl border border-sky-400/20 bg-slate-900/60 px-5 py-4 text-sky-100/80 shadow-lg backdrop-blur"
+      data-depth-blur="true"
+    >
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-4 text-left focus:outline-none"
+        onClick={handleToggle}
+        disabled={!info}
+      >
+        <div className="flex flex-1 items-center gap-3">
+          <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-sky-500/20 text-sky-100">
+            <CalendarDays className="h-5 w-5" aria-hidden />
+          </span>
+          <div className="flex flex-1 flex-col">
+            <span className="text-sm font-semibold text-sky-50/90">{headline}</span>
+            <div className="mt-1 flex flex-wrap gap-2 text-[11px] uppercase tracking-[0.3em] text-sky-200/70">
+              {holidayBadge}
+              {patronBadge}
+              {error && !info && <span className="text-rose-300">{error}</span>}
+              {loading && <span className="text-sky-200/60">Actualizando…</span>}
+            </div>
+          </div>
+        </div>
+        <span className="text-[11px] uppercase tracking-[0.35em] text-sky-200/70">{open ? 'Ocultar' : 'Ver'}</span>
+      </button>
+
+      {open && info && (
+        <div className="absolute left-0 right-0 top-full z-20 mt-3 rounded-2xl border border-sky-400/30 bg-slate-950/90 p-5 text-sky-50 shadow-xl backdrop-blur">
+          <h3 className="text-xs uppercase tracking-[0.4em] text-sky-300/70">{formatDate(info.date)}</h3>
+          <div className="mt-3 space-y-4 text-sm text-sky-100/90">
+            {info.efemerides.length > 0 && (
+              <section>
+                <h4 className="text-[13px] font-semibold uppercase tracking-[0.3em] text-sky-200/80">Efemérides</h4>
+                <ul className="mt-2 space-y-2">
+                  {info.efemerides.slice(0, 5).map((item, index) => (
+                    <li key={`${item.text}-${index}`} className="rounded-2xl bg-sky-500/10 px-3 py-2">
+                      <span className="font-semibold text-sky-100/90">{item.year ? `${item.year}: ` : ''}</span>
+                      <span>{item.text}</span>
+                      {item.source && <span className="ml-2 text-[10px] uppercase tracking-[0.3em] text-sky-300/70">{item.source}</span>}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+            {info.santoral.length > 0 && (
+              <section>
+                <h4 className="text-[13px] font-semibold uppercase tracking-[0.3em] text-sky-200/80">Santoral</h4>
+                <ul className="mt-2 flex flex-wrap gap-2 text-sm">
+                  {info.santoral.slice(0, 5).map((entry) => (
+                    <li key={entry.name} className="rounded-2xl bg-sky-500/15 px-3 py-2">
+                      {entry.name}
+                      {entry.source && <span className="ml-2 text-[10px] uppercase tracking-[0.3em] text-sky-300/70">{entry.source}</span>}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+            <section>
+              <h4 className="text-[13px] font-semibold uppercase tracking-[0.3em] text-sky-200/80">Festivos</h4>
+              {info.holiday?.is_holiday ? (
+                <p>
+                  {info.holiday.name ?? 'Festivo'}
+                  {info.holiday.scope && <span className="ml-2 text-[11px] uppercase tracking-[0.3em] text-sky-300/70">{scopeLabel(info.holiday.scope, info.holiday.region)}</span>}
+                </p>
+              ) : (
+                <p className="text-sky-200/70">Hoy no es festivo en tu región.</p>
+              )}
+            </section>
+            {info.patron && (
+              <section>
+                <h4 className="text-[13px] font-semibold uppercase tracking-[0.3em] text-sky-200/80">Patrón local</h4>
+                <p className="flex items-center gap-2">
+                  <Landmark className="h-4 w-4 text-sky-200" aria-hidden />
+                  <span>
+                    {info.patron.name}
+                    {info.patron.place && <span className="ml-2 text-sky-200/70">({info.patron.place})</span>}
+                  </span>
+                </p>
+              </section>
+            )}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+};
+
+function getHeadline(info: DayInfoPayload | null, loading: boolean, error: string | null): string {
+  if (loading && !info) {
+    return 'Actualizando efemérides…';
+  }
+  if (!info) {
+    return error ?? 'Sin datos del día';
+  }
+  if (info.efemerides.length > 0) {
+    const first = info.efemerides[0];
+    const yearLabel = typeof first.year === 'number' ? `${first.year}: ` : '';
+    return `${yearLabel}${first.text}`;
+  }
+  if (info.santoral.length > 0) {
+    const names = info.santoral
+      .slice(0, 3)
+      .map((entry) => entry.name)
+      .filter(Boolean)
+      .join(', ');
+    if (names) {
+      return `Santoral: ${names}`;
+    }
+  }
+  return error ?? 'Sin datos relevantes para hoy';
+}
+
+function getHolidayBadge(info: DayInfoPayload | null) {
+  if (!info?.holiday?.is_holiday) return null;
+  const label = scopeLabel(info.holiday.scope ?? null, info.holiday.region ?? null);
+  return <span className="rounded-full bg-sky-500/20 px-3 py-1 text-[10px] uppercase tracking-[0.4em] text-sky-200/90">{label}</span>;
+}
+
+function getPatronBadge(info: DayInfoPayload | null) {
+  if (!info?.patron) return null;
+  const place = info.patron.place ? ` (${info.patron.place})` : '';
+  return (
+    <span className="rounded-full bg-amber-500/20 px-3 py-1 text-[10px] uppercase tracking-[0.4em] text-amber-200/90">
+      Patrón: {info.patron.name}
+      {place}
+    </span>
+  );
+}
+
+function scopeLabel(scope: DayInfoPayload['holiday']['scope'], region: string | null | undefined): string {
+  switch (scope) {
+    case 'national':
+      return 'Festivo nacional';
+    case 'regional':
+      return region ? `Festivo (${region})` : 'Festivo regional';
+    case 'local':
+      return region ? `Festivo local (${region})` : 'Festivo local';
+    default:
+      return 'Festivo';
+  }
+}
+
+function formatDate(value: string): string {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleDateString('es-ES', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+export default DayStrip;

--- a/dash-ui/src/services/dayinfo.ts
+++ b/dash-ui/src/services/dayinfo.ts
@@ -1,0 +1,42 @@
+import { BACKEND_BASE_URL } from './config';
+
+export interface DayInfoEfemeride {
+  text: string;
+  year?: number | null;
+  source?: string;
+}
+
+export interface DayInfoSantoral {
+  name: string;
+  source?: string;
+}
+
+export interface DayInfoHoliday {
+  is_holiday: boolean;
+  name?: string | null;
+  scope?: 'national' | 'regional' | 'local' | null;
+  region?: string | null;
+  source?: string;
+}
+
+export interface DayInfoPatron {
+  place?: string | null;
+  name?: string | null;
+  source?: string;
+}
+
+export interface DayInfoPayload {
+  date: string;
+  efemerides: DayInfoEfemeride[];
+  santoral: DayInfoSantoral[];
+  holiday: DayInfoHoliday;
+  patron: DayInfoPatron | null;
+}
+
+export const fetchDayBrief = async (): Promise<DayInfoPayload> => {
+  const response = await fetch(`${BACKEND_BASE_URL}/api/day/brief`);
+  if (!response.ok) {
+    throw new Error(`Error ${response.status}`);
+  }
+  return (await response.json()) as DayInfoPayload;
+};


### PR DESCRIPTION
## Summary
- add a cached day info service that aggregates Wikipedia efemérides, santoral fallback data and Nager.Date holidays
- expose the `/api/day/brief` endpoint and extend configuration/schema with locale and patron metadata
- add the DayStrip dashboard widget and supporting client service that surfaces the brief with badges and popover details

## Testing
- python -m compileall backend/services/dayinfo.py
- npm --prefix dash-ui install *(fails: registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ecdbc8a11483269860d244b9dce954