### PR TITLE
Add missing dependencies for background generator

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,5 @@ httpx==0.26.0
 pydantic==2.6.1
 python-json-logger==2.0.7
 openai>=1.10.0
+requests==2.31.0
+Pillow==10.2.0


### PR DESCRIPTION
## Summary
- add requests and Pillow to the backend requirements to satisfy the background generator's imports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f7295d18148326b338e498b4b285a1