### PR TITLE
Add month tips and DST notifications

### DIFF
--- a/backend/data/seasonality_es.json
+++ b/backend/data/seasonality_es.json
@@ -1,0 +1,206 @@
+{
+  "1": {
+    "hortalizas": [
+      "ajo (siembra diente)",
+      "cebolla (semillero)",
+      "acelga",
+      "espinaca"
+    ],
+    "frutas": [
+      "naranja",
+      "mandarina",
+      "kiwi (temporada)"
+    ],
+    "nota": "Proteger de heladas en zonas frías."
+  },
+  "2": {
+    "hortalizas": [
+      "guisante",
+      "haba",
+      "zanahoria (temprana)",
+      "lechuga (semillero)"
+    ],
+    "frutas": [
+      "fresa (inicio)",
+      "naranja",
+      "pomelo"
+    ],
+    "nota": "Semilleros bajo abrigo."
+  },
+  "3": {
+    "hortalizas": [
+      "tomate (semillero)",
+      "pimiento (semillero)",
+      "calabacín",
+      "berenjena (semillero)",
+      "patata (siembra)"
+    ],
+    "frutas": [
+      "fresa",
+      "naranja (fin)",
+      "mandarina (fin)"
+    ],
+    "nota": "Atento a últimas heladas."
+  },
+  "4": {
+    "hortalizas": [
+      "tomate (trasplante zonas templadas)",
+      "pimiento",
+      "calabacín",
+      "pepino",
+      "judía verde"
+    ],
+    "frutas": [
+      "fresa",
+      "albaricoque (inicio)"
+    ],
+    "nota": "Trasplantes cuando mínimas >10°C."
+  },
+  "5": {
+    "hortalizas": [
+      "tomate (campo)",
+      "pimiento",
+      "berenjena",
+      "pepino",
+      "calabaza",
+      "judía verde"
+    ],
+    "frutas": [
+      "fresa (fin)",
+      "cereza (inicio)",
+      "albaricoque",
+      "nispero"
+    ],
+    "nota": "Controlar pulgón y primeros golpes de calor."
+  },
+  "6": {
+    "hortalizas": [
+      "lechuga de verano",
+      "pepino",
+      "calabacín",
+      "judía verde",
+      "maíz dulce",
+      "melón (trasplante)"
+    ],
+    "frutas": [
+      "cereza",
+      "albaricoque",
+      "melocotón (inicio)",
+      "ciruela",
+      "nispero (fin)"
+    ],
+    "nota": "Riegos regulares y acolchado para conservar humedad."
+  },
+  "7": {
+    "hortalizas": [
+      "lechuga (siembra escalonada)",
+      "pepino",
+      "judía verde",
+      "zanahoria de verano",
+      "remolacha",
+      "coles de otoño (semillero)"
+    ],
+    "frutas": [
+      "melocotón",
+      "nectarina",
+      "paraguayo",
+      "ciruela",
+      "melón",
+      "sandía"
+    ],
+    "nota": "Proteger semilleros del sol directo."
+  },
+  "8": {
+    "hortalizas": [
+      "brócoli",
+      "coliflor",
+      "col lombarda",
+      "espinaca (siembra)",
+      "acelga",
+      "rábano"
+    ],
+    "frutas": [
+      "uva (inicio)",
+      "higo",
+      "melón",
+      "sandía",
+      "pera",
+      "manzana temprana"
+    ],
+    "nota": "Siembras de otoño-invierno comienzan ahora."
+  },
+  "9": {
+    "hortalizas": [
+      "coles de invierno",
+      "puerro",
+      "espinaca",
+      "lechuga de otoño",
+      "rábano",
+      "zanahoria de otoño"
+    ],
+    "frutas": [
+      "uva",
+      "higo",
+      "granada (inicio)",
+      "manzana",
+      "pera",
+      "membrillo (inicio)"
+    ],
+    "nota": "Aprovecha la humedad de finales de verano."
+  },
+  "10": {
+    "hortalizas": [
+      "ajo (siembra temprana)",
+      "haba",
+      "guisante",
+      "espinaca",
+      "acelga",
+      "coliflor (trasplante)"
+    ],
+    "frutas": [
+      "granada",
+      "caqui",
+      "manzana tardía",
+      "pera tardía",
+      "membrillo",
+      "uva (fin)"
+    ],
+    "nota": "Preparar el huerto para lluvias otoñales."
+  },
+  "11": {
+    "hortalizas": [
+      "ajo",
+      "cebolla temprana",
+      "haba",
+      "guisante",
+      "acelga",
+      "espinaca"
+    ],
+    "frutas": [
+      "caqui",
+      "granada",
+      "naranja (inicio)",
+      "mandarina",
+      "kiwi"
+    ],
+    "nota": "Mantener protección contra heladas tempranas."
+  },
+  "12": {
+    "hortalizas": [
+      "ajo (siembra)",
+      "cebolla (semillero)",
+      "acelga",
+      "espinaca",
+      "canónigo",
+      "nabo"
+    ],
+    "frutas": [
+      "naranja",
+      "mandarina",
+      "limón",
+      "pomelo",
+      "kiwi"
+    ],
+    "nota": "Aprovechar los días soleados para trabajos de mantenimiento."
+  }
+}

