### PR TITLE
Persist configuration secrets and improve Wi-Fi management

### DIFF
--- a/backend/services/config_store.py
+++ b/backend/services/config_store.py
@@ -1,147 +1,253 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any, Dict, Tuple
 import json
+import logging
 import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Tuple
 
-ETC_DIR = Path("/etc/pantalla-dash")
-HOME_DIR = Path.home() / ".config" / "pantalla-dash"
-CONFIG_PATHS = [ETC_DIR / "config.json", HOME_DIR / "config.json"]
-ENV_PATHS = [ETC_DIR / "env", HOME_DIR / "env"]
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from .config import AppConfig
+
+logger = logging.getLogger(__name__)
+
+CONFIG_DIR = Path(os.environ.get("PANTALLA_CONFIG_DIR", "/etc/pantalla-dash"))
+CONFIG_PATH = CONFIG_DIR / "config.json"
+SECRETS_PATH = CONFIG_DIR / "secrets.json"
+
+ALLOWED_CONFIG_FIELDS: dict[str, set[str]] = {
+    "aemet": {"municipioId", "municipioName", "apiKey", "postalCode", "province"},
+    "weather": {"city", "units"},
+    "storm": {"threshold", "enableExperimentalLightning"},
+    "theme": {"current"},
+    "background": {"intervalMinutes", "mode", "retainDays"},
+    "tts": {"voice", "volume"},
+    "wifi": {"preferredInterface"},
+    "calendar": {"enabled", "icsUrl", "maxEvents", "notifyMinutesBefore"},
+    "locale": {"country", "autonomousCommunity", "province", "city"},
+    "patron": {"city", "name", "month", "day"},
+}
+
+class SecretPatch(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    class OpenAISecret(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+
+        apiKey: str | None = Field(default=None, alias="apiKey", max_length=200)
+
+    openai: OpenAISecret | None = None
 
 
-def _first_existing(paths):
-    for path in paths:
-        if path.exists():
-            return path
-    return None
-
-
-def _ensure_parent(path: Path) -> None:
+def _ensure_dir(path: Path) -> None:
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        pass
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:  # pragma: no cover - defensive
+        logger.warning("No se pudo crear directorio %s: %s", path, exc)
 
 
-def _load_json(path: Path) -> Dict[str, Any]:
+def _load_json(path: Path) -> dict[str, Any]:
     try:
-        with path.open("r", encoding="utf-8") as fh:
-            return json.load(fh)
-    except (OSError, json.JSONDecodeError):
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError as exc:
+        logger.warning("JSON inválido en %s: %s", path, exc)
+        return {}
+    except OSError as exc:  # pragma: no cover - defensive
+        logger.error("No se pudo leer %s: %s", path, exc)
         return {}
 
 
-def _read_env_file(path: Path) -> Dict[str, str]:
-    data: Dict[str, str] = {}
-    try:
-        with path.open("r", encoding="utf-8") as fh:
-            for line in fh:
-                line = line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                if "=" not in line:
-                    continue
-                key, value = line.split("=", 1)
-                data[key.strip()] = value.strip()
-    except OSError:
-        return {}
-    return data
+def _write_json(path: Path, data: dict[str, Any], *, mode: int) -> None:
+    _ensure_dir(path.parent)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(data, handle, ensure_ascii=False, indent=2, sort_keys=True)
+        handle.write("\n")
+    os.chmod(tmp_path, mode)
+    tmp_path.replace(path)
 
 
-def _merge_dict(base: Dict[str, Any], patch: Dict[str, Any]) -> Dict[str, Any]:
-    for key, value in patch.items():
-        if isinstance(value, dict) and isinstance(base.get(key), dict):
-            base[key] = _merge_dict(dict(base[key]), value)
-        else:
-            base[key] = value
-    return base
+def _mask_secret(value: str) -> str:
+    masked = value.strip()
+    if len(masked) <= 4:
+        return "***"
+    last4 = masked[-4:]
+    return f"***…{last4}"
 
 
-def _dump_json(path: Path, data: Dict[str, Any]) -> None:
-    with path.open("w", encoding="utf-8") as fh:
-        json.dump(data, fh, ensure_ascii=False, indent=2, sort_keys=True)
-        fh.write("\n")
-    try:
-        os.chmod(path, 0o660)
-    except OSError:
-        pass
+def _merge(base: dict[str, Any], patches: Iterable[dict[str, Any]]) -> dict[str, Any]:
+    result = dict(base)
+    for patch in patches:
+        for key, value in patch.items():
+            if isinstance(value, dict) and isinstance(result.get(key), dict):
+                result[key] = _merge(result[key], [value])  # type: ignore[arg-type]
+            else:
+                result[key] = value
+    return result
 
 
-def _write_env(path: Path, data: Dict[str, str]) -> None:
-    with path.open("w", encoding="utf-8") as fh:
-        for key, value in data.items():
-            fh.write(f"{key}={value}\n")
-    try:
-        os.chmod(path, 0o660)
-    except OSError:
-        pass
+def _sanitize_patch(payload: dict[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    invalid_top = [key for key in payload if key not in ALLOWED_CONFIG_FIELDS]
+    if invalid_top:
+        raise ValueError(
+            "Claves no permitidas: " + ", ".join(sorted(invalid_top))
+        )
+    for section, allowed_fields in ALLOWED_CONFIG_FIELDS.items():
+        if section not in payload:
+            continue
+        value = payload[section]
+        if not isinstance(value, dict):
+            raise ValueError(f"Sección {section} debe ser un objeto")
+        filtered = {k: v for k, v in value.items() if k in allowed_fields}
+        invalid_nested = [k for k in value.keys() if k not in allowed_fields]
+        if invalid_nested:
+            raise ValueError(
+                f"Claves no permitidas en {section}: " + ", ".join(sorted(invalid_nested))
+            )
+        if filtered:
+            sanitized[section] = filtered
+    return sanitized
 
 
-def read_config() -> Tuple[Dict[str, Any], str]:
-    target = _first_existing(CONFIG_PATHS)
-    if target is None:
-        return {}, str(CONFIG_PATHS[-1])
-    return _load_json(target), str(target)
+def _migrate_config(data: dict[str, Any]) -> dict[str, Any]:
+    migrated = dict(data)
+    background = migrated.get("background")
+    if isinstance(background, dict):
+        mode = background.get("mode")
+        if mode == "auto":
+            background = dict(background)
+            background["mode"] = "daily"
+            migrated["background"] = background
+            logger.warning("Migrando background.mode=auto -> daily")
+            try:
+                _write_json(CONFIG_PATH, migrated, mode=0o640)
+            except OSError as exc:
+                logger.error("No se pudo persistir migración de background.mode: %s", exc)
+    return migrated
 
 
-def read_env() -> Tuple[Dict[str, str], str]:
-    target = _first_existing(ENV_PATHS)
-    if target is None:
-        return {}, str(ENV_PATHS[-1])
-    return _read_env_file(target), str(target)
+def read_config() -> tuple[dict[str, Any], str]:
+    data = _load_json(CONFIG_PATH)
+    if not data and not CONFIG_PATH.exists():
+        try:
+            _write_json(CONFIG_PATH, {}, mode=0o640)
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.error("No se pudo inicializar config.json: %s", exc)
+    migrated = _migrate_config(data)
+    return migrated, str(CONFIG_PATH)
+
+
+def read_secrets() -> tuple[dict[str, Any], str]:
+    data = _load_json(SECRETS_PATH)
+    if not data and not SECRETS_PATH.exists():
+        try:
+            _write_json(SECRETS_PATH, {}, mode=0o600)
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.error("No se pudo inicializar secrets.json: %s", exc)
+    return data, str(SECRETS_PATH)
 
 
 def has_openai_key() -> bool:
-    env, _ = read_env()
-    key = env.get("OPENAI_API_KEY", "").strip()
-    return bool(key)
+    secrets, _ = read_secrets()
+    value = secrets.get("openai") if isinstance(secrets, dict) else None
+    if isinstance(value, dict):
+        api_key = value.get("apiKey")
+        return isinstance(api_key, str) and api_key.strip() != ""
+    return False
 
 
-def _find_writable(paths) -> Path | None:
-    for path in paths:
-        try:
-            _ensure_parent(path)
-            if path.exists():
-                with path.open("a", encoding="utf-8"):
-                    pass
-            else:
-                with path.open("w", encoding="utf-8"):
-                    pass
-            return path
-        except OSError:
-            continue
-    return None
-
-
-def write_config_partial(patch: Dict[str, Any]) -> Tuple[bool, str]:
-    writable = _find_writable(CONFIG_PATHS)
-    if writable is None:
-        return False, "read-only: ajusta permisos"
-
+def write_config_patch(patch: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    sanitized = _sanitize_patch(patch)
     current, _ = read_config()
-    merged = _merge_dict(dict(current), patch)
+    merged = _merge(current, [sanitized])
     try:
-        _dump_json(writable, merged)
-    except OSError:
-        return False, "read-only: ajusta permisos"
-    return True, str(writable)
+        AppConfig.model_validate(merged)
+    except ValidationError as exc:
+        details = exc.errors()
+        if details:
+            first = details[0]
+            location = ".".join(str(part) for part in first.get("loc", []))
+            message = first.get("msg", str(exc))
+            if location:
+                raise ValueError(f"{location}: {message}") from exc
+            raise ValueError(message) from exc
+        raise ValueError(str(exc)) from exc
+    try:
+        _write_json(CONFIG_PATH, merged, mode=0o640)
+    except OSError as exc:  # pragma: no cover - permisos insuficientes
+        raise PermissionError("No se pudo escribir config.json") from exc
+    return merged, str(CONFIG_PATH)
 
 
-def write_openai_key(value: str) -> Tuple[bool, str]:
-    writable = _find_writable(ENV_PATHS)
-    if writable is None:
-        return False, "read-only: ajusta permisos"
+def write_secrets_patch(payload: dict[str, Any]) -> tuple[dict[str, Any], str]:
+    try:
+        patch = SecretPatch.model_validate(payload)
+    except ValidationError as exc:
+        details = exc.errors()
+        if details:
+            first = details[0]
+            location = ".".join(str(part) for part in first.get("loc", []))
+            message = first.get("msg", str(exc))
+            if location:
+                raise ValueError(f"{location}: {message}") from exc
+            raise ValueError(message) from exc
+        raise ValueError(str(exc)) from exc
 
-    env_data, _ = read_env()
-    env_data = dict(env_data)
-    if value:
-        env_data["OPENAI_API_KEY"] = value.strip()
+    secrets, _ = read_secrets()
+    updated = dict(secrets)
+    if patch.openai:
+        target = patch.openai.apiKey.strip() if patch.openai.apiKey else ""
+        if target:
+            updated.setdefault("openai", {})
+            updated["openai"]["apiKey"] = target
+        else:
+            openai_data = updated.get("openai")
+            if isinstance(openai_data, dict):
+                openai_data.pop("apiKey", None)
+            if not openai_data:
+                updated.pop("openai", None)
+
+    try:
+        _write_json(SECRETS_PATH, updated, mode=0o600)
+    except OSError as exc:  # pragma: no cover - permisos insuficientes
+        raise PermissionError("No se pudo escribir secrets.json") from exc
+    return updated, str(SECRETS_PATH)
+
+
+def mask_secrets(secrets: dict[str, Any]) -> dict[str, Any]:
+    masked: dict[str, Any] = {}
+    openai_secret = secrets.get("openai") if isinstance(secrets, dict) else None
+    if isinstance(openai_secret, dict):
+        api_key = openai_secret.get("apiKey")
+        if isinstance(api_key, str) and api_key.strip():
+            masked["openai"] = {
+                "hasKey": True,
+                "masked": _mask_secret(api_key),
+            }
+        else:
+            masked["openai"] = {"hasKey": False, "masked": None}
     else:
-        env_data.pop("OPENAI_API_KEY", None)
-    try:
-        _write_env(writable, env_data)
-    except OSError:
-        return False, "read-only: ajusta permisos"
-    return True, str(writable)
+        masked["openai"] = {"hasKey": False, "masked": None}
+    return masked
+
+
+def secrets_metadata() -> dict[str, Any]:
+    meta: dict[str, Any] = {}
+    if SECRETS_PATH.exists():
+        stat = SECRETS_PATH.stat()
+        updated_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
+        has_key = has_openai_key()
+        meta["openai"] = {
+            "hasKey": has_key,
+            "updatedAt": updated_at,
+            "path": str(SECRETS_PATH),
+        }
+    else:
+        meta["openai"] = {"hasKey": False, "updatedAt": None, "path": str(SECRETS_PATH)}
+    return meta

--- a/backend/services/wifi.py
+++ b/backend/services/wifi.py
@@ -1,28 +1,47 @@
 from __future__ import annotations
 
 import logging
+import os
 import shlex
 import shutil
 import subprocess
-from typing import Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 from .config import get_wifi_interface, read_config
 
 logger = logging.getLogger(__name__)
 
-NMCLI_BIN = "nmcli"
+NMCLI_BIN = os.environ.get("NMCLI_BIN", "nmcli")
 AP_SERVICE = "pantalla-ap.service"
 
 
+@dataclass
+class CommandResult:
+    stdout: str
+    stderr: str
+    returncode: int
+
+
 class WifiError(Exception):
-    pass
+    def __init__(self, message: str, *, stderr: str | None = None, code: int | None = None) -> None:
+        super().__init__(message)
+        self.stderr = stderr
+        self.code = code
 
 
-def _run_nmcli(args: List[str]) -> subprocess.CompletedProcess:
-    cmd = [NMCLI_BIN] + args
+def _needs_sudo(stderr: str) -> bool:
+    lowered = stderr.lower()
+    return any(keyword in lowered for keyword in ["not authorized", "permiso denegado", "permission denied"])
+
+
+def _run_nmcli(args: List[str]) -> CommandResult:
+    if shutil.which(NMCLI_BIN) is None:
+        raise WifiError("nmcli no está instalado")
+
     sanitized: List[str] = []
     mask_next = False
-    for part in cmd:
+    for part in args:
         if mask_next:
             sanitized.append("****")
             mask_next = False
@@ -30,64 +49,77 @@ def _run_nmcli(args: List[str]) -> subprocess.CompletedProcess:
         sanitized.append(part)
         if part.lower() == "password":
             mask_next = True
-    logger.debug("Executing nmcli command: %s", " ".join(shlex.quote(part) for part in sanitized))
-    return subprocess.run(cmd, check=False, capture_output=True, text=True)
+
+    logger.debug("Ejecutando nmcli %s", " ".join(shlex.quote(part) for part in sanitized))
+
+    base_cmd = [NMCLI_BIN, *args]
+    result = subprocess.run(base_cmd, capture_output=True, text=True, check=False)
+
+    if result.returncode != 0 and _needs_sudo(result.stderr) and os.geteuid() != 0:
+        sudo_path = shutil.which("sudo")
+        if sudo_path:
+            logger.info("Reintentando nmcli con sudo")
+            sudo_cmd = [sudo_path, NMCLI_BIN, *args]
+            result = subprocess.run(sudo_cmd, capture_output=True, text=True, check=False)
+
+    return CommandResult(stdout=result.stdout, stderr=result.stderr, returncode=result.returncode)
 
 
 def _truncate(text: str, limit: int = 4096) -> str:
     if not text:
         return ""
     text = text.strip()
-    if len(text) > limit:
-        return text[:limit]
-    return text
+    return text[:limit]
 
 
-def scan_networks() -> List[Dict[str, Optional[str]]]:
-    config = read_config()
-    interface = get_wifi_interface(config)
-    args = ["-t", "-f", "SSID,SIGNAL,SECURITY", "dev", "wifi", "list"]
-    if interface:
-        args.extend(["ifname", interface])
-    result = _run_nmcli(args)
-    if result.returncode != 0:
-        logger.error("nmcli scan failed: %s", result.stderr.strip())
-        raise WifiError(result.stderr.strip() or "No se pudo escanear redes Wi-Fi")
-
-    networks: List[Dict[str, Optional[str]]] = []
-    for line in result.stdout.splitlines():
+def _parse_networks(output: str) -> List[Dict[str, Any]]:
+    items: Dict[str, Dict[str, Any]] = {}
+    for line in output.splitlines():
         if not line:
             continue
         parts = line.split(":")
         if len(parts) < 3:
             continue
         ssid = parts[0].strip()
-        signal = parts[1].strip()
+        if not ssid:
+            continue
+        signal_raw = parts[1].strip()
         security = parts[2].strip() or "OPEN"
-        networks.append(
-            {
-                "ssid": ssid,
-                "signal": int(signal) if signal.isdigit() else None,
-                "security": security,
-            }
-        )
-    # Deduplicate by SSID keeping highest signal
-    dedup: Dict[str, Dict[str, Optional[str]]] = {}
-    for net in networks:
-        existing = dedup.get(net["ssid"])
-        if not existing or (net["signal"] or 0) > (existing["signal"] or 0):
-            dedup[net["ssid"]] = net
+        entry = items.setdefault(ssid, {"ssid": ssid, "security": security})
+        if signal_raw.isdigit():
+            signal = int(signal_raw)
+            previous = entry.get("signal")
+            if not isinstance(previous, int) or signal > previous:
+                entry["signal"] = signal
     ordered = sorted(
-        dedup.values(),
-        key=lambda item: item.get("signal") if item.get("signal") is not None else -1,
+        items.values(),
+        key=lambda data: data.get("signal") if isinstance(data.get("signal"), int) else -1,
         reverse=True,
     )
     return ordered
 
 
-def connect(ssid: str, psk: Optional[str] = None) -> None:
+def wifi_scan() -> Dict[str, Any]:
+    config = read_config()
+    interface = get_wifi_interface(config)
+    args = ["-t", "-f", "SSID,SIGNAL,SECURITY", "dev", "wifi", "list"]
+    if interface:
+        args.extend(["ifname", interface])
+
+    result = _run_nmcli(args)
+    raw_output = _truncate("\n".join(part for part in [result.stdout, result.stderr] if part))
+    if result.returncode != 0:
+        message = result.stderr.strip() or "No se pudo escanear redes Wi-Fi"
+        raise WifiError(message, stderr=result.stderr, code=result.returncode)
+
+    networks = _parse_networks(result.stdout)
+    return {"networks": networks, "raw": raw_output}
+
+
+def wifi_connect(ssid: str, psk: Optional[str] = None) -> Dict[str, Any]:
     if not ssid:
         raise WifiError("SSID requerido")
+
     config = read_config()
     interface = get_wifi_interface(config)
     args = ["device", "wifi", "connect", ssid]
@@ -95,37 +127,34 @@ def connect(ssid: str, psk: Optional[str] = None) -> None:
         args.extend(["ifname", interface])
     if psk:
         args.extend(["password", psk])
+
     result = _run_nmcli(args)
     if result.returncode != 0:
-        stderr = result.stderr.strip()
-        logger.error("Error al conectar a Wi-Fi: %s", stderr)
-        raise WifiError(stderr or "No se pudo conectar a la red")
+        message = result.stderr.strip() or "No se pudo conectar a la red"
+        raise WifiError(message, stderr=result.stderr, code=result.returncode)
 
-    stop_access_point_service()
+    try:
+        stop_access_point_service()
+    except Exception:  # pragma: no cover - defensivo
+        logger.debug("No se pudo detener el servicio AP tras conectar", exc_info=True)
 
-
-def forget(ssid: str) -> None:
-    if not ssid:
-        raise WifiError("SSID requerido")
-    args = ["connection", "delete", "id", ssid]
-    result = _run_nmcli(args)
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        logger.error("Error al olvidar red Wi-Fi: %s", stderr)
-        raise WifiError(stderr or "No se pudo olvidar la red")
+    return {
+        "connected": True,
+        "ssid": ssid,
+        "stdout": _truncate(result.stdout),
+    }
 
 
-def status() -> Dict[str, Optional[str]]:
+def wifi_status() -> Dict[str, Any]:
     config = read_config()
     preferred_interface = get_wifi_interface(config)
-    args = ["-t", "-f", "DEVICE,TYPE,STATE,CONNECTION", "device"]
-    result = _run_nmcli(args)
+    result = _run_nmcli(["-t", "-f", "DEVICE,TYPE,STATE,CONNECTION", "device"])
     if result.returncode != 0:
-        logger.error("nmcli status failed: %s", result.stderr.strip())
-        raise WifiError(result.stderr.strip() or "No se pudo obtener el estado")
+        message = result.stderr.strip() or "No se pudo obtener el estado"
+        raise WifiError(message, stderr=result.stderr, code=result.returncode)
 
-    active_ssid = None
     active_device = None
+    active_ssid = None
     for line in result.stdout.splitlines():
         if not line:
             continue
@@ -141,21 +170,32 @@ def status() -> Dict[str, Optional[str]]:
         active_ssid = None
 
     ip_address = None
-    if active_ssid:
-        device = preferred_interface or active_device
-        if device:
-            show = _run_nmcli(["-t", "-f", "IP4.ADDRESS[1]", "device", "show", device])
-            if show.returncode == 0:
-                for line in show.stdout.splitlines():
-                    if line:
-                        ip_address = line.split("/")[0]
-                        break
+    device_name = preferred_interface or active_device
+    if active_ssid and device_name:
+        show = _run_nmcli(["-t", "-f", "GENERAL.STATE,IP4.ADDRESS[1]", "device", "show", device_name])
+        if show.returncode == 0:
+            for line in show.stdout.splitlines():
+                if line.startswith("GENERAL.STATE"):
+                    continue
+                if line:
+                    ip_address = line.split("/")[0]
+                    break
 
     return {
         "connected": bool(active_ssid),
         "ssid": active_ssid,
+        "interface": device_name,
         "ip": ip_address,
     }
+
+
+def forget(ssid: str) -> None:
+    if not ssid:
+        raise WifiError("SSID requerido")
+    result = _run_nmcli(["connection", "delete", "id", ssid])
+    if result.returncode != 0:
+        message = result.stderr.strip() or "No se pudo olvidar la red"
+        raise WifiError(message, stderr=result.stderr, code=result.returncode)
 
 
 def stop_access_point_service() -> None:
@@ -169,86 +209,3 @@ def stop_access_point_service() -> None:
         stderr = result.stderr.strip()
         if stderr:
             logger.debug("No se pudo detener %s: %s", AP_SERVICE, stderr)
-
-
-def wifi_scan() -> Dict[str, object]:
-    if shutil.which(NMCLI_BIN) is None:
-        return {"items": [], "raw": "nmcli not found"}
-
-    config = read_config()
-    interface = get_wifi_interface(config)
-    args = ["-t", "-f", "SSID,SIGNAL,SECURITY", "dev", "wifi", "list"]
-    if interface:
-        args.extend(["ifname", interface])
-
-    result = _run_nmcli(args)
-    raw_parts = [part for part in (result.stdout, result.stderr) if part]
-    raw_output = _truncate("\n".join(raw_parts))
-
-    if result.returncode != 0:
-        if not raw_output:
-            raw_output = f"nmcli exited with code {result.returncode}"
-        return {"items": [], "raw": raw_output}
-
-    items: List[Dict[str, object]] = []
-    for line in result.stdout.splitlines():
-        if not line:
-            continue
-        parts = line.split(":")
-        if len(parts) < 3:
-            continue
-        ssid = parts[0].strip()
-        signal = parts[1].strip()
-        security = parts[2].strip() or "OPEN"
-        entry: Dict[str, object] = {"ssid": ssid, "security": security}
-        if signal.isdigit():
-            entry["signal"] = int(signal)
-        items.append(entry)
-
-    # Deduplicate by SSID keeping highest signal strength
-    dedup: Dict[str, Dict[str, object]] = {}
-    for item in items:
-        existing = dedup.get(item["ssid"])
-        current_signal = item.get("signal")
-        existing_signal = existing.get("signal") if isinstance(existing, dict) else None
-        if existing is None or (
-            isinstance(current_signal, int)
-            and (not isinstance(existing_signal, int) or current_signal > existing_signal)
-        ):
-            dedup[item["ssid"]] = item
-
-    ordered = sorted(
-        dedup.values(),
-        key=lambda entry: entry.get("signal") if isinstance(entry.get("signal"), int) else -1,
-        reverse=True,
-    )
-    return {"items": ordered, "raw": raw_output}
-
-
-def wifi_connect(ssid: str, psk: Optional[str] = None) -> Dict[str, object]:
-    if not ssid:
-        return {"ok": False, "stdout": "", "stderr": "SSID requerido"}
-
-    if shutil.which(NMCLI_BIN) is None:
-        return {"ok": False, "stdout": "", "stderr": "nmcli not found"}
-
-    config = read_config()
-    interface = get_wifi_interface(config)
-    args = ["device", "wifi", "connect", ssid]
-    if interface:
-        args.extend(["ifname", interface])
-    if psk:
-        args.extend(["password", psk])
-
-    result = _run_nmcli(args)
-    stdout = _truncate(result.stdout)
-    stderr = _truncate(result.stderr)
-    ok = result.returncode == 0
-
-    if ok:
-        try:
-            stop_access_point_service()
-        except Exception:  # pragma: no cover - defensivo
-            logger.debug("Fallo al detener AP tras conectar", exc_info=True)
-
-    return {"ok": ok, "stdout": stdout, "stderr": stderr}

--- a/dash-ui/package-lock.json
+++ b/dash-ui/package-lock.json
@@ -25,6 +25,9 @@
         "tailwindcss": "^3.4.3",
         "typescript": "^5.4.5",
         "vite": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@alloc/quick-lru": {


### PR DESCRIPTION
## Summary
- enable configurable CORS, a health endpoint, and new config/secrets APIs that mask sensitive data while exposing Wi-Fi status
- persist dashboard configuration and secrets in JSON files with validation plus an nmcli-backed Wi-Fi service that supports sudo fallback
- update the settings UI to use the new endpoints and installer to seed secrets, allowed origins, and Chromium policies while proxying the backend on 8081

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f665a8cfb08326b613d7575d711687