### PR TITLE
Add systemd sync for background generator timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,25 @@ permisos, systemd y endurecimiento.
   }
   ```
 
-- Registra los servicios systemd incluidos en `system/`:
+- Registra los servicios systemd incluidos en `system/` y el script de sincronización:
 
   ```bash
   sudo cp system/pantalla-bg-generate.service /etc/systemd/system/
   sudo cp system/pantalla-bg-generate.timer /etc/systemd/system/
+  sudo cp system/pantalla-bg-sync.service /etc/systemd/system/
+  sudo cp system/pantalla-bg-sync.path /etc/systemd/system/
+  sudo install -Dm755 scripts/pantalla-bg-sync-timer /usr/local/sbin/pantalla-bg-sync-timer
+  sudo mkdir -p /etc/systemd/system/pantalla-bg-generate.timer.d
   sudo cp system/logrotate.d/pantalla-bg /etc/logrotate.d/
   sudo systemctl daemon-reload
   sudo systemctl enable --now pantalla-bg-generate.timer
+  sudo systemctl enable --now pantalla-bg-sync.path
+  sudo systemctl start pantalla-bg-sync.service
   ```
 
-- El temporizador ejecuta el script cada día a las 07:00, 12:00 y 19:00 (hora local) y guarda
-  las imágenes (`.webp`, 1280x720) en `/opt/dash/assets/backgrounds/auto/`,
+- El temporizador se sincroniza automáticamente con `config.background.intervalMinutes`
+  (con valores válidos entre 1 y 1440 minutos) y guarda las imágenes (`.webp`, 1280x720)
+  en `/opt/dash/assets/backgrounds/auto/`,
   manteniendo las últimas 30 o el número de días configurado. El backend expone
   la última imagen en `/api/backgrounds/current` y la UI actualiza el fondo con
   transición suave.

--- a/docs/DEPLOY_BACKEND.md
+++ b/docs/DEPLOY_BACKEND.md
@@ -91,6 +91,10 @@ sudo install -Dm644 system/pantalla-ap.service /etc/systemd/system/
 sudo install -Dm644 system/pantalla-ap-ensure.service /etc/systemd/system/
 sudo install -Dm644 system/pantalla-bg-generate.service /etc/systemd/system/
 sudo install -Dm644 system/pantalla-bg-generate.timer /etc/systemd/system/
+sudo install -Dm644 system/pantalla-bg-sync.service /etc/systemd/system/
+sudo install -Dm644 system/pantalla-bg-sync.path /etc/systemd/system/
+sudo install -Dm755 scripts/pantalla-bg-sync-timer /usr/local/sbin/pantalla-bg-sync-timer
+sudo mkdir -p /etc/systemd/system/pantalla-bg-generate.timer.d
 ```
 
 Opcional: crea `/etc/pantalla-dash/ap.conf` para fijar interfaz del hotspot:
@@ -106,6 +110,8 @@ sudo systemctl daemon-reload
 sudo systemctl enable --now pantalla-dash-backend.service
 sudo systemctl enable --now pantalla-ap-ensure.service
 sudo systemctl enable --now pantalla-bg-generate.timer
