### PR TITLE
feat: configurar rotación automática para pantalla 8.8"

### DIFF
--- a/docs/screen-rotation.md
+++ b/docs/screen-rotation.md
@@ -1,0 +1,7 @@
+# Rotación automática para pantalla 8.8" (1920×480)
+
+- El instalador configura LightDM (autologin) + Openbox y crea `~/.config/openbox/autostart`.
+- Si la salida conectada reporta `480x1920`, al iniciar sesión se aplica `xrandr --rotate left` y queda horizontal (1920×480).
+- Si la imagen aparece invertida, cambia `left` por `right` en `~/.config/openbox/autostart`.
+- Para ocultar el cursor en modo kiosko, edita el autostart y descomenta `unclutter -idle 0.5 &`.
+- Si no usas `pantalla-kiosk.service`, puedes lanzar Chromium en el autostart (línea comentada).


### PR DESCRIPTION
## Summary
- install Xorg, Openbox, LightDM, and utilities during setup, configuring autologin for the installer user
- create an Openbox autostart script that rotates 480x1920 outputs to horizontal and leaves kiosk helpers commented
- document the rotation workflow in docs/screen-rotation.md

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f62b1a74e483268d39181c265f1f0f