### PR TITLE
Pin requests dependency to 2.32.3

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,5 +4,5 @@ httpx==0.26.0
 pydantic==2.6.1
 python-json-logger==2.0.7
 openai>=1.10.0
-requests>=2.32.0
+requests==2.32.3
 Pillow==10.2.0


### PR DESCRIPTION
## Summary
- pin the backend requests dependency to version 2.32.3 to keep deterministic installs while pulling in the security fix

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f738ee47c8832694fbbecabbbcacb2