### PR TITLE
Add support for local ICS calendar uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ Desde la UI puedes:
 - Gestionar Wi-Fi (escanear, conectar, olvidar y ver estado).
 - Seleccionar voz local y volumen TTS, lanzar prueba de voz.
 - Ajustar intervalo, modo y retención de fondos AI junto al tema (sincronizado con backend).
+- Activar el calendario y elegir si se carga desde una URL ICS o desde un archivo local `.ics`.
+
+### Calendario (URL o archivo .ics)
+
+- Desde `/#/config` selecciona la pestaña **URL ICS** para pegar la dirección remota o **Archivo .ics** para subir un fichero local.
+- Al subir un archivo se envía una petición `POST /api/calendar/upload` (multipart) con validación de tamaño ≤5 MB, extensión `.ics`/`text/calendar` y contenido mínimo (`BEGIN:VCALENDAR`…`END:VCALENDAR`).
+- El backend guarda el archivo en `/etc/pantalla-dash/calendar/calendar.ics` (permisos `0644`, directorio `0755`) y actualiza `config.calendar` con `mode="ics"` y la ruta persistida.
+- Puedes descargar el archivo almacenado con `GET /api/calendar/download` o eliminarlo vía `DELETE /api/calendar/file` (se renombra a `.bak` con sello temporal y se vuelve al modo URL si existe una dirección configurada).
+- `GET /api/calendar/status` devuelve `{ mode, url, icsPath, exists, size, mtime }` para sincronizar la UI y mostrar la fecha/tamaño de la última carga.
+- Todos los eventos se registran en `/var/log/pantalla-dash/calendar.log` para auditar subidas, eliminaciones y errores.
 
 ## Backend (FastAPI)
 

--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -31,7 +31,9 @@
   },
   "calendar": {
     "enabled": false,
-    "icsUrl": "https://calendar.google.com/calendar/ical/tu_id_privado/basic.ics",
+    "mode": "url",
+    "url": "https://calendar.google.com/calendar/ical/tu_id_privado/basic.ics",
+    "icsPath": "/etc/pantalla-dash/calendar/calendar.ics",
     "maxEvents": 3,
     "notifyMinutesBefore": 15
   },

--- a/backend/config/config.json
+++ b/backend/config/config.json
@@ -31,7 +31,9 @@
   },
   "calendar": {
     "enabled": false,
-    "icsUrl": "https://calendar.google.com/calendar/ical/tu_id_privado/basic.ics",
+    "mode": "url",
+    "url": "https://calendar.google.com/calendar/ical/tu_id_privado/basic.ics",
+    "icsPath": "/etc/pantalla-dash/calendar/calendar.ics",
     "maxEvents": 3,
     "notifyMinutesBefore": 15
   },

