### PR TITLE
Update requests dependency to secure release

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,5 +4,5 @@ httpx==0.26.0
 pydantic==2.6.1
 python-json-logger==2.0.7
 openai>=1.10.0
-requests==2.31.0
+requests>=2.32.0
 Pillow==10.2.0


### PR DESCRIPTION
## Summary
- bump the backend requests requirement to 2.32.0 or newer to resolve the CVE-2024-47081 vulnerability

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f72f744ed48326a362d1f12e8d1f6e