### PR TITLE
Ensure kiosk UI launches automatically after installation

### DIFF
--- a/install-all.sh
+++ b/install-all.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ $EUID -ne 0 ]]; then
+  exec sudo -E bash "$0" "$@"
+fi
+
+"$SCRIPT_DIR/scripts/install.sh" --non-interactive "$@"


### PR DESCRIPTION
## Summary
- install Chromium during provisioning and update the Openbox autostart to launch the kiosk browser automatically
- add an install-all.sh wrapper that reruns the hardened installer in non-interactive mode with sudo escalation

## Testing
- bash -n scripts/install.sh
- bash -n install-all.sh

------
https://chatgpt.com/codex/tasks/task_e_68f65ff8e2f483269a24d4c2e69c3be8