### PR TITLE
Add systemd kiosk autostart service for Chromium UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ permisos, systemd y endurecimiento.
 - `/etc/pantalla-dash/config.json` debe tener permisos `600` (root:root).
 - No se exponen secretos vía endpoints ni logs.
 
+## Autoinicio UI
+
+El instalador (`scripts/install.sh`) registra el servicio `pantalla-ui.service`,
+que lanza Chromium en modo *app+kiosk* apuntando a `http://127.0.0.1:8080/` con
+las barras ocultas y tamaño fijo `1920x480`.
+
+- **Habilitar**: `sudo systemctl enable --now pantalla-ui.service`
+- **Deshabilitar temporalmente**: `sudo systemctl disable --now pantalla-ui.service`
+- **Cambiar la URL/ajustes**: edita `/etc/systemd/system/pantalla-ui.service` o
+  usa `sudo systemctl edit pantalla-ui.service` para sobreescribir la variable
+  `PANTALLA_UI_URL`. Recarga y reinicia con `sudo systemctl daemon-reload` y
+  `sudo systemctl restart pantalla-ui.service`.
+- **Verificar estado/logs**: `systemctl status pantalla-ui.service --no-pager -l`
+
+El binario a lanzar se resuelve automáticamente (Chromium, `chromium-browser` o
+Google Chrome) mediante `/usr/local/bin/pantalla-ui-launch.sh`.
+
 ## Licencia
 
 MIT (o la licencia original del repositorio si se define).

--- a/scripts/pantalla-ui-launch.sh
+++ b/scripts/pantalla-ui-launch.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="${PANTALLA_UI_URL:-http://127.0.0.1:8080/}"
+WIDTH="${PANTALLA_UI_WIDTH:-1920}"
+HEIGHT="${PANTALLA_UI_HEIGHT:-480}"
+POSITION_X="${PANTALLA_UI_POS_X:-0}"
+POSITION_Y="${PANTALLA_UI_POS_Y:-0}"
+
+candidates=(chromium-browser chromium google-chrome-stable google-chrome)
+CHROMIUM_BIN=""
+for candidate in "${candidates[@]}"; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    CHROMIUM_BIN="$(command -v "$candidate")"
+    break
+  fi
+done
+
+if [[ -z "$CHROMIUM_BIN" ]]; then
+  echo "pantalla-ui-launch: no se encontró un binario de Chromium compatible" >&2
+  exit 1
+fi
+
+exec "$CHROMIUM_BIN" \
+  --app="$URL" \
+  --kiosk \
+  --start-fullscreen \
+  --window-size="${WIDTH},${HEIGHT}" \
+  --window-position="${POSITION_X},${POSITION_Y}" \
+  --no-first-run \
+  --disable-session-crashed-bubble \
+  --disable-infobars \
+  --noerrdialogs \
+  --check-for-update-interval=31536000

--- a/system/pantalla-ui.service
+++ b/system/pantalla-ui.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Pantalla Chromium UI (kiosk)
+After=graphical.target
+Wants=graphical.target
+
+[Service]
+Type=simple
+User={{UI_USER}}
+Environment=DISPLAY=:0
+Environment=PANTALLA_UI_URL=http://127.0.0.1:8080/
+ExecStartPre=/usr/bin/bash -c '/usr/bin/pkill -f chromium || true'
+ExecStart=/usr/local/bin/pantalla-ui-launch.sh
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
## Summary
- add a dedicated pantalla-ui.service unit that launches Chromium in kiosk/app mode via a new launcher script
- update the installer to deploy the launcher, install and enable the service, and disable XDG Chromium autostarts while keeping Openbox autostart focused on display prep
- document how to manage the new service and adjust its target URL

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f67918a9e0832695f4813428b24c2f