### PR TITLE
Redesign display dashboard and admin panel for 8.8" screen

### DIFF
--- a/dash-ui/.gitignore
+++ b/dash-ui/.gitignore
@@ -3,3 +3,7 @@ dist/
 .vite/
 .DS_Store
 config.local.json
+tsconfig.tsbuildinfo
+tsconfig.node.tsbuildinfo
+vite.config.d.ts
+vite.config.js

--- a/dash-ui/src/App.tsx
+++ b/dash-ui/src/App.tsx
@@ -1,93 +1,16 @@
 import { Routes, Route } from 'react-router-dom';
-import { useEffect, useRef } from 'react';
-import DynamicBackground from './components/DynamicBackground';
-import StatusBar from './components/StatusBar';
-import Clock from './components/Clock';
-import Weather from './components/Weather';
-import WeatherBrief from './components/WeatherBrief';
-import CalendarPeek from './components/CalendarPeek';
-import DayStrip from './components/DayStrip';
-import MonthTips from './components/MonthTips';
-import StormOverlay from './components/StormOverlay';
-import SceneEffects from './components/SceneEffects';
-import FpsMeter from './components/FpsMeter';
-import GearButton from './components/GearButton';
-import { DashboardConfigProvider, useDashboardConfig } from './context/DashboardConfigContext';
+import { DashboardConfigProvider } from './context/DashboardConfigContext';
 import { StormStatusProvider } from './context/StormStatusContext';
-import { BACKEND_BASE_URL } from './services/config';
-import Settings from './pages/Settings';
-
-const useGeolocationSync = () => {
-  const postedRef = useRef(false);
-
-  useEffect(() => {
-    if (postedRef.current) return;
-    if (!('geolocation' in navigator)) return;
-
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        if (postedRef.current) return;
-        postedRef.current = true;
-        const { latitude, longitude } = position.coords;
-        void fetch(`${BACKEND_BASE_URL}/api/location/override`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ lat: latitude, lon: longitude }),
-        }).catch(() => {
-          // La ubicación es opcional; silenciosamente ignoramos errores.
-        });
-      },
-      () => {
-        postedRef.current = true;
-      },
-      { enableHighAccuracy: true, maximumAge: 5 * 60_000, timeout: 5_000 },
-    );
-  }, []);
-};
-
-const DashboardLayout = () => {
-  const { config } = useDashboardConfig();
-  useGeolocationSync();
-
-  const refreshMinutes = config?.background?.intervalMinutes ?? 60;
-
-  return (
-    <div className="relative flex h-full w-full items-center justify-center overflow-hidden">
-      <DynamicBackground refreshMinutes={refreshMinutes} />
-      <SceneEffects />
-      <div className="absolute right-10 top-6 z-20">
-        <GearButton />
-      </div>
-      <div className="relative z-10 flex h-full w-full max-w-[1920px] flex-col gap-4 px-10 py-6">
-        <StatusBar />
-        <div className="grid flex-1 grid-cols-[40%_35%_25%] gap-6">
-          <Clock />
-          <div className="flex h-full flex-col gap-3">
-            <div className="flex flex-1">
-              <Weather />
-            </div>
-            <WeatherBrief />
-          </div>
-          <div className="flex h-full flex-col gap-3">
-            <CalendarPeek />
-            <DayStrip />
-            <MonthTips />
-          </div>
-        </div>
-      </div>
-      <StormOverlay />
-      <FpsMeter />
-    </div>
-  );
-};
+import Display from './pages/Display';
+import Config from './pages/Config';
 
 const App = () => (
   <DashboardConfigProvider>
     <StormStatusProvider>
       <div className="h-full w-full">
         <Routes>
-          <Route path="/" element={<DashboardLayout />} />
-          <Route path="/config" element={<Settings />} />
+          <Route path="/" element={<Display />} />
+          <Route path="/config" element={<Config />} />
         </Routes>
       </div>
     </StormStatusProvider>

--- a/dash-ui/src/components/Background.tsx
+++ b/dash-ui/src/components/Background.tsx
@@ -1,0 +1,13 @@
+import DynamicBackground from './DynamicBackground';
+
+interface BackgroundProps {
+  refreshMinutes?: number;
+}
+
+const Background = ({ refreshMinutes }: BackgroundProps) => (
+  <div className="pointer-events-none absolute inset-0">
+    <DynamicBackground refreshMinutes={refreshMinutes} />
+  </div>
+);
+
+export default Background;

--- a/dash-ui/src/components/GlassPanel.tsx
+++ b/dash-ui/src/components/GlassPanel.tsx
@@ -1,0 +1,15 @@
+import type { PropsWithChildren } from 'react';
+
+interface GlassPanelProps extends PropsWithChildren {
+  className?: string;
+}
+
+const GlassPanel = ({ children, className }: GlassPanelProps) => (
+  <div
+    className={`glass-panel flex h-full w-full flex-col gap-4 rounded-[28px] border border-white/15 bg-[rgba(20,20,20,0.35)] p-8 text-white shadow-[0_20px_45px_rgba(0,0,0,0.45)] backdrop-blur-lg backdrop-brightness-[0.85] ${className ?? ''}`}
+  >
+    {children}
+  </div>
+);
+
+export default GlassPanel;

--- a/dash-ui/src/components/panels/ClockPanel.tsx
+++ b/dash-ui/src/components/panels/ClockPanel.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useState } from 'react';
+import GlassPanel from '../GlassPanel';
+import type { OfflineState } from '../../services/system';
+import type { LocaleConfig } from '../../services/config';
+
+interface ClockPanelProps {
+  locale?: LocaleConfig;
+  offlineState?: OfflineState | null;
+  healthStatus?: string;
+  lastRefresh?: number;
+}
+
+const ClockPanel = ({ locale, offlineState, healthStatus, lastRefresh }: ClockPanelProps) => {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => {
+      setNow(new Date());
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const localeCode = useMemo(() => {
+    const pieces = [locale?.language, locale?.country].filter(Boolean);
+    if (pieces.length > 0) {
+      return pieces.join('-');
+    }
+    if (locale?.country) {
+      return `es-${locale.country}`;
+    }
+    return 'es-ES';
+  }, [locale]);
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(localeCode, {
+        hour: '2-digit',
+        minute: '2-digit',
+      }),
+    [localeCode],
+  );
+
+  const secondsFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(localeCode, {
+        second: '2-digit',
+      }),
+    [localeCode],
+  );
+
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(localeCode, {
+        weekday: 'long',
+        day: 'numeric',
+        month: 'long',
+      }),
+    [localeCode],
+  );
+
+  const formattedTime = useMemo(() => timeFormatter.format(now), [timeFormatter, now]);
+  const formattedSeconds = useMemo(() => secondsFormatter.format(now), [secondsFormatter, now]);
+  const formattedDate = useMemo(() => dateFormatter.format(now), [dateFormatter, now]);
+
+  const offlineLabel = useMemo(() => {
+    if (!offlineState) return 'Sincronizando';
+    if (!offlineState.offline) return 'Conectado';
+    return 'Sin conexión';
+  }, [offlineState]);
+
+  const refreshLabel = useMemo(() => {
+    if (!lastRefresh) return null;
+    return new Intl.DateTimeFormat(localeCode, {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    }).format(new Date(lastRefresh));
+  }, [lastRefresh, localeCode]);
+
+  return (
+    <GlassPanel className="justify-between">
+      <div className="flex flex-col gap-2">
+        <div className="text-[112px] font-light leading-none tracking-tight text-white/95">
+          <span>{formattedTime}</span>
+          <span className="text-[64px] align-top text-white/60">{formattedSeconds}</span>
+        </div>
+        <div className="text-2xl capitalize text-white/80">{formattedDate}</div>
+      </div>
+      <div className="flex items-center justify-between text-sm text-white/65">
+        <span>{offlineLabel}</span>
+        <span>{healthStatus ?? ''}</span>
+        <span>{refreshLabel ? `Actualizado ${refreshLabel}` : ''}</span>
+      </div>
+    </GlassPanel>
+  );
+};
+
+export default ClockPanel;

