### PR TITLE
Fix Nginx asset routing to use webroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ permisos, systemd y endurecimiento.
   servir las nuevas rutas de salud y radar sin bloquear solicitudes.
 - La plantilla Nginx `system/nginx/pantalla-dash.conf` sirve la UI desde
   `/var/www/html` y mantiene únicamente un alias específico para
-  `/assets/backgrounds/auto/`.
+  `/assets/backgrounds/`.
 - `system/pantalla-kiosk.service` lanza Chromium en modo kiosko con aceleración
   VA-API, rasterización fuera de proceso y *zero-copy* para maximizar FPS.
 
@@ -185,6 +185,16 @@ mediante `/usr/local/bin/pantalla-ui-launch.sh`.
 - No debe existir un alias global `alias /opt/dash/assets/;` sobre `/assets/`,
   ya que desviaría los ficheros `index-*.js`, `vendor-*.js` e `index-*.css` del
   build.
+- Si se requieren fondos externos, usa un bloque dedicado en Nginx:
+
+  ```nginx
+  location ^~ /assets/backgrounds/ {
+    alias /opt/dash/assets/backgrounds/;
+    access_log off;
+    expires 7d;
+  }
+  ```
+
 - Tras instalar o actualizar, valida que todo responde con:
 
   ```bash

--- a/etc/nginx/sites-available/pantalla
+++ b/etc/nginx/sites-available/pantalla
@@ -9,13 +9,12 @@ server {
     proxy_set_header Host $host;
   }
 
-  # Servir estáticos directamente desde /var/www/html; 404 si el recurso no existe.
-  # ⚠️ No añadir alias globales sobre /assets/, para evitar desviar los bundles del build.
+  # Servir estáticos desde el root; 404 si no existe
   location / {
     try_files $uri $uri/ =404;
   }
 
-  # RUTA ESPECÍFICA para fondos (no tocar bundles).
+  # RUTA ESPECÍFICA para fondos (no tocar bundles)
   location ^~ /assets/backgrounds/ {
     alias /opt/dash/assets/backgrounds/;
     access_log off;

--- a/etc/nginx/sites-enabled/pantalla
+++ b/etc/nginx/sites-enabled/pantalla
@@ -1,0 +1,1 @@
+../sites-available/pantalla


### PR DESCRIPTION
## Summary
- update the packaged pantalla vhost to serve assets directly from /var/www/html and keep only the backgrounds alias
- add the nginx site definition and symlink so the installer no longer reintroduces the global /assets alias
- document the dedicated /assets/backgrounds/ block required for external backgrounds

## Testing
- nginx -t *(fails: nginx is not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f77ad83b788326a5f8e22173f4a05a