### PR TITLE
Add nocursor flag to Xorg kiosk service

### DIFF
--- a/system/pantalla-xorg@.service
+++ b/system/pantalla-xorg@.service
@@ -11,7 +11,7 @@ StandardInput=tty
 TTYPath=/dev/tty1
 TTYReset=yes
 TTYVHangup=yes
-ExecStart=/bin/bash -lc 'XBIN=""; for p in /usr/lib/xorg/Xorg /usr/bin/Xorg; do [ -x "$p" ] && XBIN="$p" && break; done; [ -n "$XBIN" ] || { echo "Xorg bin not found"; exit 1; }; exec "$XBIN" :0 -nolisten tcp vt1 -keeptty'
+ExecStart=/bin/bash -lc 'XBIN=""; for p in /usr/lib/xorg/Xorg /usr/bin/Xorg; do [ -x "$p" ] && XBIN="$p" && break; done; [ -n "$XBIN" ] || { echo "Xorg bin not found"; exit 1; }; exec "$XBIN" :0 -nolisten tcp vt1 -keeptty -nocursor'
 Restart=always
 RestartSec=2
 Environment=HOME=/root


### PR DESCRIPTION
## Summary
- add the -nocursor option to the pantalla-xorg@.service ExecStart to hide the mouse cursor

## Testing
- `systemctl daemon-reload` *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*
- `systemctl restart pantalla-xorg@dani.service` *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*
- `systemctl is-active pantalla-xorg@dani` *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*
- `systemctl status pantalla-xorg@dani --no-pager -l | sed -n '1,40p'` *(fails: System has not been booted with systemd as init system (PID 1). Can't operate.)*

------
https://chatgpt.com/codex/tasks/task_e_68f7d1c67f908326aaee3245ed9aba8d