### PR TITLE
Restore geolocation sync on display load

### DIFF
--- a/dash-ui/src/services/location.ts
+++ b/dash-ui/src/services/location.ts
@@ -1,0 +1,17 @@
+import { apiRequest } from './config';
+
+export interface LocationOverridePayload {
+  lat: number;
+  lon: number;
+}
+
+export interface LocationOverrideResponse {
+  ok: boolean;
+}
+
+export async function overrideLocation(payload: LocationOverridePayload): Promise<LocationOverrideResponse> {
+  return await apiRequest<LocationOverrideResponse>('/location/override', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}


### PR DESCRIPTION
## Summary
- add a location service wrapper for posting the browser coordinates to the backend
- reinstate a geolocation effect on the display dashboard so the device position syncs on mount

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f674cc8a288326b9b206b0c5e8e45d