### PR TITLE
Add remote configuration API endpoints and dashboard settings UI

### DIFF
--- a/backend/services/config_store.py
+++ b/backend/services/config_store.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Tuple
+import json
+import os
+
+ETC_DIR = Path("/etc/pantalla-dash")
+HOME_DIR = Path.home() / ".config" / "pantalla-dash"
+CONFIG_PATHS = [ETC_DIR / "config.json", HOME_DIR / "config.json"]
+ENV_PATHS = [ETC_DIR / "env", HOME_DIR / "env"]
+
+
+def _first_existing(paths):
+    for path in paths:
+        if path.exists():
+            return path
+    return None
+
+
+def _ensure_parent(path: Path) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _read_env_file(path: Path) -> Dict[str, str]:
+    data: Dict[str, str] = {}
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                data[key.strip()] = value.strip()
+    except OSError:
+        return {}
+    return data
+
+
+def _merge_dict(base: Dict[str, Any], patch: Dict[str, Any]) -> Dict[str, Any]:
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            base[key] = _merge_dict(dict(base[key]), value)
+        else:
+            base[key] = value
+    return base
+
+
+def _dump_json(path: Path, data: Dict[str, Any]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2, sort_keys=True)
+        fh.write("\n")
+    try:
+        os.chmod(path, 0o660)
+    except OSError:
+        pass
+
+
+def _write_env(path: Path, data: Dict[str, str]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for key, value in data.items():
+            fh.write(f"{key}={value}\n")
+    try:
+        os.chmod(path, 0o660)
+    except OSError:
+        pass
+
+
+def read_config() -> Tuple[Dict[str, Any], str]:
+    target = _first_existing(CONFIG_PATHS)
+    if target is None:
+        return {}, str(CONFIG_PATHS[-1])
+    return _load_json(target), str(target)
+
+
+def read_env() -> Tuple[Dict[str, str], str]:
+    target = _first_existing(ENV_PATHS)
+    if target is None:
+        return {}, str(ENV_PATHS[-1])
+    return _read_env_file(target), str(target)
+
+
+def has_openai_key() -> bool:
+    env, _ = read_env()
+    key = env.get("OPENAI_API_KEY", "").strip()
+    return bool(key)
+
+
+def _find_writable(paths) -> Path | None:
+    for path in paths:
+        try:
+            _ensure_parent(path)
+            if path.exists():
+                with path.open("a", encoding="utf-8"):
+                    pass
+            else:
+                with path.open("w", encoding="utf-8"):
+                    pass
+            return path
+        except OSError:
+            continue
+    return None
+
+
+def write_config_partial(patch: Dict[str, Any]) -> Tuple[bool, str]:
+    writable = _find_writable(CONFIG_PATHS)
+    if writable is None:
+        return False, "read-only: ajusta permisos"
+
+    current, _ = read_config()
+    merged = _merge_dict(dict(current), patch)
+    try:
+        _dump_json(writable, merged)
+    except OSError:
+        return False, "read-only: ajusta permisos"
+    return True, str(writable)
+
+
+def write_openai_key(value: str) -> Tuple[bool, str]:
+    writable = _find_writable(ENV_PATHS)
+    if writable is None:
+        return False, "read-only: ajusta permisos"
+
+    env_data, _ = read_env()
+    env_data = dict(env_data)
+    if value:
+        env_data["OPENAI_API_KEY"] = value.strip()
+    else:
+        env_data.pop("OPENAI_API_KEY", None)
+    try:
+        _write_env(writable, env_data)
+    except OSError:
+        return False, "read-only: ajusta permisos"
+    return True, str(writable)

--- a/backend/services/wifi.py
+++ b/backend/services/wifi.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import shlex
+import shutil
 import subprocess
 from typing import Dict, List, Optional
 
@@ -31,6 +32,15 @@ def _run_nmcli(args: List[str]) -> subprocess.CompletedProcess:
             mask_next = True
     logger.debug("Executing nmcli command: %s", " ".join(shlex.quote(part) for part in sanitized))
     return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+
+def _truncate(text: str, limit: int = 4096) -> str:
+    if not text:
+        return ""
+    text = text.strip()
+    if len(text) > limit:
+        return text[:limit]
+    return text
 
 
 def scan_networks() -> List[Dict[str, Optional[str]]]:
@@ -159,3 +169,86 @@ def stop_access_point_service() -> None:
         stderr = result.stderr.strip()
         if stderr:
             logger.debug("No se pudo detener %s: %s", AP_SERVICE, stderr)
+
+
+def wifi_scan() -> Dict[str, object]:
+    if shutil.which(NMCLI_BIN) is None:
+        return {"items": [], "raw": "nmcli not found"}
+
+    config = read_config()
+    interface = get_wifi_interface(config)
+    args = ["-t", "-f", "SSID,SIGNAL,SECURITY", "dev", "wifi", "list"]
+    if interface:
+        args.extend(["ifname", interface])
+
+    result = _run_nmcli(args)
+    raw_parts = [part for part in (result.stdout, result.stderr) if part]
+    raw_output = _truncate("\n".join(raw_parts))
+
+    if result.returncode != 0:
+        if not raw_output:
+            raw_output = f"nmcli exited with code {result.returncode}"
+        return {"items": [], "raw": raw_output}
+
+    items: List[Dict[str, object]] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        parts = line.split(":")
+        if len(parts) < 3:
+            continue
+        ssid = parts[0].strip()
+        signal = parts[1].strip()
+        security = parts[2].strip() or "OPEN"
+        entry: Dict[str, object] = {"ssid": ssid, "security": security}
+        if signal.isdigit():
+            entry["signal"] = int(signal)
+        items.append(entry)
+
+    # Deduplicate by SSID keeping highest signal strength
+    dedup: Dict[str, Dict[str, object]] = {}
+    for item in items:
+        existing = dedup.get(item["ssid"])
+        current_signal = item.get("signal")
+        existing_signal = existing.get("signal") if isinstance(existing, dict) else None
+        if existing is None or (
+            isinstance(current_signal, int)
+            and (not isinstance(existing_signal, int) or current_signal > existing_signal)
+        ):
+            dedup[item["ssid"]] = item
+
+    ordered = sorted(
+        dedup.values(),
+        key=lambda entry: entry.get("signal") if isinstance(entry.get("signal"), int) else -1,
+        reverse=True,
+    )
+    return {"items": ordered, "raw": raw_output}
+
+
+def wifi_connect(ssid: str, psk: Optional[str] = None) -> Dict[str, object]:
+    if not ssid:
+        return {"ok": False, "stdout": "", "stderr": "SSID requerido"}
+
+    if shutil.which(NMCLI_BIN) is None:
+        return {"ok": False, "stdout": "", "stderr": "nmcli not found"}
+
+    config = read_config()
+    interface = get_wifi_interface(config)
+    args = ["device", "wifi", "connect", ssid]
+    if interface:
+        args.extend(["ifname", interface])
+    if psk:
+        args.extend(["password", psk])
+
+    result = _run_nmcli(args)
+    stdout = _truncate(result.stdout)
+    stderr = _truncate(result.stderr)
+    ok = result.returncode == 0
+
+    if ok:
+        try:
+            stop_access_point_service()
+        except Exception:  # pragma: no cover - defensivo
+            logger.debug("Fallo al detener AP tras conectar", exc_info=True)
+
+    return {"ok": ok, "stdout": stdout, "stderr": stderr}

--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -13,7 +13,8 @@
     "lottie-web": "^5.12.2",
     "lucide-react": "^0.424.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",

--- a/dash-ui/src/App.tsx
+++ b/dash-ui/src/App.tsx
@@ -1,3 +1,4 @@
+import { Routes, Route } from 'react-router-dom';
 import { useEffect, useRef } from 'react';
 import DynamicBackground from './components/DynamicBackground';
 import StatusBar from './components/StatusBar';
@@ -10,9 +11,11 @@ import MonthTips from './components/MonthTips';
 import StormOverlay from './components/StormOverlay';
 import SceneEffects from './components/SceneEffects';
 import FpsMeter from './components/FpsMeter';
+import GearButton from './components/GearButton';
 import { DashboardConfigProvider, useDashboardConfig } from './context/DashboardConfigContext';
 import { StormStatusProvider } from './context/StormStatusContext';
 import { BACKEND_BASE_URL } from './services/config';
+import Settings from './pages/Settings';
 
 const useGeolocationSync = () => {
   const postedRef = useRef(false);
@@ -52,6 +55,9 @@ const DashboardLayout = () => {
     <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
       <DynamicBackground refreshMinutes={refreshMinutes} />
       <SceneEffects />
+      <div className="absolute right-10 top-6 z-20">
+        <GearButton />
+      </div>
       <div className="relative z-10 flex h-full w-full max-w-[1920px] flex-col gap-4 px-10 py-6">
         <StatusBar />
         <div className="grid flex-1 grid-cols-[40%_35%_25%] gap-6">
@@ -78,7 +84,12 @@ const DashboardLayout = () => {
 const App = () => (
   <DashboardConfigProvider>
     <StormStatusProvider>
-      <DashboardLayout />
+      <div className="h-full w-full">
+        <Routes>
+          <Route path="/" element={<DashboardLayout />} />
+          <Route path="/config" element={<Settings />} />
+        </Routes>
+      </div>
     </StormStatusProvider>
   </DashboardConfigProvider>
 );

--- a/dash-ui/src/components/GearButton.tsx
+++ b/dash-ui/src/components/GearButton.tsx
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router-dom';
+
+const GearButton = () => {
+  const navigate = useNavigate();
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate('/config')}
+      className="rounded-full bg-white/20 px-4 py-2 text-sm font-medium text-white shadow-lg backdrop-blur transition hover:bg-white/30 focus:outline-none focus:ring-2 focus:ring-white/60 focus:ring-offset-2 focus:ring-offset-black/20"
+    >
+      ⚙ Ajustes
+    </button>
+  );
+};
+
+export default GearButton;

--- a/dash-ui/src/main.tsx
+++ b/dash-ui/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { HashRouter } from 'react-router-dom';
 import App from './App';
 import './styles/globals.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <HashRouter>
+      <App />
+    </HashRouter>
   </React.StrictMode>
 );

--- a/dash-ui/src/pages/Settings.tsx
+++ b/dash-ui/src/pages/Settings.tsx
@@ -1,0 +1,456 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import DynamicBackground from '../components/DynamicBackground';
+import SceneEffects from '../components/SceneEffects';
+import { BACKEND_BASE_URL } from '../services/config';
+
+type NoticeType = 'success' | 'error' | 'info';
+
+interface Notice {
+  type: NoticeType;
+  text: string;
+}
+
+interface ConfigStatus {
+  hasOpenAI: boolean;
+  configPath: string;
+  envPath: string;
+}
+
+interface WifiItem {
+  ssid: string;
+  signal?: number;
+  security?: string;
+}
+
+interface ConfigDraft {
+  aemetApiKey: string;
+  aemetMunicipioId: string;
+  weatherCity: string;
+  backgroundInterval: string;
+  localeLanguage: string;
+}
+
+const DEFAULT_DRAFT: ConfigDraft = {
+  aemetApiKey: '',
+  aemetMunicipioId: '',
+  weatherCity: '',
+  backgroundInterval: '',
+  localeLanguage: '',
+};
+
+async function parseError(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    if (typeof data?.detail === 'string') return data.detail;
+    if (typeof data?.message === 'string') return data.message;
+  } catch (error) {
+    // ignore
+  }
+  return response.statusText || 'Error inesperado';
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${BACKEND_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(await parseError(response));
+  }
+  return (await response.json()) as T;
+}
+
+const buildDraftFromConfig = (config: Record<string, unknown> | null): ConfigDraft => {
+  if (!config) return DEFAULT_DRAFT;
+  const raw = (config.config as Record<string, any> | undefined) ?? {};
+  const locale = (raw.locale as Record<string, unknown> | undefined) ?? {};
+  const background = (raw.background as Record<string, unknown> | undefined) ?? {};
+  const aemet = (raw.aemet as Record<string, unknown> | undefined) ?? {};
+  const weather = (raw.weather as Record<string, unknown> | undefined) ?? {};
+  return {
+    aemetApiKey: typeof aemet.apiKey === 'string' ? aemet.apiKey : '',
+    aemetMunicipioId: typeof aemet.municipioId === 'string' ? aemet.municipioId : '',
+    weatherCity: typeof weather.city === 'string' ? weather.city : '',
+    backgroundInterval:
+      typeof background.intervalMinutes === 'number'
+        ? String(background.intervalMinutes)
+        : typeof background.intervalMinutes === 'string'
+        ? background.intervalMinutes
+        : '',
+    localeLanguage: typeof locale.language === 'string' ? locale.language : '',
+  };
+};
+
+const Settings = () => {
+  const navigate = useNavigate();
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [status, setStatus] = useState<ConfigStatus | null>(null);
+  const [draft, setDraft] = useState<ConfigDraft>(DEFAULT_DRAFT);
+  const [initialDraft, setInitialDraft] = useState<ConfigDraft>(DEFAULT_DRAFT);
+  const [openAiKey, setOpenAiKey] = useState('');
+  const [savingKey, setSavingKey] = useState(false);
+  const [savingConfig, setSavingConfig] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [wifiNetworks, setWifiNetworks] = useState<WifiItem[]>([]);
+  const [wifiRaw, setWifiRaw] = useState('');
+  const [scanningWifi, setScanningWifi] = useState(false);
+  const [wifiMessage, setWifiMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!notice) return;
+    const timeout = window.setTimeout(() => setNotice(null), 4000);
+    return () => window.clearTimeout(timeout);
+  }, [notice]);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        setLoading(true);
+        const [statusPayload, configPayload] = await Promise.all([
+          request<ConfigStatus>('/api/config/status'),
+          request<Record<string, unknown>>('/api/config'),
+        ]);
+        setStatus(statusPayload);
+        const nextDraft = buildDraftFromConfig(configPayload);
+        setDraft(nextDraft);
+        setInitialDraft(nextDraft);
+      } catch (error) {
+        console.error('Error cargando ajustes', error);
+        setNotice({
+          type: 'error',
+          text: error instanceof Error ? error.message : 'No se pudieron cargar los ajustes',
+        });
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const openAiStateLabel = useMemo(() => {
+    if (!status) return 'Desconocido';
+    return status.hasOpenAI ? 'Configurada' : 'Sin configurar';
+  }, [status]);
+
+  const buildConfigPatch = () => {
+    const patch: Record<string, unknown> = {};
+    const initial = initialDraft;
+
+    if (draft.aemetApiKey !== initial.aemetApiKey || draft.aemetMunicipioId !== initial.aemetMunicipioId) {
+      const payload: Record<string, string> = {};
+      if (draft.aemetApiKey !== initial.aemetApiKey) {
+        payload.apiKey = draft.aemetApiKey.trim();
+      }
+      if (draft.aemetMunicipioId !== initial.aemetMunicipioId) {
+        payload.municipioId = draft.aemetMunicipioId.trim();
+      }
+      patch.aemet = payload;
+    }
+
+    if (draft.weatherCity !== initial.weatherCity) {
+      patch.weather = { city: draft.weatherCity.trim() };
+    }
+
+    if (draft.backgroundInterval !== initial.backgroundInterval) {
+      const trimmed = draft.backgroundInterval.trim();
+      const minutes = Number.parseInt(trimmed, 10);
+      if (!trimmed || Number.isNaN(minutes) || minutes <= 0) {
+        throw new Error('Intervalo de actualización inválido');
+      }
+      patch.background = { intervalMinutes: minutes };
+    }
+
+    if (draft.localeLanguage !== initial.localeLanguage) {
+      patch.locale = { language: draft.localeLanguage.trim() };
+    }
+
+    if (Object.keys(patch).length === 0) {
+      throw new Error('No hay cambios para guardar');
+    }
+
+    return patch;
+  };
+
+  const handleSaveConfig = async () => {
+    try {
+      setSavingConfig(true);
+      const patch = buildConfigPatch();
+      const result = await request<Record<string, unknown>>('/api/config', {
+        method: 'POST',
+        body: JSON.stringify(patch),
+      });
+      const nextDraft = buildDraftFromConfig(result);
+      setDraft(nextDraft);
+      setInitialDraft(nextDraft);
+      setNotice({ type: 'success', text: 'Configuración guardada correctamente' });
+    } catch (error) {
+      if (error instanceof Error) {
+        setNotice({ type: 'error', text: error.message });
+      } else {
+        setNotice({ type: 'error', text: 'No se pudo guardar la configuración' });
+      }
+    } finally {
+      setSavingConfig(false);
+    }
+  };
+
+  const handleSaveKey = async () => {
+    const trimmed = openAiKey.trim();
+    if (!trimmed) {
+      setNotice({ type: 'error', text: 'Introduce una clave válida' });
+      return;
+    }
+
+    try {
+      setSavingKey(true);
+      await request<Record<string, unknown>>('/api/config/openai', {
+        method: 'POST',
+        body: JSON.stringify({ key: trimmed }),
+      });
+      setOpenAiKey('');
+      setNotice({ type: 'success', text: 'Clave OpenAI actualizada' });
+      const freshStatus = await request<ConfigStatus>('/api/config/status');
+      setStatus(freshStatus);
+    } catch (error) {
+      setNotice({ type: 'error', text: error instanceof Error ? error.message : 'No se pudo guardar la clave' });
+    } finally {
+      setSavingKey(false);
+    }
+  };
+
+  const handleScanWifi = async () => {
+    try {
+      setScanningWifi(true);
+      const result = await request<{ items?: WifiItem[]; raw?: string }>('/api/wifi/scan');
+      setWifiNetworks(result.items ?? []);
+      setWifiRaw(result.raw ?? '');
+      setWifiMessage('Escaneo completado');
+    } catch (error) {
+      setWifiMessage(null);
+      setNotice({ type: 'error', text: error instanceof Error ? error.message : 'No se pudo escanear redes Wi-Fi' });
+    } finally {
+      setScanningWifi(false);
+    }
+  };
+
+  const handleWifiConnect = async (network: WifiItem) => {
+    let psk: string | undefined;
+    if (network.security && !/open/i.test(network.security)) {
+      const input = window.prompt(`Contraseña para ${network.ssid}`) ?? '';
+      if (!input.trim()) {
+        setNotice({ type: 'info', text: 'Conexión cancelada' });
+        return;
+      }
+      psk = input.trim();
+    }
+
+    try {
+      const result = await request<{ ok?: boolean; stdout?: string; stderr?: string }>('/api/wifi/connect', {
+        method: 'POST',
+        body: JSON.stringify({ ssid: network.ssid, ...(psk ? { psk } : {}) }),
+      });
+      if (result.ok) {
+        setWifiMessage(`Conectado a ${network.ssid}`);
+        setNotice({ type: 'success', text: `Conectado a ${network.ssid}` });
+      } else {
+        const reason = result.stderr || 'No se pudo conectar';
+        setWifiMessage(reason);
+        setNotice({ type: 'error', text: reason });
+      }
+    } catch (error) {
+      setWifiMessage(null);
+      setNotice({ type: 'error', text: error instanceof Error ? error.message : 'No se pudo conectar a la red' });
+    }
+  };
+
+  return (
+    <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
+      <DynamicBackground refreshMinutes={60} />
+      <SceneEffects />
+      <div className="relative z-10 flex h-full w-full max-w-[1920px] flex-col gap-6 px-10 py-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-4xl font-semibold text-white">Ajustes</h1>
+            <p className="text-sm text-white/70">Gestiona parámetros remotos y conectividad</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => navigate('/')}
+            className="rounded-full border border-white/40 px-4 py-2 text-sm font-medium text-white transition hover:border-white/80 hover:bg-white/10"
+          >
+            ← Volver
+          </button>
+        </div>
+        {notice && (
+          <div
+            className={`rounded-2xl px-4 py-3 text-sm font-medium text-white shadow-lg backdrop-blur ${
+              notice.type === 'success'
+                ? 'bg-emerald-500/30'
+                : notice.type === 'error'
+                ? 'bg-rose-500/40'
+                : 'bg-white/20'
+            }`}
+          >
+            {notice.text}
+          </div>
+        )}
+        <div className="grid flex-1 grid-cols-3 gap-6 text-white">
+          <section className="flex flex-col rounded-3xl bg-black/30 p-6 backdrop-blur-lg">
+            <header className="mb-4 flex items-center justify-between">
+              <div>
+                <h2 className="text-2xl font-semibold">OpenAI</h2>
+                <p className="text-sm text-white/70">Estado: {openAiStateLabel}</p>
+              </div>
+            </header>
+            <div className="flex flex-col gap-3">
+              <input
+                type="text"
+                value={openAiKey}
+                onChange={(event) => setOpenAiKey(event.target.value)}
+                placeholder="sk-..."
+                className="w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/50 focus:border-white focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={handleSaveKey}
+                disabled={savingKey}
+                className="rounded-2xl bg-white/20 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/30 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {savingKey ? 'Guardando...' : 'Guardar clave'}
+              </button>
+              {status && (
+                <div className="mt-2 space-y-1 text-xs text-white/70">
+                  <p>Config: {status.configPath || '—'}</p>
+                  <p>Env: {status.envPath || '—'}</p>
+                </div>
+              )}
+            </div>
+          </section>
+          <section className="flex flex-col rounded-3xl bg-black/30 p-6 backdrop-blur-lg">
+            <header className="mb-4">
+              <h2 className="text-2xl font-semibold">AEMET y clima</h2>
+              <p className="text-sm text-white/70">Configura la fuente de datos meteorológicos</p>
+            </header>
+            <div className="flex flex-1 flex-col gap-3">
+              <div>
+                <label className="mb-1 block text-xs uppercase tracking-wide text-white/60">AEMET API Key</label>
+                <input
+                  type="text"
+                  value={draft.aemetApiKey}
+                  onChange={(event) => setDraft((prev) => ({ ...prev, aemetApiKey: event.target.value }))}
+                  className="w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs uppercase tracking-wide text-white/60">AEMET Municipio ID</label>
+                <input
+                  type="text"
+                  value={draft.aemetMunicipioId}
+                  onChange={(event) => setDraft((prev) => ({ ...prev, aemetMunicipioId: event.target.value }))}
+                  className="w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs uppercase tracking-wide text-white/60">Ciudad</label>
+                <input
+                  type="text"
+                  value={draft.weatherCity}
+                  onChange={(event) => setDraft((prev) => ({ ...prev, weatherCity: event.target.value }))}
+                  className="w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs uppercase tracking-wide text-white/60">Intervalo fondos (min)</label>
+                <input
+                  type="text"
+                  value={draft.backgroundInterval}
+                  onChange={(event) => setDraft((prev) => ({ ...prev, backgroundInterval: event.target.value }))}
+                  className="w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                />
+              </div>
+              <div>
+                <label className="mb-1 block text-xs uppercase tracking-wide text-white/60">Idioma (locale.language)</label>
+                <input
+                  type="text"
+                  value={draft.localeLanguage}
+                  onChange={(event) => setDraft((prev) => ({ ...prev, localeLanguage: event.target.value }))}
+                  className="w-full rounded-2xl border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                />
+              </div>
+              <div className="mt-auto pt-2">
+                <button
+                  type="button"
+                  onClick={handleSaveConfig}
+                  disabled={savingConfig}
+                  className="w-full rounded-2xl bg-white/20 px-4 py-3 text-sm font-semibold text-white transition hover:bg-white/30 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {savingConfig ? 'Guardando...' : 'Guardar configuración'}
+                </button>
+              </div>
+            </div>
+          </section>
+          <section className="flex flex-col rounded-3xl bg-black/30 p-6 backdrop-blur-lg">
+            <header className="mb-4 flex items-center justify-between">
+              <div>
+                <h2 className="text-2xl font-semibold">Wi-Fi</h2>
+                <p className="text-sm text-white/70">Gestiona redes disponibles</p>
+              </div>
+              <button
+                type="button"
+                onClick={handleScanWifi}
+                disabled={scanningWifi}
+                className="rounded-2xl bg-white/20 px-4 py-2 text-sm font-semibold text-white transition hover:bg-white/30 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {scanningWifi ? 'Escaneando...' : 'Escanear'}
+              </button>
+            </header>
+            <div className="flex flex-1 flex-col gap-3 overflow-hidden">
+              <div className="flex-1 space-y-2 overflow-y-auto pr-1">
+                {wifiNetworks.length === 0 && (
+                  <p className="text-sm text-white/60">No hay redes disponibles. {scanningWifi ? 'Buscando...' : 'Pulsa escanear.'}</p>
+                )}
+                {wifiNetworks.map((network) => (
+                  <div
+                    key={`${network.ssid}-${network.security ?? 'open'}`}
+                    className="flex items-center justify-between rounded-2xl bg-white/10 px-4 py-3 text-sm"
+                  >
+                    <div>
+                      <p className="font-semibold">{network.ssid || '(sin SSID)'}</p>
+                      <p className="text-xs text-white/60">
+                        {network.signal != null ? `${network.signal}% · ` : ''}
+                        {network.security || 'OPEN'}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleWifiConnect(network)}
+                      className="rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white transition hover:bg-white/30"
+                    >
+                      Conectar
+                    </button>
+                  </div>
+                ))}
+              </div>
+              {wifiMessage && <p className="text-xs text-white/70">{wifiMessage}</p>}
+              {wifiRaw && (
+                <pre className="max-h-32 overflow-y-auto rounded-2xl bg-black/40 px-3 py-2 text-[11px] text-white/50">
+                  {wifiRaw}
+                </pre>
+              )}
+            </div>
+          </section>
+        </div>
+        {loading && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 text-white">
+            Cargando ajustes...
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
- add configuration store utilities for reading and writing JSON and env files with fallback paths
- expose new FastAPI endpoints for configuration status/updates and Wi-Fi diagnostics while reusing existing config responses
- introduce settings page with router support, remote config forms, OpenAI key management, and Wi-Fi controls plus a dashboard gear shortcut

## Testing
- npm run build *(fails: react-router-dom dependency cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f073577cfc8326a8606802b004303e