--- a/dash-ui/src/components/panels/InfoPanel.tsx
+++ b/dash-ui/src/components/panels/InfoPanel.tsx
@@ -1,0 +1,56 @@
+import GlassPanel from '../GlassPanel';
+import type { DayInfoPayload } from '../../services/dayinfo';
+
+interface InfoPanelProps {
+  dayInfo?: DayInfoPayload | null;
+}
+
+const InfoPanel = ({ dayInfo }: InfoPanelProps) => {
+  if (!dayInfo) {
+    return (
+      <GlassPanel className="justify-center text-center text-white/75">
+        <div className="text-2xl">Preparando información…</div>
+      </GlassPanel>
+    );
+  }
+
+  const efemeride = dayInfo.efemerides?.[0];
+  const santoral = dayInfo.santoral?.map((item) => item.name).join(', ');
+  const holiday = dayInfo.holiday?.is_holiday ? dayInfo.holiday.name : null;
+  const patronName = dayInfo.patron?.name?.trim();
+  const patronPlace = dayInfo.patron?.place?.trim();
+  const patron = patronName ? (patronPlace ? `${patronName} (${patronPlace})` : patronName) : null;
+
+  return (
+    <GlassPanel className="justify-between">
+      <div className="flex flex-col gap-4">
+        <div>
+          <h2 className="text-xs uppercase tracking-[0.3em] text-white/45">Efeméride</h2>
+          <p className="mt-2 text-lg leading-tight text-white/85">
+            {efemeride?.text ?? 'Sin efemérides destacadas.'}
+          </p>
+        </div>
+        <div>
+          <h2 className="text-xs uppercase tracking-[0.3em] text-white/45">Santoral</h2>
+          <p className="mt-2 text-base text-white/80">{santoral ?? 'Sin datos.'}</p>
+        </div>
+      </div>
+      <div className="space-y-2 text-sm text-white/75">
+        {holiday ? (
+          <div>
+            <span className="text-white/60">Festivo:</span> {holiday}
+          </div>
+        ) : (
+          <div className="text-white/45">Hoy no es festivo</div>
+        )}
+        {patron ? (
+          <div>
+            <span className="text-white/60">Patrón:</span> {patron}
+          </div>
+        ) : null}
+      </div>
+    </GlassPanel>
+  );
+};
+
+export default InfoPanel;

