### PR TITLE
Adjust kiosk default URL to deployed UI port

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ permisos, systemd y endurecimiento.
 ## Autoinicio UI
 
 El instalador (`scripts/install.sh`) registra el servicio `pantalla-ui.service`,
-que lanza Chromium en modo *app+kiosk* apuntando a `http://127.0.0.1:8080/` con
+que lanza Chromium en modo *app+kiosk* apuntando a `http://127.0.0.1/` con
 las barras ocultas y tamaño fijo `1920x480`.
 
 - **Habilitar**: `sudo systemctl enable --now pantalla-ui.service`

--- a/scripts/pantalla-ui-launch.sh
+++ b/scripts/pantalla-ui-launch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-URL="${PANTALLA_UI_URL:-http://127.0.0.1:8080/}"
+URL="${PANTALLA_UI_URL:-http://127.0.0.1/}"
 WIDTH="${PANTALLA_UI_WIDTH:-1920}"
 HEIGHT="${PANTALLA_UI_HEIGHT:-480}"
 POSITION_X="${PANTALLA_UI_POS_X:-0}"

--- a/system/pantalla-ui.service
+++ b/system/pantalla-ui.service
@@ -7,7 +7,7 @@ Wants=graphical.target
 Type=simple
 User={{UI_USER}}
 Environment=DISPLAY=:0
-Environment=PANTALLA_UI_URL=http://127.0.0.1:8080/
+Environment=PANTALLA_UI_URL=http://127.0.0.1/
 ExecStartPre=/usr/bin/bash -c '/usr/bin/pkill -f chromium || true'
 ExecStart=/usr/local/bin/pantalla-ui-launch.sh
 Restart=always


### PR DESCRIPTION
## Summary
- point the default `PANTALLA_UI_URL` to `http://127.0.0.1/` so Chromium targets the deployed nginx site
- update the launcher script and README to reflect the port 80 default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f67de608908326abcc8a03a47af2aa