### PR TITLE
Refactor storms radar service to cache AEMET GIF data

### DIFF
--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -8,7 +8,8 @@
   },
   "storm": {
     "threshold": 0.6,
-    "enableExperimentalLightning": false
+    "enableExperimentalLightning": false,
+    "radarCacheSeconds": 180
   },
   "weather": {
     "units": "metric",

--- a/backend/services/config.py
+++ b/backend/services/config.py
@@ -45,6 +45,7 @@ class WeatherConfig(BaseModel):
 class StormConfig(BaseModel):
     threshold: float = Field(default=0.6, ge=0.0, le=1.0)
     enableExperimentalLightning: bool = Field(default=False, alias="enableExperimentalLightning")
+    radarCacheSeconds: int = Field(default=180, ge=60, le=3600, alias="radarCacheSeconds")
 
     class Config:
         allow_population_by_field_name = True


### PR DESCRIPTION
## Summary
- fetch the AEMET radar descriptor and download binary GIF data into a short-lived local cache
- serve the cached radar GIF for both /api/storms/radar endpoints with the original content-type and propagate the latest radar_url in storm status
- add the radarCacheSeconds knob to the storm config model and example config

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68f84b6e2aa083269782638536ad7690