--- a/dash-ui/src/components/panels/WeatherPanel.tsx
+++ b/dash-ui/src/components/panels/WeatherPanel.tsx
@@ -1,0 +1,60 @@
+import GlassPanel from '../GlassPanel';
+import type { WeatherToday } from '../../services/weather';
+
+interface WeatherPanelProps {
+  weather?: WeatherToday | null;
+}
+
+const iconMap: Record<string, string> = {
+  sun: '☀️',
+  cloud: '☁️',
+  rain: '🌧️',
+  storm: '⛈️',
+  snow: '❄️',
+  fog: '🌫️',
+};
+
+const WeatherPanel = ({ weather }: WeatherPanelProps) => {
+  if (!weather) {
+    return (
+      <GlassPanel className="justify-center text-center text-white/75">
+        <div className="text-2xl">Cargando clima…</div>
+      </GlassPanel>
+    );
+  }
+
+  const icon = iconMap[weather.icon] ?? '🌡️';
+  const updatedAt = weather.updatedAt ? new Date(weather.updatedAt * 1000) : null;
+
+  return (
+    <GlassPanel className="justify-between">
+      <div className="flex items-start justify-between gap-4">
+        <div className="text-[96px] leading-none">{icon}</div>
+        <div className="flex flex-col items-end">
+          <div className="text-6xl font-light text-white/90">{Math.round(weather.temp)}°</div>
+          <div className="text-lg text-white/70">{weather.condition}</div>
+          <div className="text-sm text-white/60">{weather.city}</div>
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-4 text-sm text-white/70">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-white/50">Mínima</div>
+          <div className="text-xl text-white/80">{Math.round(weather.min)}°</div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wide text-white/50">Máxima</div>
+          <div className="text-xl text-white/80">{Math.round(weather.max)}°</div>
+        </div>
+        <div>
+          <div className="text-xs uppercase tracking-wide text-white/50">Lluvia</div>
+          <div className="text-xl text-white/80">{Math.round(weather.rainProb)}%</div>
+        </div>
+      </div>
+      <div className="text-right text-xs text-white/55">
+        {updatedAt ? `Actualizado ${updatedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''}
+      </div>
+    </GlassPanel>
+  );
+};
+
+export default WeatherPanel;

--- a/dash-ui/src/pages/Config.tsx
+++ b/dash-ui/src/pages/Config.tsx
@@ -1,0 +1,589 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Background from '../components/Background';
+import GlassPanel from '../components/GlassPanel';
+import {
+  fetchConfigEnvelope,
+  saveConfigPatch,
+  saveSecretsPatch,
+  type ConfigEnvelope,
+  type ConfigUpdate,
+} from '../services/config';
+import { connectNetwork, fetchWifiStatus, scanNetworks, type WifiNetwork, type WifiStatus } from '../services/wifi';
+import { useDashboardConfig } from '../context/DashboardConfigContext';
+
+interface Notice {
+  type: 'success' | 'error' | 'info';
+  text: string;
+}
+
+interface FormState {
+  aemetApiKey: string;
+  aemetMunicipioId: string;
+  weatherCity: string;
+  weatherUnits: 'metric' | 'imperial';
+  calendarEnabled: boolean;
+  calendarIcsUrl: string;
+  calendarMaxEvents: string;
+  calendarNotifyMinutesBefore: string;
+  backgroundMode: 'daily' | 'weather';
+  backgroundIntervalMinutes: string;
+  backgroundRetainDays: string;
+}
+
+const DEFAULT_FORM: FormState = {
+  aemetApiKey: '',
+  aemetMunicipioId: '',
+  weatherCity: '',
+  weatherUnits: 'metric',
+  calendarEnabled: false,
+  calendarIcsUrl: '',
+  calendarMaxEvents: '3',
+  calendarNotifyMinutesBefore: '15',
+  backgroundMode: 'daily',
+  backgroundIntervalMinutes: '60',
+  backgroundRetainDays: '7',
+};
+
+const Config = () => {
+  const { refresh: refreshConfig } = useDashboardConfig();
+  const [form, setForm] = useState<FormState>(DEFAULT_FORM);
+  const [envelope, setEnvelope] = useState<ConfigEnvelope | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [wifiNotice, setWifiNotice] = useState<Notice | null>(null);
+  const [wifiStatus, setWifiStatus] = useState<WifiStatus | null>(null);
+  const [wifiNetworks, setWifiNetworks] = useState<WifiNetwork[]>([]);
+  const [wifiRaw, setWifiRaw] = useState('');
+  const [scanningWifi, setScanningWifi] = useState(false);
+  const [connectingWifi, setConnectingWifi] = useState(false);
+  const [selectedSsid, setSelectedSsid] = useState<string | null>(null);
+  const [wifiPassword, setWifiPassword] = useState('');
+  const [openAiInput, setOpenAiInput] = useState('');
+  const [savingSecrets, setSavingSecrets] = useState(false);
+  const [savingConfig, setSavingConfig] = useState(false);
+
+  const openAiDetails = useMemo(() => {
+    const secrets = (envelope?.secrets ?? {}) as Record<string, any>;
+    const openai = secrets?.openai as { hasKey?: boolean; masked?: string | null } | undefined;
+    return {
+      hasKey: Boolean(openai?.hasKey),
+      masked: typeof openai?.masked === 'string' ? openai.masked : null,
+    };
+  }, [envelope?.secrets]);
+
+  const buildFormFromConfig = useCallback((configData: Record<string, any> | null): FormState => {
+    if (!configData) return DEFAULT_FORM;
+    const aemet = (configData.aemet as Record<string, any> | undefined) ?? {};
+    const weather = (configData.weather as Record<string, any> | undefined) ?? {};
+    const calendar = (configData.calendar as Record<string, any> | undefined) ?? {};
+    const background = (configData.background as Record<string, any> | undefined) ?? {};
+
+    return {
+      aemetApiKey: typeof aemet.apiKey === 'string' ? aemet.apiKey : '',
+      aemetMunicipioId: typeof aemet.municipioId === 'string' ? aemet.municipioId : '',
+      weatherCity: typeof weather.city === 'string' ? weather.city : '',
+      weatherUnits: weather.units === 'imperial' ? 'imperial' : 'metric',
+      calendarEnabled: Boolean(calendar.enabled),
+      calendarIcsUrl: typeof calendar.icsUrl === 'string' ? calendar.icsUrl : '',
+      calendarMaxEvents:
+        typeof calendar.maxEvents === 'number' ? String(calendar.maxEvents) : DEFAULT_FORM.calendarMaxEvents,
+      calendarNotifyMinutesBefore:
+        typeof calendar.notifyMinutesBefore === 'number'
+          ? String(calendar.notifyMinutesBefore)
+          : DEFAULT_FORM.calendarNotifyMinutesBefore,
+      backgroundMode: background.mode === 'weather' ? 'weather' : 'daily',
+      backgroundIntervalMinutes:
+        typeof background.intervalMinutes === 'number'
+          ? String(background.intervalMinutes)
+          : DEFAULT_FORM.backgroundIntervalMinutes,
+      backgroundRetainDays:
+        typeof background.retainDays === 'number'
+          ? String(background.retainDays)
+          : DEFAULT_FORM.backgroundRetainDays,
+    };
+  }, []);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [configData, wifiData] = await Promise.all([
+        fetchConfigEnvelope(),
+        fetchWifiStatus().catch(() => null),
+      ]);
+      setEnvelope(configData);
+      setForm(buildFormFromConfig((configData.config as Record<string, any>) ?? null));
+      if (wifiData) setWifiStatus(wifiData);
+      setNotice(null);
+      setWifiNotice(null);
+    } catch (error) {
+      console.error('Error cargando configuración', error);
+      setNotice({
+        type: 'error',
+        text: error instanceof Error ? error.message : 'No se pudo cargar la configuración',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [buildFormFromConfig]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!notice) return;
+    const timeout = window.setTimeout(() => setNotice(null), 5000);
+    return () => window.clearTimeout(timeout);
+  }, [notice]);
+
+  useEffect(() => {
+    if (!wifiNotice) return;
+    const timeout = window.setTimeout(() => setWifiNotice(null), 5000);
+    return () => window.clearTimeout(timeout);
+  }, [wifiNotice]);
+
+  const handleFormChange = <T extends keyof FormState>(key: T, value: FormState[T]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const parseInteger = (value: string) => {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  };
+
+  const handleSaveConfig = async () => {
+    setSavingConfig(true);
+    setNotice(null);
+    const patch: ConfigUpdate = {
+      aemet: {
+        apiKey: form.aemetApiKey || undefined,
+        municipioId: form.aemetMunicipioId || undefined,
+      },
+      weather: {
+        city: form.weatherCity || undefined,
+        units: form.weatherUnits,
+      },
+      calendar: {
+        enabled: form.calendarEnabled,
+        icsUrl: form.calendarIcsUrl || null,
+        maxEvents: parseInteger(form.calendarMaxEvents),
+        notifyMinutesBefore: parseInteger(form.calendarNotifyMinutesBefore),
+      },
+      background: {
+        mode: form.backgroundMode,
+        intervalMinutes: parseInteger(form.backgroundIntervalMinutes),
+        retainDays: parseInteger(form.backgroundRetainDays),
+      },
+    };
+
+    try {
+      const updated = await saveConfigPatch(patch);
+      setEnvelope(updated);
+      setForm(buildFormFromConfig((updated.config as Record<string, any>) ?? null));
+      setNotice({ type: 'success', text: 'Configuración guardada' });
+      await refreshConfig();
+    } catch (error) {
+      console.error('No se pudo guardar configuración', error);
+      setNotice({
+        type: 'error',
+        text: error instanceof Error ? error.message : 'Error al guardar configuración',
+      });
+    } finally {
+      setSavingConfig(false);
+    }
+  };
+
+  const handleSaveSecrets = async () => {
+    setSavingSecrets(true);
+    setNotice(null);
+    try {
+      const updated = await saveSecretsPatch({ openai: { apiKey: openAiInput || null } });
+      setEnvelope(updated);
+      setOpenAiInput('');
+      setNotice({ type: 'success', text: 'Clave de OpenAI actualizada' });
+    } catch (error) {
+      console.error('Error guardando secreto', error);
+      setNotice({
+        type: 'error',
+        text: error instanceof Error ? error.message : 'No se pudo guardar la clave',
+      });
+    } finally {
+      setSavingSecrets(false);
+      try {
+        await refreshConfig();
+      } catch (error) {
+        console.warn('No se pudo refrescar config tras guardar secreto', error);
+      }
+    }
+  };
+
+  const handleScanWifi = async () => {
+    setScanningWifi(true);
+    try {
+      const result = await scanNetworks();
+      setWifiNetworks(result.networks ?? []);
+      setWifiRaw(result.raw ?? '');
+      setWifiNotice({ type: 'info', text: `Se encontraron ${result.networks?.length ?? 0} redes` });
+    } catch (error) {
+      console.error('Error escaneando redes', error);
+      setWifiNotice({
+        type: 'error',
+        text: error instanceof Error ? error.message : 'No se pudo escanear Wi-Fi',
+      });
+    } finally {
+      setScanningWifi(false);
+    }
+  };
+
+  const handleConnectWifi = async () => {
+    if (!selectedSsid) {
+      setWifiNotice({ type: 'error', text: 'Selecciona una red para conectar' });
+      return;
+    }
+    setConnectingWifi(true);
+    try {
+      await connectNetwork(selectedSsid, wifiPassword || undefined);
+      const status = await fetchWifiStatus();
+      setWifiStatus(status);
+      setWifiNotice({ type: 'success', text: `Conectado a ${selectedSsid}` });
+    } catch (error) {
+      console.error('Error conectando a Wi-Fi', error);
+      setWifiNotice({
+        type: 'error',
+        text: error instanceof Error ? error.message : 'No se pudo conectar a la red',
+      });
+    } finally {
+      setConnectingWifi(false);
+    }
+  };
+
+  const backgroundMinutes = useMemo(() => {
+    const configData = (envelope?.config ?? {}) as Record<string, any>;
+    const background = (configData.background as Record<string, any> | undefined) ?? {};
+    return typeof background.intervalMinutes === 'number' ? background.intervalMinutes : undefined;
+  }, [envelope?.config]);
+
+  return (
+    <div className="relative flex h-screen w-screen bg-slate-950 text-white">
+      <Background refreshMinutes={backgroundMinutes ?? 60} />
+      <div className="relative z-10 flex h-full w-full overflow-y-auto">
+        <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col gap-8 px-8 py-10">
+          <header className="flex flex-col gap-2">
+            <h1 className="text-3xl font-semibold text-white/90">Configuración general</h1>
+            <p className="text-sm text-white/60">
+              Ajusta las integraciones y la conectividad de la pantalla desde este panel administrativo.
+            </p>
+          </header>
+
+          {notice ? (
+            <div
+              className={`rounded-xl border px-4 py-3 text-sm ${
+                notice.type === 'success'
+                  ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
+                  : notice.type === 'error'
+                  ? 'border-red-400/40 bg-red-500/10 text-red-100'
+                  : 'border-sky-400/40 bg-sky-500/10 text-sky-100'
+              }`}
+            >
+              {notice.text}
+            </div>
+          ) : null}
+
+          <div className="grid gap-6 lg:grid-cols-2">
+            <GlassPanel className="gap-6">
+              <div>
+                <h2 className="text-lg font-medium text-white/85">APIs y servicios</h2>
+                <p className="text-sm text-white/55">
+                  Configura las claves y parámetros de acceso para OpenAI, AEMET y Google Calendar.
+                </p>
+              </div>
+
+              <div className="space-y-4">
+                <div>
+                  <label className="block text-xs uppercase tracking-wide text-white/50">Clave OpenAI</label>
+                  <div className="mt-2 grid gap-2 md:grid-cols-[2fr_1fr]">
+                    <input
+                      type="text"
+                      className="rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+                      placeholder={openAiDetails.masked ?? 'sk-••••••'}
+                      value={openAiInput}
+                      onChange={(event) => setOpenAiInput(event.target.value)}
+                    />
+                    <button
+                      type="button"
+                      onClick={handleSaveSecrets}
+                      className="rounded-lg bg-emerald-500/80 px-3 py-2 text-sm font-medium text-white shadow-md transition hover:bg-emerald-500"
+                      disabled={savingSecrets}
+                    >
+                      {savingSecrets ? 'Guardando…' : openAiDetails.hasKey ? 'Actualizar clave' : 'Guardar clave'}
+                    </button>
+                  </div>
+                  <p className="mt-1 text-xs text-white/45">
+                    Estado: {openAiDetails.hasKey ? 'Configurada' : 'Sin configurar'}
+                  </p>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label className="block text-xs uppercase tracking-wide text-white/50">AEMET API Key</label>
+                    <input
+                      type="text"
+                      className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+                      value={form.aemetApiKey}
+                      onChange={(event) => handleFormChange('aemetApiKey', event.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs uppercase tracking-wide text-white/50">AEMET Municipio ID</label>
+                    <input
+                      type="text"
+                      className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+                      value={form.aemetMunicipioId}
+                      onChange={(event) => handleFormChange('aemetMunicipioId', event.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label className="block text-xs uppercase tracking-wide text-white/50">Ciudad para el clima</label>
+                    <input
+                      type="text"
+                      className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+                      value={form.weatherCity}
+                      onChange={(event) => handleFormChange('weatherCity', event.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs uppercase tracking-wide text-white/50">Unidades</label>
+                    <select
+                      className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white focus:border-white/40 focus:outline-none"
+                      value={form.weatherUnits}
+                      onChange={(event) =>
+                        handleFormChange('weatherUnits', event.target.value === 'imperial' ? 'imperial' : 'metric')
+                      }
+                    >
+                      <option value="metric">Métrico</option>
+                      <option value="imperial">Imperial</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div>
+                  <label className="block text-xs uppercase tracking-wide text-white/50">Google Calendar ICS</label>
+                  <input
+                    type="url"
+                    className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
+                    value={form.calendarIcsUrl}
+                    onChange={(event) => handleFormChange('calendarIcsUrl', event.target.value)}
+                  />
+                  <div className="mt-3 grid gap-3 md:grid-cols-3">
+                    <label className="flex items-center gap-2 text-xs text-white/70">
+                      <input
+                        type="checkbox"
+                        checked={form.calendarEnabled}
+                        onChange={(event) => handleFormChange('calendarEnabled', event.target.checked)}
+                        className="h-4 w-4 rounded border-white/30 bg-white/10 text-emerald-400 focus:ring-emerald-400"
+                      />
+                      Calendario activo
+                    </label>
+                    <div>
+                      <span className="block text-xs uppercase tracking-wide text-white/50">Máx. eventos</span>
+                      <input
+                        type="number"
+                        min={1}
+                        max={10}
+                        className="mt-1 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white focus:border-white/40 focus:outline-none"
+                        value={form.calendarMaxEvents}
+                        onChange={(event) => handleFormChange('calendarMaxEvents', event.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <span className="block text-xs uppercase tracking-wide text-white/50">Aviso previo (min)</span>
+                      <input
+                        type="number"
+                        min={0}
+                        max={360}
+                        className="mt-1 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white focus:border-white/40 focus:outline-none"
+                        value={form.calendarNotifyMinutesBefore}
+                        onChange={(event) => handleFormChange('calendarNotifyMinutesBefore', event.target.value)}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleSaveConfig}
+                  className="rounded-lg bg-white/15 px-4 py-2 text-sm font-medium text-white shadow-md transition hover:bg-white/25"
+                  disabled={savingConfig || loading}
+                >
+                  {savingConfig ? 'Guardando…' : 'Guardar cambios'}
+                </button>
+              </div>
+            </GlassPanel>
+
+            <GlassPanel className="gap-6">
+              <div>
+                <h2 className="text-lg font-medium text-white/85">Fondo dinámico</h2>
+                <p className="text-sm text-white/55">
+                  Controla el modo de rotación de fondos generados por el backend y su frecuencia.
+                </p>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label className="block text-xs uppercase tracking-wide text-white/50">Modo</label>
+                  <select
+                    className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white focus:border-white/40 focus:outline-none"
+                    value={form.backgroundMode}
+                    onChange={(event) =>
+                      handleFormChange('backgroundMode', event.target.value === 'weather' ? 'weather' : 'daily')
+                    }
+                  >
+                    <option value="daily">Diario</option>
+                    <option value="weather">Según clima</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-xs uppercase tracking-wide text-white/50">Intervalo (minutos)</label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={240}
+                    className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white focus:border-white/40 focus:outline-none"
+                    value={form.backgroundIntervalMinutes}
+                    onChange={(event) => handleFormChange('backgroundIntervalMinutes', event.target.value)}
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs uppercase tracking-wide text-white/50">Retención (días)</label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={90}
+                    className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white focus:border-white/40 focus:outline-none"
+                    value={form.backgroundRetainDays}
+                    onChange={(event) => handleFormChange('backgroundRetainDays', event.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <h3 className="text-lg font-medium text-white/85">Conectividad Wi-Fi</h3>
+                {wifiNotice ? (
+                  <div
+                    className={`rounded-lg border px-3 py-2 text-xs ${
+                      wifiNotice.type === 'success'
+                        ? 'border-emerald-400/40 bg-emerald-500/10 text-emerald-100'
+                        : wifiNotice.type === 'error'
+                        ? 'border-red-400/40 bg-red-500/10 text-red-100'
+                        : 'border-sky-400/40 bg-sky-500/10 text-sky-100'
+                    }`}
+                  >
+                    {wifiNotice.text}
+                  </div>
+                ) : null}
+
+                <div className="rounded-xl border border-white/15 bg-white/5 p-4 text-sm text-white/80">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <div className="text-xs uppercase tracking-wide text-white/50">Estado actual</div>
+                      <div className="mt-1 text-base text-white/90">
+                        {wifiStatus?.connected
+                          ? `Conectado a ${wifiStatus.ssid ?? 'desconocido'}`
+                          : 'Sin conexión Wi-Fi'}
+                      </div>
+                      <div className="text-xs text-white/55">
+                        {wifiStatus?.ip ? `IP: ${wifiStatus.ip}` : 'IP no disponible'}
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={handleScanWifi}
+                      className="rounded-lg bg-white/20 px-3 py-2 text-xs font-medium text-white transition hover:bg-white/30"
+                      disabled={scanningWifi}
+                    >
+                      {scanningWifi ? 'Buscando…' : 'Escanear redes'}
+                    </button>
+                  </div>
+                </div>
+
+                {wifiNetworks.length > 0 ? (
+                  <div className="space-y-2">
+                    <div className="text-xs uppercase tracking-wide text-white/45">Redes disponibles</div>
+                    <div className="max-h-64 space-y-2 overflow-y-auto pr-2">
+                      {wifiNetworks.map((network) => (
+                        <button
+                          key={network.ssid}
+                          type="button"
+                          onClick={() => setSelectedSsid(network.ssid)}
+                          className={`flex w-full items-center justify-between rounded-lg border px-3 py-2 text-left text-sm transition ${
+                            selectedSsid === network.ssid
+                              ? 'border-emerald-400/50 bg-emerald-500/10 text-emerald-100'
+                              : 'border-white/15 bg-white/5 text-white/80 hover:border-white/30 hover:bg-white/10'
+                          }`}
+                        >
+                          <span>{network.ssid}</span>
+                          <span className="text-xs text-white/60">{network.signal ?? '–'}%</span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {wifiRaw ? (
+                  <details className="rounded-lg border border-white/10 bg-black/30 p-3 text-xs text-white/60">
+                    <summary className="cursor-pointer text-white/70">Detalle nmcli</summary>
+                    <pre className="mt-2 whitespace-pre-wrap break-words text-[11px] text-white/50">{wifiRaw}</pre>
+                  </details>
+                ) : null}
+
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <label className="block text-xs uppercase tracking-wide text-white/50">SSID seleccionado</label>
+                    <input
+                      type="text"
+                      readOnly
+                      className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white focus:border-white/40 focus:outline-none"
+                      value={selectedSsid ?? ''}
+                      placeholder="Selecciona una red"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs uppercase tracking-wide text-white/50">Contraseña</label>
+                    <input
+                      type="password"
+                      className="mt-2 w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white focus:border-white/40 focus:outline-none"
+                      value={wifiPassword}
+                      onChange={(event) => setWifiPassword(event.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    onClick={handleConnectWifi}
+                    className="rounded-lg bg-emerald-500/80 px-4 py-2 text-sm font-medium text-white shadow-md transition hover:bg-emerald-500"
+                    disabled={connectingWifi}
+                  >
+                    {connectingWifi ? 'Conectando…' : 'Conectar' }
+                  </button>
+                </div>
+              </div>
+            </GlassPanel>
+          </div>
+
+          {loading ? (
+            <div className="text-center text-sm text-white/60">Cargando configuración…</div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Config;

--- a/dash-ui/src/pages/Display.tsx
+++ b/dash-ui/src/pages/Display.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Background from '../components/Background';
+import ClockPanel from '../components/panels/ClockPanel';
+import WeatherPanel from '../components/panels/WeatherPanel';
+import InfoPanel from '../components/panels/InfoPanel';
+import { useDashboardConfig } from '../context/DashboardConfigContext';
+import { fetchWeatherToday, type WeatherToday } from '../services/weather';
+import { fetchDayBrief, type DayInfoPayload } from '../services/dayinfo';
+import { fetchHealth, fetchOfflineState, type HealthStatus, type OfflineState } from '../services/system';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+const Display = () => {
+  const { config, refresh: refreshConfig } = useDashboardConfig();
+  const [weather, setWeather] = useState<WeatherToday | null>(null);
+  const [dayInfo, setDayInfo] = useState<DayInfoPayload | null>(null);
+  const [offlineState, setOfflineState] = useState<OfflineState | null>(null);
+  const [health, setHealth] = useState<HealthStatus | null>(null);
+  const [lastRefresh, setLastRefresh] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    const [weatherData, dayInfoData, offlineData, healthData] = await Promise.all([
+      fetchWeatherToday().catch((error) => {
+        console.warn('No se pudo cargar el clima', error);
+        return null;
+      }),
+      fetchDayBrief().catch((error) => {
+        console.warn('No se pudo cargar la información del día', error);
+        return null;
+      }),
+      fetchOfflineState().catch((error) => {
+        console.warn('No se pudo cargar el estado offline', error);
+        return null;
+      }),
+      fetchHealth().catch((error) => {
+        console.warn('No se pudo cargar healthcheck', error);
+        return null;
+      }),
+    ]);
+
+    if (weatherData) setWeather(weatherData);
+    if (dayInfoData) setDayInfo(dayInfoData);
+    if (offlineData) setOfflineState(offlineData);
+    if (healthData) setHealth(healthData);
+    setLastRefresh(Date.now());
+
+    try {
+      await refreshConfig();
+    } catch (error) {
+      console.warn('No se pudo refrescar configuración', error);
+    }
+  }, [refreshConfig]);
+
+  useEffect(() => {
+    void load();
+    const interval = window.setInterval(() => {
+      void load();
+    }, REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [load]);
+
+  const healthLabel = useMemo(() => {
+    if (!health) return '';
+    if (health.status?.toLowerCase() === 'ok') {
+      return 'Sistema estable';
+    }
+    return `Estado: ${health.status}`;
+  }, [health]);
+
+  return (
+    <div className="relative h-screen w-screen overflow-hidden bg-black text-white">
+      <Background refreshMinutes={config?.background?.intervalMinutes ?? 60} />
+      <div className="relative z-10 flex h-full w-full items-center justify-center px-12 py-8">
+        <div className="grid h-full w-full max-w-[1840px] grid-cols-3 gap-8">
+          <ClockPanel
+            locale={config?.locale}
+            offlineState={offlineState}
+            healthStatus={healthLabel}
+            lastRefresh={lastRefresh ?? undefined}
+          />
+          <WeatherPanel weather={weather} />
+          <InfoPanel dayInfo={dayInfo} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Display;

--- a/dash-ui/src/services/system.ts
+++ b/dash-ui/src/services/system.ts
@@ -1,0 +1,22 @@
+import { apiRequest } from './config';
+
+export interface HealthStatus {
+  status: string;
+  uptime?: number;
+  version?: string;
+}
+
+export interface OfflineState {
+  offline: boolean;
+  since?: number;
+  sources?: Record<string, boolean>;
+  errors?: Record<string, string>;
+}
+
+export async function fetchHealth(): Promise<HealthStatus> {
+  return await apiRequest<HealthStatus>('/health');
+}
+
+export async function fetchOfflineState(): Promise<OfflineState> {
+  return await apiRequest<OfflineState>('/system/offline-state');
+}

--- a/dash-ui/src/services/wifi.ts
+++ b/dash-ui/src/services/wifi.ts
@@ -6,14 +6,20 @@ export interface WifiNetwork {
   security?: string;
 }
 
+export interface WifiScanResult {
+  networks: WifiNetwork[];
+  raw?: string;
+}
+
 export interface WifiStatus {
   connected: boolean;
   ssid?: string | null;
   ip?: string | null;
+  interface?: string | null;
 }
 
-export async function scanNetworks(): Promise<WifiNetwork[]> {
-  return await apiRequest<WifiNetwork[]>('/wifi/scan');
+export async function scanNetworks(): Promise<WifiScanResult> {
+  return await apiRequest<WifiScanResult>('/wifi/scan');
 }
 
 export async function connectNetwork(ssid: string, password?: string): Promise<void> {
@@ -23,13 +29,6 @@ export async function connectNetwork(ssid: string, password?: string): Promise<v
   });
 }
 
-export async function forgetNetwork(ssid: string): Promise<void> {
-  await apiRequest('/wifi/forget', {
-    method: 'POST',
-    body: JSON.stringify({ ssid }),
-  });
-}
-
 export async function fetchWifiStatus(): Promise<WifiStatus> {
-  return await apiRequest<WifiStatus>('/network/status');
+  return await apiRequest<WifiStatus>('/wifi/status');
 }


### PR DESCRIPTION
## Summary
- rebuild the public `/` view into a glassmorphism display with clock, weather, and daily info refreshed every 60 seconds
- add a `/config` admin panel covering API credentials, background settings, and Wi-Fi management backed by config/secrets endpoints
- extend frontend services for config, health, and Wi-Fi to align with backend persistence and nmcli helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f66f9899e08326ba9d51b8a4646d17