--- a/backend/services/dst.py
+++ b/backend/services/dst.py
@@ -1,0 +1,115 @@
+"""Daylight saving time helpers for Europe/Madrid."""
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+from zoneinfo import ZoneInfo
+import calendar
+import json
+
+TZ_NAME = "Europe/Madrid"
+_DST_NOTICE_STATE = Path(__file__).resolve().parent.parent / "storage" / "cache" / "dst_notice.json"
+
+
+@runtime_checkable
+class SpeechQueueLike(Protocol):
+    async def enqueue(self, text: str, volume: float = 1.0) -> None:  # pragma: no cover - interface
+        ...
+
+
+def _last_sunday(year: int, month: int) -> date:
+    last_day = calendar.monthrange(year, month)[1]
+    candidate = date(year, month, last_day)
+    offset = (candidate.weekday() - 6) % 7  # weekday: 0=Monday, 6=Sunday
+    return candidate - timedelta(days=offset)
+
+
+def _transitions_for_year(year: int) -> list[tuple[date, str, int]]:
+    return [
+        (_last_sunday(year, 3), "forward", 1),
+        (_last_sunday(year, 10), "back", -1),
+    ]
+
+
+def next_transition_info(today: date) -> dict[str, Any]:
+    """Return information about the next DST transition from ``today`` onwards."""
+    transitions: list[tuple[date, str, int]] = []
+    for year in (today.year, today.year + 1):
+        transitions.extend(_transitions_for_year(year))
+    transitions.sort(key=lambda item: item[0])
+
+    for change_date, kind, delta in transitions:
+        if change_date < today:
+            continue
+        days_left = (change_date - today).days
+        return {
+            "has_upcoming": True,
+            "date": change_date.isoformat(),
+            "kind": kind,
+            "delta_hours": delta,
+            "days_left": days_left,
+        }
+
+    # Should not happen with the above logic, but keep fallback for safety.
+    return {
+        "has_upcoming": False,
+        "date": None,
+        "kind": None,
+        "delta_hours": 0,
+        "days_left": None,
+    }
+
+
+def current_time_payload(now: datetime | None = None) -> dict[str, Any]:
+    tz = ZoneInfo(TZ_NAME)
+    now_dt = now.astimezone(tz) if now else datetime.now(tz)
+    offset = now_dt.utcoffset() or timedelta(0)
+    return {
+        "datetime": now_dt.isoformat(),
+        "timestamp": now_dt.timestamp(),
+        "timezone": TZ_NAME,
+        "utc_offset_seconds": int(offset.total_seconds()),
+        "is_dst": bool(now_dt.dst()),
+    }
+
+
+async def maybe_tts_dst_notice(
+    queue: SpeechQueueLike | None,
+    change_date: date,
+    message: str,
+    *,
+    volume: float = 1.0,
+) -> bool:
+    """Queue a DST notice via TTS once per change date.
+
+    Returns ``True`` if the message was enqueued or ``False`` when it was skipped
+    because it has already been announced or the queue is not available.
+    """
+
+    if queue is None:
+        return False
+
+    try:
+        state_data = json.loads(_DST_NOTICE_STATE.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        state_data = {}
+    except json.JSONDecodeError:
+        state_data = {}
+
+    key = change_date.isoformat()
+    if state_data.get("last_date") == key:
+        return False
+
+    _DST_NOTICE_STATE.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        await queue.enqueue(message, volume=volume)
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+    state_data["last_date"] = key
+    _DST_NOTICE_STATE.write_text(json.dumps(state_data), encoding="utf-8")
+    return True
+
+
+__all__ = ["TZ_NAME", "current_time_payload", "maybe_tts_dst_notice", "next_transition_info"]

--- a/backend/services/seasonality.py
+++ b/backend/services/seasonality.py
@@ -1,0 +1,112 @@
+"""Seasonality helpers for Spanish horticulture tips."""
+from __future__ import annotations
+
+from datetime import date
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+import json
+
+DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "seasonality_es.json"
+MONTH_NAMES_ES = [
+    "enero",
+    "febrero",
+    "marzo",
+    "abril",
+    "mayo",
+    "junio",
+    "julio",
+    "agosto",
+    "septiembre",
+    "octubre",
+    "noviembre",
+    "diciembre",
+]
+
+
+def _coerce_list(values: Any) -> list[str]:
+    if isinstance(values, list) and all(isinstance(item, str) for item in values):
+        return values
+    if values is None:
+        return []
+    if isinstance(values, Sequence) and not isinstance(values, (str, bytes)):
+        return [str(item) for item in values]
+    if isinstance(values, str):
+        return [values]
+    return []
+
+
+@lru_cache(maxsize=1)
+def _load_dataset() -> dict[int, dict[str, Any]]:
+    if not DATA_PATH.exists():
+        return {}
+    try:
+        payload = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    result: dict[int, dict[str, Any]] = {}
+    for key, value in payload.items():
+        try:
+            month = int(key)
+        except (TypeError, ValueError):
+            continue
+        if not 1 <= month <= 12:
+            continue
+        if not isinstance(value, Mapping):
+            continue
+        result[month] = {
+            "hortalizas": _coerce_list(value.get("hortalizas")),
+            "frutas": _coerce_list(value.get("frutas")),
+            "nota": value.get("nota") if isinstance(value.get("nota"), str) else None,
+        }
+    return result
+
+
+def get_month_season(month: int) -> dict[str, Any]:
+    """Return the seasonality information for the given month (1-12)."""
+    if not 1 <= month <= 12:
+        raise ValueError("Mes fuera de rango (1-12)")
+    dataset = _load_dataset()
+    data = dataset.get(month, {})
+    hortalizas = data.get("hortalizas", []) if isinstance(data, Mapping) else []
+    frutas = data.get("frutas", []) if isinstance(data, Mapping) else []
+    nota = data.get("nota") if isinstance(data, Mapping) else None
+    return {
+        "month": month,
+        "hortalizas": list(hortalizas),
+        "frutas": list(frutas),
+        "nota": nota,
+    }
+
+
+def get_current_month_season(today: date) -> dict[str, Any]:
+    """Return seasonality information for the month that includes *today*."""
+    return get_month_season(today.month)
+
+
+def build_month_tip(payload: Mapping[str, Any]) -> str:
+    """Create a compact textual tip for the provided seasonality payload."""
+    try:
+        month = int(payload.get("month", 0))
+    except (TypeError, ValueError):
+        month = 0
+    month_name = MONTH_NAMES_ES[month - 1].capitalize() if 1 <= month <= 12 else "Este mes"
+
+    hortalizas = _coerce_list(payload.get("hortalizas"))
+    frutas = _coerce_list(payload.get("frutas"))
+
+    parts: list[str] = []
+    if hortalizas:
+        parts.append(f"Siembra → {', '.join(hortalizas)}")
+    if frutas:
+        parts.append(f"Temporada → {', '.join(frutas)}")
+    if not parts:
+        parts.append("Consulta la huerta para más detalles.")
+    return f"En {month_name}: {' | '.join(parts)}"
+
+
+__all__ = [
+    "build_month_tip",
+    "get_current_month_season",
+    "get_month_season",
+]

--- a/dash-ui/src/App.tsx
+++ b/dash-ui/src/App.tsx
@@ -6,6 +6,7 @@ import Weather from './components/Weather';
 import WeatherBrief from './components/WeatherBrief';
 import CalendarPeek from './components/CalendarPeek';
 import DayStrip from './components/DayStrip';
+import MonthTips from './components/MonthTips';
 import StormOverlay from './components/StormOverlay';
 import SceneEffects from './components/SceneEffects';
 import FpsMeter from './components/FpsMeter';
@@ -64,6 +65,7 @@ const DashboardLayout = () => {
           <div className="flex h-full flex-col gap-3">
             <CalendarPeek />
             <DayStrip />
+            <MonthTips />
           </div>
         </div>
       </div>

--- a/dash-ui/src/components/DstNotice.tsx
+++ b/dash-ui/src/components/DstNotice.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useRef, useState } from 'react';
+import { fetchNextDstTransition, type DstTransitionInfo } from '../services/time';
+import { enqueueAlertTts } from '../services/tts';
+
+const POLL_INTERVAL = 6 * 60 * 60 * 1000;
+const STORAGE_KEY = 'dstNotice.lastShownDate';
+
+interface DisplayState {
+  mode: 'chip' | 'banner';
+  key: string;
+  message: string;
+  subMessage?: string;
+  date: string | null;
+  kind: 'back' | 'forward' | null;
+  deltaHours: number;
+  daysLeft: number;
+}
+
+function describeChange(kind: 'back' | 'forward' | null, deltaHours: number): string {
+  const hours = Math.abs(deltaHours || (kind === 'back' ? -1 : 1));
+  const hourLabel = hours === 1 ? '1 hora' : `${hours} horas`;
+  if (kind === 'back') return `retrasamos ${hourLabel}`;
+  if (kind === 'forward') return `adelantamos ${hourLabel}`;
+  return `${deltaHours >= 0 ? 'adelantamos' : 'retrasamos'} ${hourLabel}`;
+}
+
+function formatShort(date: string | null): string | null {
+  if (!date) return null;
+  const parsed = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(parsed.valueOf())) return null;
+  return parsed.toLocaleDateString('es-ES', { day: '2-digit', month: 'short' });
+}
+
+function formatLong(date: string | null): string | null {
+  if (!date) return null;
+  const parsed = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(parsed.valueOf())) return null;
+  return parsed.toLocaleDateString('es-ES', { day: '2-digit', month: 'long' });
+}
+
+const DstNotice = () => {
+  const [info, setInfo] = useState<DstTransitionInfo | null>(null);
+  const [display, setDisplay] = useState<DisplayState | null>(null);
+  const autoHideRef = useRef<number | null>(null);
+  const dismissedKeyRef = useRef<string | null>(null);
+  const spokenRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const data = await fetchNextDstTransition();
+        if (!cancelled) {
+          setInfo(data);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setInfo(null);
+        }
+      }
+    };
+
+    void load();
+    const timer = window.setInterval(() => {
+      void load();
+    }, POLL_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!info || !info.hasUpcoming || info.daysLeft == null) {
+      setDisplay(null);
+      return;
+    }
+    if (info.daysLeft > 7) {
+      setDisplay(null);
+      return;
+    }
+
+    const daysLeft = info.daysLeft ?? 0;
+    const key = `${info.date ?? 'unknown'}:${daysLeft}`;
+    const mode: DisplayState['mode'] = daysLeft === 0 ? 'banner' : 'chip';
+
+    if (mode === 'banner' && info.date) {
+      try {
+        const stored = window.localStorage.getItem(STORAGE_KEY);
+        if (stored === info.date) {
+          setDisplay(null);
+          return;
+        }
+      } catch (error) {
+        console.warn('No se pudo leer dstNotice.lastShownDate', error);
+      }
+    }
+
+    if (mode === 'chip' && dismissedKeyRef.current === key) {
+      setDisplay(null);
+      return;
+    }
+
+    const change = describeChange(info.kind, info.deltaHours ?? 0);
+    const shortDate = formatShort(info.date);
+
+    const message = mode === 'banner'
+      ? `Hoy cambia la hora: ${change} el reloj.`
+      : `Cambio de hora en ${daysLeft} ${daysLeft === 1 ? 'día' : 'días'}: ${change}${shortDate ? ` (${shortDate})` : ''}`;
+
+    const subMessage = mode === 'banner' ? formatLong(info.date) : null;
+
+    setDisplay((current) => {
+      if (current && current.key === key && current.mode === mode && current.message === message) {
+        return current;
+      }
+      return {
+        mode,
+        key,
+        message,
+        subMessage: subMessage ? `Entrada en vigor: ${subMessage}` : undefined,
+        date: info.date ?? null,
+        kind: info.kind,
+        deltaHours: info.deltaHours,
+        daysLeft,
+      };
+    });
+  }, [info]);
+
+  useEffect(() => {
+    if (display?.mode !== 'banner') {
+      return;
+    }
+    if (display.date) {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, display.date);
+      } catch (error) {
+        console.warn('No se pudo guardar dstNotice.lastShownDate', error);
+      }
+    }
+    if (display.date && spokenRef.current !== display.date) {
+      spokenRef.current = display.date;
+      const ttsMessage = display.kind === 'forward'
+        ? 'Hoy cambia la hora. Adelantamos el reloj una hora.'
+        : 'Hoy cambia la hora. Retrasamos el reloj una hora.';
+      void enqueueAlertTts(ttsMessage).catch(() => {
+        /* silencio si falla */
+      });
+    }
+  }, [display]);
+
+  useEffect(() => {
+    if (!display) return;
+    if (autoHideRef.current) {
+      window.clearTimeout(autoHideRef.current);
+    }
+    autoHideRef.current = window.setTimeout(() => {
+      dismissedKeyRef.current = display.key;
+      setDisplay(null);
+    }, display.mode === 'banner' ? 15_000 : 12_000);
+
+    return () => {
+      if (autoHideRef.current) {
+        window.clearTimeout(autoHideRef.current);
+        autoHideRef.current = null;
+      }
+    };
+  }, [display]);
+
+  useEffect(() => {
+    return () => {
+      if (autoHideRef.current) {
+        window.clearTimeout(autoHideRef.current);
+      }
+    };
+  }, []);
+
+  const handleClose = () => {
+    if (!display) return;
+    if (autoHideRef.current) {
+      window.clearTimeout(autoHideRef.current);
+      autoHideRef.current = null;
+    }
+    dismissedKeyRef.current = display.key;
+    if (display.mode === 'banner' && display.date) {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, display.date);
+      } catch (error) {
+        console.warn('No se pudo persistir dstNotice.lastShownDate', error);
+      }
+    }
+    setDisplay(null);
+  };
+
+  if (!display) return null;
+
+  const bannerVisible = display.mode === 'banner';
+  const chipVisible = display.mode === 'chip';
+
+  return (
+    <>
+      {bannerVisible && (
+        <div className="pointer-events-auto absolute left-1/2 top-full z-30 mt-3 w-[min(420px,calc(100vw-4rem))] -translate-x-1/2 rounded-2xl border border-emerald-400/30 bg-emerald-500/15 px-5 py-3 text-sm text-emerald-50 shadow-2xl backdrop-blur">
+          <div className="flex items-start gap-3">
+            <div className="flex-1">
+              <p className="font-semibold leading-snug">{display.message}</p>
+              {display.subMessage && (
+                <p className="mt-1 text-[0.7rem] uppercase tracking-[0.35em] text-emerald-100/70">{display.subMessage}</p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={handleClose}
+              aria-label="Cerrar aviso de cambio de hora"
+              className="rounded-full border border-emerald-300/40 bg-emerald-500/20 px-2 py-1 text-xs text-emerald-50/80 transition hover:bg-emerald-400/20"
+            >
+              ×
+            </button>
+          </div>
+        </div>
+      )}
+      {chipVisible && (
+        <div className="flex max-w-xs items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-500/10 px-3 py-1 text-[0.65rem] font-medium uppercase tracking-[0.3em] text-emerald-100/90 shadow-sm backdrop-blur">
+          <span className="leading-tight text-left">{display.message}</span>
+          <button
+            type="button"
+            onClick={handleClose}
+            aria-label="Ocultar aviso de cambio de hora"
+            className="rounded-full border border-emerald-400/40 px-1 text-[0.65rem] text-emerald-50/70 transition hover:bg-emerald-400/20"
+          >
+            ×
+          </button>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default DstNotice;

--- a/dash-ui/src/components/MonthTips.tsx
+++ b/dash-ui/src/components/MonthTips.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchSeasonMonth, type MonthSeason } from '../services/season';
+import { subscribeTime } from '../services/time';
+
+const STORAGE_KEY = 'monthTips.lastShown';
+const HIGHLIGHT_TIMEOUT = 12_000;
+
+function toMonthLabel(month: number): string {
+  const date = new Date(Date.UTC(2020, month - 1, 1));
+  const label = date.toLocaleDateString('es-ES', { month: 'long' });
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+const MonthTips = () => {
+  const [season, setSeason] = useState<MonthSeason | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [highlight, setHighlight] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const monthRef = useRef<number>(new Date().getMonth() + 1);
+  const highlightTimerRef = useRef<number | null>(null);
+
+  const triggerHighlight = useCallback((month: number) => {
+    const now = new Date();
+    const key = `${now.getFullYear()}-${String(month).padStart(2, '0')}`;
+    let stored: string | null = null;
+    try {
+      stored = window.localStorage.getItem(STORAGE_KEY);
+    } catch (err) {
+      console.warn('No se pudo leer monthTips.lastShown', err);
+    }
+    if (stored === key) {
+      setHighlight(false);
+      return;
+    }
+    setHighlight(true);
+    if (highlightTimerRef.current) {
+      window.clearTimeout(highlightTimerRef.current);
+    }
+    highlightTimerRef.current = window.setTimeout(() => {
+      setHighlight(false);
+    }, HIGHLIGHT_TIMEOUT);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, key);
+    } catch (err) {
+      console.warn('No se pudo persistir monthTips.lastShown', err);
+    }
+  }, []);
+
+  const loadSeason = useCallback(
+    async (targetMonth?: number) => {
+      setLoading(true);
+      try {
+        const data = await fetchSeasonMonth(targetMonth);
+        setSeason(data);
+        setError(null);
+        monthRef.current = data.month;
+        triggerHighlight(data.month);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Sin datos';
+        setError(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [triggerHighlight],
+  );
+
+  useEffect(() => {
+    void loadSeason();
+  }, [loadSeason]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeTime((now) => {
+      const month = now.getMonth() + 1;
+      if (month !== monthRef.current) {
+        monthRef.current = month;
+        void loadSeason(month);
+      }
+    });
+    return unsubscribe;
+  }, [loadSeason]);
+
+  useEffect(() => {
+    if (!popoverOpen) return;
+
+    const onPointer = (event: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(event.target as Node)) {
+        setPopoverOpen(false);
+      }
+    };
+
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setPopoverOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', onPointer);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [popoverOpen]);
+
+  useEffect(() => {
+    return () => {
+      if (highlightTimerRef.current) {
+        window.clearTimeout(highlightTimerRef.current);
+      }
+    };
+  }, []);
+
+  const monthLabel = season ? toMonthLabel(season.month) : null;
+  const summary = season?.tip ?? (loading ? 'Actualizando recomendaciones…' : 'Sin datos de temporada.');
+
+  return (
+    <section
+      ref={containerRef}
+      className="relative rounded-3xl bg-slate-900/40 p-4 text-sm text-slate-100/80 shadow-lg backdrop-blur"
+      data-depth-blur="true"
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex flex-1 flex-col gap-1 text-left">
+          <span className="text-[0.65rem] uppercase tracking-[0.4em] text-emerald-200/80">
+            Temporadas {monthLabel ? `· ${monthLabel}` : ''}
+          </span>
+          <p className="text-sm font-medium leading-snug text-slate-100/90">{summary}</p>
+        </div>
+        <div className="flex items-start gap-2">
+          {highlight && (
+            <span className="rounded-full bg-emerald-500/20 px-2 py-1 text-[0.65rem] uppercase tracking-[0.35em] text-emerald-200 animate-pulse">
+              Nuevo mes
+            </span>
+          )}
+          <button
+            type="button"
+            aria-label="Detalles de temporada"
+            aria-expanded={popoverOpen}
+            aria-controls="month-tips-popover"
+            onClick={() => setPopoverOpen((value) => !value)}
+            className="rounded-full border border-slate-500/40 bg-slate-900/60 px-2 py-1 text-xs text-slate-200/90 transition hover:bg-slate-800/80"
+          >
+            ℹ︎
+          </button>
+        </div>
+      </header>
+      {error && <p className="mt-3 text-xs text-amber-300">{error}</p>}
+      {popoverOpen && season && (
+        <div
+          id="month-tips-popover"
+          role="dialog"
+          aria-modal="false"
+          className="absolute right-4 top-full z-20 mt-3 w-72 rounded-2xl border border-slate-500/30 bg-slate-900/95 p-4 text-xs text-slate-100 shadow-2xl backdrop-blur"
+        >
+          <div className="space-y-4">
+            <div>
+              <p className="text-[0.65rem] uppercase tracking-[0.35em] text-emerald-200/80">Siembra</p>
+              {season.hortalizas.length > 0 ? (
+                <ul className="mt-2 space-y-1 text-sm leading-tight text-slate-100/90">
+                  {season.hortalizas.map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span aria-hidden className="pt-[2px] text-emerald-300">•</span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm text-slate-300/70">Sin recomendaciones de siembra.</p>
+              )}
+            </div>
+            <div>
+              <p className="text-[0.65rem] uppercase tracking-[0.35em] text-amber-200/80">Temporada</p>
+              {season.frutas.length > 0 ? (
+                <ul className="mt-2 space-y-1 text-sm leading-tight text-slate-100/90">
+                  {season.frutas.map((item) => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span aria-hidden className="pt-[2px] text-amber-300">•</span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm text-slate-300/70">Sin frutas destacadas.</p>
+              )}
+            </div>
+            {season.nota && (
+              <p className="rounded-2xl border border-slate-500/20 bg-slate-800/60 p-3 text-[0.75rem] leading-relaxed text-slate-100/80">
+                {season.nota}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default MonthTips;

--- a/dash-ui/src/components/StatusBar.tsx
+++ b/dash-ui/src/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Wifi, WifiOff } from 'lucide-react';
 import { fetchWifiStatus, type WifiStatus } from '../services/wifi';
+import DstNotice from './DstNotice';
 
 const StatusBar = () => {
   const [wifiStatus, setWifiStatus] = useState<WifiStatus | null>(null);
@@ -48,7 +49,7 @@ const StatusBar = () => {
 
   return (
     <header
-      className="flex items-center justify-between rounded-3xl bg-black/40 px-6 py-4 text-xs uppercase tracking-[0.35em] text-slate-100/80 backdrop-blur"
+      className="relative flex items-center justify-between rounded-3xl bg-black/40 px-6 py-4 text-xs uppercase tracking-[0.35em] text-slate-100/80 backdrop-blur"
       data-depth-blur="true"
     >
       <div className="flex items-center gap-4 text-shadow-soft">
@@ -57,6 +58,7 @@ const StatusBar = () => {
         <span className="hidden md:inline">Modo operativo</span>
       </div>
       <div className="flex items-center gap-4 text-shadow-soft">
+        <DstNotice />
         <span className="flex items-center gap-2 text-slate-100">
           {wifiStatus?.connected ? (
             <Wifi className="h-4 w-4 text-emerald-300" aria-hidden />

--- a/dash-ui/src/services/season.ts
+++ b/dash-ui/src/services/season.ts
@@ -1,0 +1,29 @@
+import { apiRequest } from './config';
+
+export interface MonthSeason {
+  month: number;
+  hortalizas: string[];
+  frutas: string[];
+  nota?: string | null;
+  tip: string;
+}
+
+interface SeasonResponse {
+  month: number;
+  hortalizas: string[];
+  frutas: string[];
+  nota?: string | null;
+  tip: string;
+}
+
+export async function fetchSeasonMonth(month?: number): Promise<MonthSeason> {
+  const query = month ? `?month=${month}` : '';
+  const data = await apiRequest<SeasonResponse>(`/season/month${query}`);
+  return {
+    month: data.month,
+    hortalizas: data.hortalizas ?? [],
+    frutas: data.frutas ?? [],
+    nota: data.nota ?? undefined,
+    tip: data.tip,
+  };
+}

--- a/dash-ui/src/services/tts.ts
+++ b/dash-ui/src/services/tts.ts
@@ -17,3 +17,10 @@ export async function speakPreview(voice: string | undefined, text: string, volu
     body: JSON.stringify({ voice, text, volume }),
   });
 }
+
+export async function enqueueAlertTts(text: string): Promise<void> {
+  await apiRequest('/alerts/tts', {
+    method: 'POST',
+    body: JSON.stringify({ text }),
+  });
+}


### PR DESCRIPTION
## Summary
- add a seasonality dataset and service so `/api/season/month` can deliver month-specific tips with a synthesized summary line
- expose `/api/time/dst/next` and `/api/time/now` for daylight-saving awareness alongside the reusable DST helper module
- surface the new data in the UI with the MonthTips widget and a DST notice component, including supporting client services

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee0abd78e48326b9ad85f263853619