### PR TITLE
Remove status tagline from clock panel

### DIFF
--- a/dash-ui/src/components/panels/ClockPanel.tsx
+++ b/dash-ui/src/components/panels/ClockPanel.tsx
@@ -1,16 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
 import GlassPanel from '../GlassPanel';
-import type { OfflineState } from '../../services/system';
 import type { LocaleConfig } from '../../services/config';
 
 interface ClockPanelProps {
   locale?: LocaleConfig;
-  offlineState?: OfflineState | null;
-  healthStatus?: string;
-  lastRefresh?: number;
 }
 
-const ClockPanel = ({ locale, offlineState, healthStatus, lastRefresh }: ClockPanelProps) => {
+const ClockPanel = ({ locale }: ClockPanelProps) => {
   const [now, setNow] = useState(() => new Date());
 
   useEffect(() => {
@@ -62,34 +58,14 @@ const ClockPanel = ({ locale, offlineState, healthStatus, lastRefresh }: ClockPa
   const formattedSeconds = useMemo(() => secondsFormatter.format(now), [secondsFormatter, now]);
   const formattedDate = useMemo(() => dateFormatter.format(now), [dateFormatter, now]);
 
-  const offlineLabel = useMemo(() => {
-    if (!offlineState) return 'Sincronizando';
-    if (!offlineState.offline) return 'Conectado';
-    return 'Sin conexión';
-  }, [offlineState]);
-
-  const refreshLabel = useMemo(() => {
-    if (!lastRefresh) return null;
-    return new Intl.DateTimeFormat(localeCode, {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    }).format(new Date(lastRefresh));
-  }, [lastRefresh, localeCode]);
-
   return (
-    <GlassPanel className="justify-between">
+    <GlassPanel className="justify-center">
       <div className="flex flex-col gap-2">
         <div className="text-[112px] font-light leading-none tracking-tight text-white/95">
           <span>{formattedTime}</span>
           <span className="text-[64px] align-top text-white/60">{formattedSeconds}</span>
         </div>
         <div className="text-2xl capitalize text-white/80">{formattedDate}</div>
-      </div>
-      <div className="flex items-center justify-between text-sm text-white/65">
-        <span>{offlineLabel}</span>
-        <span>{healthStatus ?? ''}</span>
-        <span>{refreshLabel ? `Actualizado ${refreshLabel}` : ''}</span>
       </div>
     </GlassPanel>
   );

--- a/dash-ui/src/pages/Display.tsx
+++ b/dash-ui/src/pages/Display.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Background from '../components/Background';
 import ClockPanel from '../components/panels/ClockPanel';
 import WeatherPanel from '../components/panels/WeatherPanel';
@@ -6,7 +6,6 @@ import InfoPanel from '../components/panels/InfoPanel';
 import { useDashboardConfig } from '../context/DashboardConfigContext';
 import { fetchWeatherToday, type WeatherToday } from '../services/weather';
 import { fetchDayBrief, type DayInfoPayload } from '../services/dayinfo';
-import { fetchHealth, fetchOfflineState, type HealthStatus, type OfflineState } from '../services/system';
 
 const REFRESH_INTERVAL_MS = 60_000;
 
@@ -14,12 +13,8 @@ const Display = () => {
   const { config, refresh: refreshConfig } = useDashboardConfig();
   const [weather, setWeather] = useState<WeatherToday | null>(null);
   const [dayInfo, setDayInfo] = useState<DayInfoPayload | null>(null);
-  const [offlineState, setOfflineState] = useState<OfflineState | null>(null);
-  const [health, setHealth] = useState<HealthStatus | null>(null);
-  const [lastRefresh, setLastRefresh] = useState<number | null>(null);
-
   const load = useCallback(async () => {
-    const [weatherData, dayInfoData, offlineData, healthData] = await Promise.all([
+    const [weatherData, dayInfoData] = await Promise.all([
       fetchWeatherToday().catch((error) => {
         console.warn('No se pudo cargar el clima', error);
         return null;
@@ -28,21 +23,10 @@ const Display = () => {
         console.warn('No se pudo cargar la información del día', error);
         return null;
       }),
-      fetchOfflineState().catch((error) => {
-        console.warn('No se pudo cargar el estado offline', error);
-        return null;
-      }),
-      fetchHealth().catch((error) => {
-        console.warn('No se pudo cargar healthcheck', error);
-        return null;
-      }),
     ]);
 
     if (weatherData) setWeather(weatherData);
     if (dayInfoData) setDayInfo(dayInfoData);
-    if (offlineData) setOfflineState(offlineData);
-    if (healthData) setHealth(healthData);
-    setLastRefresh(Date.now());
 
     try {
       await refreshConfig();
@@ -59,25 +43,12 @@ const Display = () => {
     return () => window.clearInterval(interval);
   }, [load]);
 
-  const healthLabel = useMemo(() => {
-    if (!health) return '';
-    if (health.status?.toLowerCase() === 'ok') {
-      return 'Sistema estable';
-    }
-    return `Estado: ${health.status}`;
-  }, [health]);
-
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-black text-white">
       <Background refreshMinutes={config?.background?.intervalMinutes ?? 60} />
       <div className="relative z-10 flex h-full w-full items-center justify-center px-12 py-8">
         <div className="grid h-full w-full max-w-[1840px] grid-cols-3 gap-8">
-          <ClockPanel
-            locale={config?.locale}
-            offlineState={offlineState}
-            healthStatus={healthLabel}
-            lastRefresh={lastRefresh ?? undefined}
-          />
+          <ClockPanel locale={config?.locale} />
           <WeatherPanel weather={weather} />
           <InfoPanel dayInfo={dayInfo} />
         </div>


### PR DESCRIPTION
## Summary
- remove the status/footer row from the clock panel so only the time and date remain
- simplify the display page by dropping unused status polling and props after the removal
- center the clock content vertically to avoid leftover spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7d585d6e483269b7f76d43e13f5c9