### PR TITLE
Address review feedback: avoid sending ui section in config patch

### DIFF
--- a/dash-ui/src/pages/Config.tsx
+++ b/dash-ui/src/pages/Config.tsx
@@ -435,11 +435,6 @@ const Config = () => {
     return Number.isNaN(parsed) ? undefined : parsed;
   };
 
-  const clampNumber = (value: number | undefined, min: number, max: number) => {
-    if (typeof value !== 'number') return undefined;
-    return Math.min(Math.max(value, min), max);
-  };
-
   const handleSaveConfig = async () => {
     setSavingConfig(true);
     setNotice(null);
@@ -466,32 +461,6 @@ const Config = () => {
         intervalMinutes: parseInteger(form.backgroundIntervalMinutes),
         retainDays: parseInteger(form.backgroundRetainDays),
       },
-    };
-
-    const rotatingInterval = clampNumber(
-      parseInteger(form.rotatingPanelIntervalSeconds),
-      4,
-      30,
-    );
-    const rotatingSections: RotatingPanelSectionKey[] = [];
-    if (form.rotatingPanelSections.weather) rotatingSections.push('weather');
-    if (form.rotatingPanelSections.calendar) rotatingSections.push('calendar');
-    if (form.rotatingPanelSections.season) rotatingSections.push('season');
-
-    const rotatingPanelPatch: {
-      enabled: boolean;
-      sections: RotatingPanelSectionKey[];
-      intervalSeconds?: number;
-    } = {
-      enabled: form.rotatingPanelEnabled,
-      sections: rotatingSections,
-    };
-    if (typeof rotatingInterval === 'number') {
-      rotatingPanelPatch.intervalSeconds = rotatingInterval;
-    }
-
-    patch.ui = {
-      rotatingPanel: rotatingPanelPatch,
     };
 
     try {


### PR DESCRIPTION
## Summary
- add a rotating information panel beneath the clock that cycles weather, calendar, and seasonal data with smooth transitions
- implement a season month data hook with 24-hour caching and integrate panel settings into the dashboard configuration
- expose UI controls for enabling the panel, choosing sections, and adjusting the rotation interval
- avoid including the unsupported `ui.rotatingPanel` block in config updates so saves are accepted by the backend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f84d3a1a2483269239e67ddcf6c6fd