+sudo systemctl enable --now pantalla-bg-sync.path
+sudo systemctl start pantalla-bg-sync.service
 ```
 
 El hotspot quedará disponible como `Pantalla-Setup` cuando no haya Wi-Fi activa.

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -13,6 +13,7 @@ El script **NO borra** datos sensibles por defecto (configs, assets, logs), a me
 - Detiene y **deshabilita** los servicios:
   - `pantalla-dash-backend@<usuario>`
   - `pantalla-bg-generate.service` + `pantalla-bg-generate.timer`
+  - `pantalla-bg-sync.service` + `pantalla-bg-sync.path`
 - Elimina los **unit files** de systemd anteriores (si existen).
 - Elimina el **vhost** de Nginx `pantalla` de `sites-available` y `sites-enabled`.
 - Recarga **systemd** y **Nginx**.
@@ -54,6 +55,8 @@ Después de desinstalar:
 # No debería haber servicios activos
 systemctl status pantalla-bg-generate.service
 systemctl status pantalla-bg-generate.timer
+systemctl status pantalla-bg-sync.service
+systemctl status pantalla-bg-sync.path
 systemctl status "pantalla-dash-backend@$USER"
 
 # Nginx sin el vhost 'pantalla'

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,6 +37,10 @@ XORG_SERVICE_NAME="pantalla-xorg@.service"
 XORG_SERVICE_SRC="$REPO_DIR/system/$XORG_SERVICE_NAME"
 BG_SVC="pantalla-bg-generate.service"
 BG_TIMER="pantalla-bg-generate.timer"
+BG_SYNC_SERVICE="pantalla-bg-sync.service"
+BG_SYNC_PATH="pantalla-bg-sync.path"
+BG_SYNC_SCRIPT_SRC="$REPO_DIR/scripts/pantalla-bg-sync-timer"
+BG_SYNC_SCRIPT_DST="/usr/local/sbin/pantalla-bg-sync-timer"
 
 # ----- Defaults de configuración -----
 TZ_DEFAULT="${TZ_DEFAULT:-Europe/Madrid}"
@@ -599,8 +603,16 @@ Unit=pantalla-bg-generate.service
 WantedBy=timers.target
 TIMER
 
+log "Configurando sincronización automática del timer de fondos IA…"
+install -Dm755 "$BG_SYNC_SCRIPT_SRC" "$BG_SYNC_SCRIPT_DST"
+install -Dm644 "$REPO_DIR/system/$BG_SYNC_SERVICE" "$SYSTEMD_DIR/$BG_SYNC_SERVICE"
+install -Dm644 "$REPO_DIR/system/$BG_SYNC_PATH" "$SYSTEMD_DIR/$BG_SYNC_PATH"
+mkdir -p "$SYSTEMD_DIR/${BG_TIMER}.d"
+
 systemctl daemon-reload
 systemctl enable --now "$BG_TIMER"
+systemctl enable --now "$BG_SYNC_PATH"
+systemctl start "$BG_SYNC_SERVICE"
 
 # ----- Reinicia backend para cargar endpoints nuevos (config/Wi-Fi si los añadiste) -----
 systemctl restart "${BACKEND_SVC_BASENAME}@$APP_USER" || true

--- a/scripts/pantalla-bg-sync-timer
+++ b/scripts/pantalla-bg-sync-timer
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Synchronize pantalla-bg-generate timer interval with config.json."""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+CONFIG_PATH = Path("/etc/pantalla-dash/config.json")
+TIMER_OVERRIDE_DIR = Path("/etc/systemd/system/pantalla-bg-generate.timer.d")
+TIMER_OVERRIDE_FILE = TIMER_OVERRIDE_DIR / "override.conf"
+TIMER_UNIT = "pantalla-bg-generate.timer"
+SERVICE_UNIT = "pantalla-bg-generate.service"
+DEFAULT_INTERVAL_MIN = 60
+MIN_INTERVAL_MIN = 1
+MAX_INTERVAL_MIN = 1440
+
+
+class SyncError(Exception):
+    """Raised when synchronization fails."""
+
+
+def _load_interval() -> int:
+    """Return sanitized interval in minutes from config.json."""
+    interval = DEFAULT_INTERVAL_MIN
+    try:
+        raw = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        data = raw
+        if isinstance(raw, dict) and "config" in raw and isinstance(raw["config"], dict):
+            data = raw["config"]
+        if isinstance(data, dict) and "background" in data and isinstance(data["background"], dict):
+            candidate = data["background"].get("intervalMinutes")
+        else:
+            candidate = None
+        if candidate is not None:
+            if isinstance(candidate, (int, float)):
+                interval = int(candidate)
+            elif isinstance(candidate, str) and candidate.strip():
+                interval = int(float(candidate.strip()))
+    except FileNotFoundError:
+        pass
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        raise SyncError(f"Config inválido: {exc}") from exc
+
+    interval = max(MIN_INTERVAL_MIN, min(MAX_INTERVAL_MIN, interval))
+    if interval <= 0:
+        interval = DEFAULT_INTERVAL_MIN
+    return interval
+
+
+def _write_override(interval: int) -> None:
+    TIMER_OVERRIDE_DIR.mkdir(parents=True, exist_ok=True)
+    content = """[Unit]
+Description=Timer fondos IA (override desde config.json)
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec={interval}min
+AccuracySec=10s
+RandomizedDelaySec=0
+OnCalendar=
+Unit={service}
+""".format(interval=interval, service=SERVICE_UNIT)
+    TIMER_OVERRIDE_FILE.write_text(content, encoding="utf-8")
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def _run_no_check(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, check=False, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def main() -> int:
+    try:
+        interval = _load_interval()
+    except SyncError as exc:
+        print(f"[pantalla-bg-sync] Aviso: {exc}. Usando {DEFAULT_INTERVAL_MIN} min.")
+        interval = DEFAULT_INTERVAL_MIN
+
+    _write_override(interval)
+
+    for cmd in (
+        ["systemctl", "daemon-reload"],
+        ["systemctl", "enable", "--now", TIMER_UNIT],
+        ["systemctl", "restart", TIMER_UNIT],
+    ):
+        try:
+            result = _run(cmd)
+            output = "\n".join(
+                part.strip()
+                for part in (result.stdout, result.stderr)
+                if part and part.strip()
+            )
+            if output:
+                print(output)
+        except subprocess.CalledProcessError as exc:
+            print(exc.stderr.strip())
+            return exc.returncode
+
+    print(f"Intervalo aplicado: {interval} minutos")
+
+    timers = _run_no_check(["systemctl", "list-timers", "--no-legend", "--all"]).stdout.splitlines()
+    match = next((line for line in timers if TIMER_UNIT in line), "")
+    if match:
+        print(match)
+    else:
+        print(f"No se encontró {TIMER_UNIT} en systemctl list-timers")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -27,6 +27,10 @@ BACKEND_SVC_BASENAME="pantalla-dash-backend"
 BACKEND_SVC_TEMPLATE="$SYSTEMD_DIR/${BACKEND_SVC_BASENAME}@.service"
 BG_SVC_FILE="$SYSTEMD_DIR/pantalla-bg-generate.service"
 BG_TIMER_FILE="$SYSTEMD_DIR/pantalla-bg-generate.timer"
+BG_TIMER_OVERRIDE_DIR="$SYSTEMD_DIR/pantalla-bg-generate.timer.d"
+BG_SYNC_SERVICE_FILE="$SYSTEMD_DIR/pantalla-bg-sync.service"
+BG_SYNC_PATH_FILE="$SYSTEMD_DIR/pantalla-bg-sync.path"
+BG_SYNC_SCRIPT="/usr/local/sbin/pantalla-bg-sync-timer"
 
 NGINX_SITE_AV="/etc/nginx/sites-available/pantalla"
 NGINX_SITE_EN="/etc/nginx/sites-enabled/pantalla"
@@ -92,6 +96,10 @@ systemctl stop pantalla-bg-generate.service 2>/dev/null || true
 systemctl disable pantalla-bg-generate.service 2>/dev/null || true
 systemctl stop pantalla-bg-generate.timer 2>/dev/null || true
 systemctl disable pantalla-bg-generate.timer 2>/dev/null || true
+systemctl stop pantalla-bg-sync.service 2>/dev/null || true
+systemctl disable pantalla-bg-sync.service 2>/dev/null || true
+systemctl stop pantalla-bg-sync.path 2>/dev/null || true
+systemctl disable pantalla-bg-sync.path 2>/dev/null || true
 
 # Backend (templated por usuario)
 systemctl stop "${BACKEND_SVC_BASENAME}@$APP_USER" 2>/dev/null || true
@@ -119,7 +127,9 @@ if [[ -f "$SYSTEMD_DIR/$KIOSK_SERVICE" ]]; then
 fi
 
 log "Eliminando unit files systemd…"
-rm -f "$BG_SVC_FILE" "$BG_TIMER_FILE"
+rm -f "$BG_SVC_FILE" "$BG_TIMER_FILE" "$BG_SYNC_SERVICE_FILE" "$BG_SYNC_PATH_FILE"
+rm -rf "$BG_TIMER_OVERRIDE_DIR"
+rm -f "$BG_SYNC_SCRIPT"
 rm -f "$BACKEND_SVC_TEMPLATE"
 rm -f "$SYSTEMD_DIR/$KIOSK_SERVICE" 2>/dev/null || true
 rm -f "$USER_SYSTEMD_DIR/$UI_SERVICE_NAME" 2>/dev/null || true

--- a/system/pantalla-bg-sync.path
+++ b/system/pantalla-bg-sync.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Vigila cambios en /etc/pantalla-dash/config.json y re-sincroniza timer
+
+[Path]
+PathChanged=/etc/pantalla-dash/config.json
+Unit=pantalla-bg-sync.service
+
+[Install]
+WantedBy=multi-user.target

--- a/system/pantalla-bg-sync.service
+++ b/system/pantalla-bg-sync.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Sincroniza timer de fondos IA con intervalMinutes
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/pantalla-bg-sync-timer


### PR DESCRIPTION
## Summary
- add a pantalla-bg-sync timer script that reads the configured interval and rewrites the systemd drop-in override
- introduce accompanying systemd service/path units plus installer hooks for automatic synchronization
- refresh documentation to reflect the new background timer behaviour and management commands

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68f83ee7f1248326b938cd6677ff3c41