### PR TITLE
Run Chromium kiosk UI as a user service

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,20 +148,36 @@ permisos, systemd y endurecimiento.
 
 ## Autoinicio UI
 
-El instalador (`scripts/install.sh`) registra el servicio `pantalla-ui.service`,
-que lanza Chromium en modo *app+kiosk* apuntando a `http://127.0.0.1:8080/` con
-las barras ocultas y tamaño fijo `1920x480`.
+El instalador (`scripts/install.sh`) registra el servicio de **usuario**
+`pantalla-ui.service`, que lanza Chromium en modo *app+kiosk* apuntando a
+`http://127.0.0.1:8080/` con las barras ocultas y tamaño fijo `1920x480`. El
+unit se instala en `/etc/systemd/user/pantalla-ui.service`, se ejecuta en la
+sesión de `dani` (o el usuario configurado) y se engancha a
+`graphical-session.target`.
 
-- **Habilitar**: `sudo systemctl enable --now pantalla-ui.service`
-- **Deshabilitar temporalmente**: `sudo systemctl disable --now pantalla-ui.service`
-- **Cambiar la URL/ajustes**: edita `/etc/systemd/system/pantalla-ui.service` o
-  usa `sudo systemctl edit pantalla-ui.service` para sobreescribir la variable
-  `PANTALLA_UI_URL`. Recarga y reinicia con `sudo systemctl daemon-reload` y
-  `sudo systemctl restart pantalla-ui.service`.
-- **Verificar estado/logs**: `systemctl status pantalla-ui.service --no-pager -l`
+- **Habilitar**: `systemctl --user enable --now pantalla-ui.service`
+- **Deshabilitar temporalmente**: `systemctl --user disable --now pantalla-ui.service`
+- **Cambiar la URL/ajustes**: edita
+  `/etc/systemd/user/pantalla-ui.service` o usa
+  `systemctl --user edit pantalla-ui.service` para sobreescribir la variable
+  `PANTALLA_UI_URL`. Recarga y reinicia con
+  `systemctl --user daemon-reload` y
+  `systemctl --user restart pantalla-ui.service`.
+- **Verificar estado/logs**:
+  `systemctl --user status pantalla-ui.service --no-pager -l`
 
-El binario a lanzar se resuelve automáticamente (Chromium, `chromium-browser` o
-Google Chrome) mediante `/usr/local/bin/pantalla-ui-launch.sh`.
+El binario a lanzar se resuelve automáticamente (prefiriendo
+`/snap/bin/chromium`, luego `chromium`, `chromium-browser` o Google Chrome)
+mediante `/usr/local/bin/pantalla-ui-launch.sh`.
+
+### Troubleshooting
+
+- Comprueba el entorno en la sesión del usuario:
+  `echo $XDG_RUNTIME_DIR` debe apuntar a `/run/user/1000` (o el UID
+  correspondiente) y `echo $DBUS_SESSION_BUS_ADDRESS` a
+  `unix:path=/run/user/1000/bus`.
+- Verifica que `/snap/bin/chromium` existe y es ejecutable.
+- Desde el usuario, revisa el servicio: `systemctl --user status pantalla-ui.service -l --no-pager`.
 
 ## Licencia
 

--- a/scripts/pantalla-ui-launch.sh
+++ b/scripts/pantalla-ui-launch.sh
@@ -7,7 +7,7 @@ HEIGHT="${PANTALLA_UI_HEIGHT:-480}"
 POSITION_X="${PANTALLA_UI_POS_X:-0}"
 POSITION_Y="${PANTALLA_UI_POS_Y:-0}"
 
-candidates=(chromium-browser chromium google-chrome-stable google-chrome)
+candidates=(/snap/bin/chromium chromium chromium-browser google-chrome-stable google-chrome)
 CHROMIUM_BIN=""
 for candidate in "${candidates[@]}"; do
   if command -v "$candidate" >/dev/null 2>&1; then

--- a/system/pantalla-ui.service
+++ b/system/pantalla-ui.service
@@ -1,17 +1,19 @@
 [Unit]
 Description=Pantalla Chromium UI (kiosk)
-After=graphical.target
-Wants=graphical.target
+After=graphical-session.target
+Wants=graphical-session.target
 
 [Service]
 Type=simple
-User={{UI_USER}}
 Environment=DISPLAY=:0
+Environment=XDG_RUNTIME_DIR=/run/user/%U
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus
 Environment=PANTALLA_UI_URL=http://127.0.0.1:8080/
-ExecStartPre=/usr/bin/bash -c '/usr/bin/pkill -f chromium || true'
+ExecStartPre=/usr/bin/bash -lc 'pkill -9 -f "^/snap/bin/chromium( |$)" || true'
 ExecStart=/usr/local/bin/pantalla-ui-launch.sh
+KillMode=process
 Restart=always
 RestartSec=2
 
 [Install]
-WantedBy=graphical.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
## Summary
- move the pantalla-ui unit into the user systemd scope and add the snap session environment
- harden the Chromium launcher to prefer /snap/bin/chromium and document the new flow
- update the installer to deploy the user unit, remove legacy system instances, and enable linger

## Testing
- not run (not applicable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6f8f1882883269f3c22cdb44c45d2