### PR TITLE
Handle compressed AEMET responses and rate limiting

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -495,7 +495,10 @@ async def weather_today(config: AppConfig = Depends(get_config)):
     except MissingApiKeyError as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except WeatherServiceError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        message = str(exc)
+        detail_lower = message.lower()
+        status = 503 if "aemet" in detail_lower else 502
+        raise HTTPException(status_code=status, detail=message) from exc
     payload = today.as_dict()
     payload["cached"] = meta.cached
     payload["source"] = meta.source


### PR DESCRIPTION
## Summary
- add a resilient AEMET payload decoder that supports gzip/zip responses, encoding fallbacks, and in-memory caching with rate-limit handling
- reuse the decoder in the storms service while introducing short-lived caches for radar and storm prediction datasets
- surface temporary AEMET outages as 503 responses when cached data is unavailable

## Testing
- python -m compileall backend/services/aemet.py backend/services/storms.py

------
https://chatgpt.com/codex/tasks/task_e_68f7cfd665948326a39f36a3deab23bf