### PR TITLE
Fix API proxy target in Nginx vhost

### DIFF
--- a/system/nginx/pantalla-dash.conf
+++ b/system/nginx/pantalla-dash.conf
@@ -5,7 +5,7 @@ server {
   index index.html;
 
   location /api/ {
-    proxy_pass http://127.0.0.1:8081/;
+    proxy_pass http://127.0.0.1:8787;
     proxy_set_header Host $host;
   }
 


### PR DESCRIPTION
## Summary
- update the Nginx site to proxy /api requests to the backend's actual port

## Testing
- not run (config change only)

------
https://chatgpt.com/codex/tasks/task_e_68f7159576548326afa74095935b670a