--- a/dash-ui/src/components/CalendarPeek.tsx
+++ b/dash-ui/src/components/CalendarPeek.tsx
@@ -12,7 +12,14 @@ const CalendarPeek = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const enabled = Boolean(calendarPrefs?.enabled && calendarPrefs?.icsConfigured);
+  const hasSource = calendarPrefs
+    ? calendarPrefs.mode === 'ics'
+      ? Boolean(calendarPrefs.icsPath || calendarPrefs.icsConfigured)
+      : calendarPrefs.mode === 'url'
+      ? Boolean(calendarPrefs.url)
+      : Boolean(calendarPrefs.url || calendarPrefs.icsPath || calendarPrefs.icsConfigured)
+    : false;
+  const enabled = Boolean(calendarPrefs?.enabled && hasSource);
 
   useEffect(() => {
     if (!enabled) {

--- a/dash-ui/src/services/calendar.ts
+++ b/dash-ui/src/services/calendar.ts
@@ -1,4 +1,4 @@
-import { apiRequest } from './config';
+import { API_BASE_URL, apiRequest } from './config';
 
 export interface CalendarEvent {
   title: string;
@@ -8,6 +8,90 @@ export interface CalendarEvent {
   notify: boolean;
 }
 
+export interface CalendarStatus {
+  mode: 'url' | 'ics';
+  url?: string | null;
+  icsPath?: string | null;
+  exists: boolean;
+  size?: number | null;
+  mtime?: string | null;
+}
+
+export interface CalendarOperationResponse extends CalendarStatus {
+  ok: boolean;
+  message?: string;
+}
+
 export async function fetchTodayEvents(): Promise<CalendarEvent[]> {
   return await apiRequest<CalendarEvent[]>('/calendar/today');
+}
+
+export async function fetchCalendarStatus(): Promise<CalendarStatus> {
+  return await apiRequest<CalendarStatus>('/calendar/status');
+}
+
+export async function deleteCalendarFile(): Promise<CalendarOperationResponse> {
+  return await apiRequest<CalendarOperationResponse>('/calendar/file', {
+    method: 'DELETE',
+  });
+}
+
+export function uploadCalendarFile(
+  file: File,
+  onProgress?: (percent: number) => void,
+): Promise<CalendarOperationResponse> {
+  return new Promise((resolve, reject) => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', `${API_BASE_URL}/calendar/upload`);
+    xhr.responseType = 'json';
+    xhr.timeout = 60_000;
+
+    xhr.upload.onprogress = (event) => {
+      if (!onProgress) return;
+      if (event.lengthComputable && event.total > 0) {
+        onProgress((event.loaded / event.total) * 100);
+      } else if (file.size > 0) {
+        onProgress((event.loaded / file.size) * 100);
+      }
+    };
+
+    xhr.onload = () => {
+      const payload = parseXhrJson(xhr);
+      if (xhr.status >= 200 && xhr.status < 300) {
+        if (onProgress) onProgress(100);
+        resolve(payload as CalendarOperationResponse);
+        return;
+      }
+      const message =
+        (payload && (payload.detail || payload.message)) || `Error ${xhr.status}`;
+      reject(new Error(typeof message === 'string' ? message : `Error ${xhr.status}`));
+    };
+
+    xhr.onerror = () => {
+      reject(new Error('Error de red al subir el archivo .ics'));
+    };
+
+    xhr.ontimeout = () => {
+      reject(new Error('Tiempo de espera agotado al subir el archivo .ics'));
+    };
+
+    xhr.send(formData);
+  });
+}
+
+function parseXhrJson(xhr: XMLHttpRequest): any {
+  if (xhr.responseType === 'json' && xhr.response !== null) {
+    return xhr.response;
+  }
+  const text = xhr.responseText;
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    console.warn('Respuesta JSON no válida en subida de calendario', error);
+    return null;
+  }
 }

--- a/dash-ui/src/services/config.ts
+++ b/dash-ui/src/services/config.ts
@@ -38,7 +38,9 @@ export interface WifiConfig {
 
 export interface CalendarConfig {
   enabled?: boolean;
-  icsUrl?: string | null;
+  mode?: 'url' | 'ics';
+  url?: string | null;
+  icsPath?: string | null;
   maxEvents?: number;
   notifyMinutesBefore?: number;
   icsConfigured?: boolean;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -320,6 +320,11 @@ log "Creando grupos/rutas y permisos…"
 groupadd -f pantalla
 install -d -m 2770 -o root -g pantalla "$ENV_DIR"
 mkdir -p "$ASSETS_DIR" "$LOG_DIR" /opt/dash/assets
+install -d -m 755 -o root -g root "$ENV_DIR/calendar"
+chmod 755 "$LOG_DIR"
+touch "$LOG_DIR/calendar.log"
+chown root:root "$LOG_DIR/calendar.log"
+chmod 644 "$LOG_DIR/calendar.log"
 chown -R "$APP_USER:$APP_USER" /opt/dash
 chmod 755 /opt/dash /opt/dash/assets
 touch "$LOG_DIR/bg.log"


### PR DESCRIPTION
## Summary
- add FastAPI endpoints to upload, download, delete and report status for the calendar ICS file while updating configuration storage
- adjust installer scripts, config schema and documentation to handle calendar modes and persistent file paths
- refresh the configuration UI with URL/file tabs, drag-and-drop upload, progress feedback and updated calendar status handling

## Testing
- npm run build
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68f840a826648326ae8acc33defc94ff