### PR TITLE
Implement rotating panel sections for calendar, season, weekly forecast and lunar phase

### DIFF
--- a/dash-ui/src/components/RotatingInfoPanel.tsx
+++ b/dash-ui/src/components/RotatingInfoPanel.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useSeasonMonth } from '../hooks/useSeasonMonth';
-import type { WeatherToday } from '../services/weather';
-import type { DayInfoPayload } from '../services/dayinfo';
 import type { RotatingPanelSectionKey } from '../services/config';
+import { useSeasonMonth } from '../hooks/useSeasonMonth';
+import { useCalendarSummary } from '../hooks/useCalendarSummary';
+import { useWeeklyForecast } from '../hooks/useWeeklyForecast';
+import { useLunarPhase } from '../hooks/useLunarPhase';
 
 interface RotatingInfoPanelProps {
   sections: RotatingPanelSectionKey[];
   intervalMs?: number;
   height?: number;
-  weather?: WeatherToday | null;
-  dayInfo?: DayInfoPayload | null;
 }
 
 interface PanelItem {
@@ -21,13 +20,12 @@ interface PanelItem {
 const DEFAULT_INTERVAL_MS = 7000;
 const MIN_INTERVAL_MS = 4000;
 const DEFAULT_HEIGHT = 128;
-const MAX_WEATHER_TEXT = 180;
-const MAX_CALENDAR_TEXT = 200;
 
 const LABELS: Record<RotatingPanelSectionKey, string> = {
-  weather: 'Clima',
   calendar: 'Calendario',
   season: 'Temporada',
+  weekly: 'Previsión semanal',
+  lunar: 'Fase lunar',
 };
 
 function sanitizeSections(sections: RotatingPanelSectionKey[]): RotatingPanelSectionKey[] {
@@ -35,7 +33,7 @@ function sanitizeSections(sections: RotatingPanelSectionKey[]): RotatingPanelSec
   const seen = new Set<RotatingPanelSectionKey>();
   const valid: RotatingPanelSectionKey[] = [];
   for (const section of sections) {
-    if (!seen.has(section)) {
+    if (LABELS[section] && !seen.has(section)) {
       seen.add(section);
       valid.push(section);
     }
@@ -43,86 +41,55 @@ function sanitizeSections(sections: RotatingPanelSectionKey[]): RotatingPanelSec
   return valid;
 }
 
-function truncate(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text;
-  if (maxLength <= 1) return '…';
-  const slice = text.slice(0, maxLength - 1);
-  const lastSeparator = Math.max(slice.lastIndexOf(' · '), slice.lastIndexOf(', '), slice.lastIndexOf(' '));
-  const safeSlice = lastSeparator > 20 ? slice.slice(0, lastSeparator) : slice;
-  return `${safeSlice.replace(/[·,\s]+$/u, '')}…`;
-}
-
-function formatWeather(weather: WeatherToday): string {
-  const parts: string[] = [];
-  if (weather.city) parts.push(weather.city);
-  if (weather.condition) parts.push(weather.condition);
-  parts.push(`${Math.round(weather.temp)}°`);
-  parts.push(`↓${Math.round(weather.min)}° ↑${Math.round(weather.max)}°`);
-  parts.push(`Lluvia ${Math.round(weather.rainProb)}%`);
-  return truncate(parts.join(' · '), MAX_WEATHER_TEXT);
-}
-
-function formatCalendar(dayInfo: DayInfoPayload): string {
-  const efemeride = dayInfo.efemerides?.[0]?.text?.trim();
-  const santoral = dayInfo.santoral
-    ?.map((item) => item.name?.trim())
-    .filter((name): name is string => Boolean(name && name.length > 0))
-    .join(', ');
-  const holiday = dayInfo.holiday?.is_holiday ? dayInfo.holiday?.name?.trim() : null;
-  const patronName = dayInfo.patron?.name?.trim();
-  const patronPlace = dayInfo.patron?.place?.trim();
-  const patron = patronName ? (patronPlace ? `${patronName} (${patronPlace})` : patronName) : null;
-
-  const segments: string[] = [];
-  if (efemeride) segments.push(efemeride);
-  if (santoral) segments.push(`Santoral: ${santoral}`);
-  if (holiday) segments.push(`Festivo: ${holiday}`);
-  if (patron) segments.push(`Patrón: ${patron}`);
-
-  if (segments.length === 0) {
-    return 'Sin información destacada hoy';
-  }
-
-  return truncate(segments.join(' · '), MAX_CALENDAR_TEXT);
-}
-
 const RotatingInfoPanel = ({
   sections,
   intervalMs = DEFAULT_INTERVAL_MS,
   height = DEFAULT_HEIGHT,
-  weather,
-  dayInfo,
 }: RotatingInfoPanelProps) => {
-  const { formatted: seasonLine, loading: seasonLoading } = useSeasonMonth();
-
   const normalizedSections = useMemo(() => sanitizeSections(sections), [sections]);
   const effectiveInterval = Math.max(intervalMs, MIN_INTERVAL_MS);
+  const panelHeight = Math.max(96, height ?? DEFAULT_HEIGHT);
+
+  const { formatted: seasonLine, loading: seasonLoading } = useSeasonMonth();
+  const calendar = useCalendarSummary();
+  const weekly = useWeeklyForecast();
+  const lunar = useLunarPhase();
 
   const items = useMemo<PanelItem[]>(() => {
-    const collection: PanelItem[] = [];
-    normalizedSections.forEach((section) => {
-      if (section === 'weather') {
-        if (!weather) {
-          collection.push({ key: section, text: 'Cargando…', placeholder: true });
-        } else {
-          collection.push({ key: section, text: formatWeather(weather), placeholder: false });
-        }
-      } else if (section === 'calendar') {
-        if (!dayInfo) {
-          collection.push({ key: section, text: 'Cargando…', placeholder: true });
-        } else {
-          collection.push({ key: section, text: formatCalendar(dayInfo), placeholder: false });
-        }
-      } else if (section === 'season') {
-        if (seasonLoading) {
-          collection.push({ key: section, text: 'Cargando…', placeholder: true });
-        } else if (seasonLine) {
-          collection.push({ key: section, text: seasonLine, placeholder: false });
-        }
+    return normalizedSections.map((section) => {
+      if (section === 'season') {
+        const loading = seasonLoading && !seasonLine;
+        return {
+          key: section,
+          text: loading ? 'Cargando…' : seasonLine ?? 'Temporada no disponible',
+          placeholder: loading,
+        };
       }
+      if (section === 'calendar') {
+        const loading = calendar.loading && !calendar.text;
+        return {
+          key: section,
+          text: loading ? 'Cargando…' : calendar.text ?? 'Sin datos',
+          placeholder: loading,
+        };
+      }
+      if (section === 'weekly') {
+        const loading = weekly.loading && !weekly.text;
+        return {
+          key: section,
+          text: loading ? 'Cargando…' : weekly.text ?? 'Previsión no disponible',
+          placeholder: loading,
+        };
+      }
+      // section === 'lunar'
+      const loading = lunar.loading && !lunar.text;
+      return {
+        key: section,
+        text: loading ? 'Cargando…' : lunar.text ?? 'Fase lunar no disponible',
+        placeholder: loading,
+      };
     });
-    return collection;
-  }, [dayInfo, normalizedSections, seasonLine, seasonLoading, weather]);
+  }, [calendar.loading, calendar.text, lunar.loading, lunar.text, normalizedSections, seasonLine, seasonLoading, weekly.loading, weekly.text]);
 
   const [activeIndex, setActiveIndex] = useState(0);
 
@@ -148,8 +115,6 @@ const RotatingInfoPanel = ({
     return null;
   }
 
-  const panelHeight = Math.max(96, height ?? DEFAULT_HEIGHT);
-
   return (
     <div
       className="relative w-full overflow-hidden rounded-[24px] border border-white/15 bg-[rgba(20,20,20,0.45)] px-6 py-3 text-white shadow-[0_14px_32px_rgba(0,0,0,0.32)] backdrop-blur-lg backdrop-brightness-[0.88]"
@@ -158,21 +123,19 @@ const RotatingInfoPanel = ({
       {items.map((item, index) => (
         <div
           key={`${item.key}-${index}`}
-          className={`absolute inset-0 flex items-center gap-4 transition-all duration-700 ease-in-out ${
-            index === activeIndex
-              ? 'pointer-events-auto opacity-100 translate-y-0'
-              : 'pointer-events-none opacity-0 translate-y-3'
+          className={`absolute inset-0 flex items-center gap-4 transition-opacity duration-600 ease-in-out ${
+            index === activeIndex ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
           }`}
         >
           <span className="rounded-full bg-white/10 px-4 py-1 text-xs uppercase tracking-[0.3em] text-white/65">
             {LABELS[item.key]}
           </span>
           <span
-            className={`block flex-1 truncate text-[24px] font-medium leading-snug ${
+            className={`block flex-1 overflow-hidden text-[24px] font-medium leading-snug ${
               item.placeholder ? 'text-white/60' : 'text-white/90'
             }`}
           >
-            {item.text}
+            <span className="block overflow-hidden text-ellipsis whitespace-nowrap">{item.text}</span>
           </span>
         </div>
       ))}

--- a/dash-ui/src/components/panels/ClockPanel.tsx
+++ b/dash-ui/src/components/panels/ClockPanel.tsx
@@ -2,13 +2,9 @@ import { useEffect, useMemo, useState } from 'react';
 import GlassPanel from '../GlassPanel';
 import RotatingInfoPanel from '../RotatingInfoPanel';
 import type { LocaleConfig, RotatingPanelSectionKey } from '../../services/config';
-import type { WeatherToday } from '../../services/weather';
-import type { DayInfoPayload } from '../../services/dayinfo';
 
 interface ClockPanelProps {
   locale?: LocaleConfig;
-  weather?: WeatherToday | null;
-  dayInfo?: DayInfoPayload | null;
   rotatingPanel?: {
     enabled: boolean;
     sections: RotatingPanelSectionKey[];
@@ -17,7 +13,7 @@ interface ClockPanelProps {
   };
 }
 
-const ClockPanel = ({ locale, weather, dayInfo, rotatingPanel }: ClockPanelProps) => {
+const ClockPanel = ({ locale, rotatingPanel }: ClockPanelProps) => {
   const [now, setNow] = useState(() => new Date());
 
   useEffect(() => {
@@ -89,8 +85,6 @@ const ClockPanel = ({ locale, weather, dayInfo, rotatingPanel }: ClockPanelProps
           sections={activeRotatingPanel.sections}
           intervalMs={activeRotatingPanel.intervalMs}
           height={activeRotatingPanel.height}
-          weather={weather}
-          dayInfo={dayInfo}
         />
       ) : null}
     </GlassPanel>

--- a/dash-ui/src/hooks/useCalendarSummary.ts
+++ b/dash-ui/src/hooks/useCalendarSummary.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { fetchCalendarStatus, fetchTodayEvents, type CalendarStatus, type CalendarEvent } from '../services/calendar';
+import { useDashboardConfig } from '../context/DashboardConfigContext';
+import type { CalendarConfig } from '../services/config';
+
+interface CalendarSummaryResult {
+  text: string | null;
+  loading: boolean;
+}
+
+const REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+export const useCalendarSummary = (): CalendarSummaryResult => {
+  const { config } = useDashboardConfig();
+  const calendarPrefs = config?.calendar;
+  const [text, setText] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const isMountedRef = useRef(true);
+  const textRef = useRef<string | null>(null);
+
+  useEffect(() => () => {
+    isMountedRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    textRef.current = text;
+  }, [text]);
+
+  const load = useCallback(async () => {
+    if (!isMountedRef.current) return;
+    setLoading((previous) => (textRef.current ? previous : true));
+
+    try {
+      const status = await fetchCalendarStatus();
+      const readiness = resolveCalendarReadiness(calendarPrefs, status);
+
+      if (readiness !== 'ready') {
+        if (!isMountedRef.current) return;
+        setText('Sin datos');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const events = await fetchTodayEvents();
+        if (!isMountedRef.current) return;
+        if (!events || events.length === 0) {
+          setText('Sin eventos');
+        } else {
+          setText(formatCalendarLine(events));
+        }
+      } catch (eventsError) {
+        console.warn('No se pudo cargar eventos del calendario', eventsError);
+        if (!isMountedRef.current) return;
+        setText('Sin datos');
+      }
+    } catch (statusError) {
+      console.warn('No se pudo cargar estado del calendario', statusError);
+      if (!isMountedRef.current) return;
+      setText('Sin datos');
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [calendarPrefs]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const trigger = () => {
+      if (cancelled) return;
+      void load();
+    };
+
+    trigger();
+    const timer = window.setInterval(trigger, REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [load]);
+
+  const memoizedText = useMemo(() => text, [text]);
+
+  return {
+    text: memoizedText,
+    loading,
+  };
+};
+
+type Readiness = 'no-source' | 'ready';
+
+function resolveCalendarReadiness(
+  calendarPrefs: CalendarConfig | undefined,
+  status: CalendarStatus,
+): Readiness {
+  const enabled = Boolean(calendarPrefs?.enabled);
+  if (!enabled) {
+    return 'no-source';
+  }
+
+  const mode = (calendarPrefs?.mode || status?.mode || 'url').toLowerCase();
+  if (mode === 'url') {
+    const hasUrl = Boolean(calendarPrefs?.url || status?.url);
+    return hasUrl ? 'ready' : 'no-source';
+  }
+  if (mode === 'ics') {
+    const hasFile = Boolean(status?.exists || calendarPrefs?.icsConfigured || calendarPrefs?.icsPath);
+    return hasFile ? 'ready' : 'no-source';
+  }
+
+  return 'no-source';
+}
+
+function formatCalendarLine(events: CalendarEvent[]): string {
+  const safeEvents = events.filter((event) => event && typeof event.title === 'string');
+  if (safeEvents.length === 0) {
+    return 'Sin eventos';
+  }
+
+  const segments = safeEvents.slice(0, 3).map(formatCalendarEvent);
+  if (safeEvents.length > 3) {
+    segments.push(`+${safeEvents.length - 3}`);
+  }
+  return segments.join(' · ');
+}
+
+function formatCalendarEvent(event: CalendarEvent): string {
+  const title = event.title?.trim() || 'Evento';
+  if (event.allDay) {
+    return `${title} (todo el día)`;
+  }
+
+  const start = safeDate(event.start);
+  const end = safeDate(event.end);
+  const startLabel = start ? formatTime(start) : null;
+  const endLabel = end ? formatTime(end) : null;
+
+  if (startLabel && endLabel) {
+    return `${startLabel}-${endLabel} ${title}`;
+  }
+  if (startLabel) {
+    return `${startLabel} ${title}`;
+  }
+  return title;
+}
+
+function safeDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function formatTime(date: Date): string {
+  return date.toLocaleTimeString('es-ES', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+

--- a/dash-ui/src/hooks/useDayBrief.ts
+++ b/dash-ui/src/hooks/useDayBrief.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchDayBrief, type DayInfoPayload } from '../services/dayinfo';
+
+interface DayBriefCacheRecord {
+  data: DayInfoPayload | null;
+  timestamp: number | null;
+  date: string | null;
+}
+
+interface UseDayBriefResult {
+  data: DayInfoPayload | null;
+  loading: boolean;
+  error: boolean;
+  refresh: () => Promise<void>;
+}
+
+const CACHE_KEY = 'dayBriefCache_v1';
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 horas
+const ERROR_RETRY_MS = 60 * 60 * 1000; // 1 hora
+
+let memoryCache: DayBriefCacheRecord = { data: null, timestamp: null, date: null };
+let cacheHydrated = false;
+let inflightRequest: Promise<DayInfoPayload> | null = null;
+
+function todayKey(): string {
+  const now = new Date();
+  const local = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  return local.toISOString().slice(0, 10);
+}
+
+function readCacheFromStorage(): DayBriefCacheRecord | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<DayBriefCacheRecord>;
+    if (!parsed) return null;
+    const record: DayBriefCacheRecord = {
+      data: (parsed.data as DayInfoPayload) ?? null,
+      timestamp: typeof parsed.timestamp === 'number' ? parsed.timestamp : null,
+      date: typeof parsed.date === 'string' ? parsed.date : null,
+    };
+    return record;
+  } catch (error) {
+    console.warn('No se pudo leer caché de day brief', error);
+    return null;
+  }
+}
+
+function persistCache(record: DayBriefCacheRecord): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (!record.timestamp) {
+      window.localStorage.removeItem(CACHE_KEY);
+      return;
+    }
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify(record));
+  } catch (error) {
+    console.warn('No se pudo persistir caché de day brief', error);
+  }
+}
+
+function hydrateCache(): DayBriefCacheRecord {
+  if (!cacheHydrated) {
+    const stored = readCacheFromStorage();
+    if (stored) {
+      memoryCache = stored;
+    }
+    cacheHydrated = true;
+  }
+  return memoryCache;
+}
+
+function updateCache(data: DayInfoPayload | null, timestamp: number | null): void {
+  const dateValue = data?.date && typeof data.date === 'string' ? data.date : todayKey();
+  memoryCache = { data, timestamp, date: timestamp ? dateValue : null };
+  persistCache(memoryCache);
+}
+
+async function requestDayBrief(): Promise<DayInfoPayload> {
+  if (!inflightRequest) {
+    inflightRequest = fetchDayBrief()
+      .then((result) => {
+        inflightRequest = null;
+        return result;
+      })
+      .catch((error) => {
+        inflightRequest = null;
+        throw error;
+      });
+  }
+  return inflightRequest;
+}
+
+function isCacheExpired(record: DayBriefCacheRecord, now: number): boolean {
+  if (!record.timestamp) return true;
+  if (!record.date) return true;
+  if (now - record.timestamp >= CACHE_TTL_MS) return true;
+  const today = todayKey();
+  if (record.date !== today) return true;
+  return false;
+}
+
+export const useDayBrief = (): UseDayBriefResult => {
+  const initialCache = hydrateCache();
+  const [data, setData] = useState<DayInfoPayload | null>(initialCache.data);
+  const [timestamp, setTimestamp] = useState<number | null>(initialCache.timestamp);
+  const [loading, setLoading] = useState<boolean>(() => {
+    if (!initialCache.timestamp || !initialCache.date) return true;
+    const now = Date.now();
+    return isCacheExpired(initialCache, now);
+  });
+  const [error, setError] = useState(false);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => () => {
+    isMountedRef.current = false;
+  }, []);
+
+  const performFetch = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(false);
+      const result = await requestDayBrief();
+      const now = Date.now();
+      updateCache(result, now);
+      if (!isMountedRef.current) return;
+      setData(result);
+      setTimestamp(now);
+    } catch (err) {
+      console.warn('No se pudo cargar información diaria', err);
+      const now = Date.now();
+      const retryTimestamp = Math.max(0, now - CACHE_TTL_MS + ERROR_RETRY_MS);
+      updateCache(null, retryTimestamp);
+      if (!isMountedRef.current) return;
+      setData(null);
+      setTimestamp(retryTimestamp);
+      setError(true);
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const now = Date.now();
+    const cacheDate = data?.date ?? memoryCache.date;
+    const expired = isCacheExpired({ data, timestamp, date: cacheDate }, now);
+
+    const triggerFetch = () => {
+      if (cancelled) return;
+      void performFetch();
+    };
+
+    let timer: number | undefined;
+    if (expired) {
+      triggerFetch();
+    } else {
+      const delay = Math.max(1, CACHE_TTL_MS - (now - (timestamp ?? 0)));
+      timer = window.setTimeout(() => {
+        triggerFetch();
+      }, delay);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [data, performFetch, timestamp]);
+
+  const refresh = useCallback(async () => {
+    await performFetch();
+  }, [performFetch]);
+
+  return { data, loading, error, refresh };
+};
+
+export type { DayInfoPayload } from '../services/dayinfo';

--- a/dash-ui/src/hooks/useLunarPhase.ts
+++ b/dash-ui/src/hooks/useLunarPhase.ts
@@ -1,0 +1,171 @@
+import { useMemo } from 'react';
+import { useDayBrief } from './useDayBrief';
+import type { DayInfoPayload } from '../services/dayinfo';
+
+interface LunarPhaseResult {
+  text: string | null;
+  loading: boolean;
+}
+
+const SYNODIC_MONTH = 29.53058867;
+const KNOWN_NEW_MOON = Date.UTC(2000, 0, 6, 18, 14);
+
+export const useLunarPhase = (): LunarPhaseResult => {
+  const { data, loading } = useDayBrief();
+
+  const info = useMemo(() => deriveLunarInfo(data), [data]);
+  const effectiveLoading = loading && !info;
+
+  return {
+    text: info ? `Fase lunar: ${info.name} (iluminación ${Math.round(info.illumination)}%)` : null,
+    loading: effectiveLoading,
+  };
+};
+
+interface LunarInfo {
+  name: string;
+  illumination: number;
+}
+
+function deriveLunarInfo(payload: DayInfoPayload | null): LunarInfo | null {
+  const remote = extractRemoteLunarInfo(payload);
+  const computed = computeLunarPhase(payload?.date);
+
+  if (!remote && !computed) {
+    return null;
+  }
+
+  const name = remote?.name ?? computed?.name;
+  const illumination = normalizeIllumination(remote?.illumination ?? computed?.illumination ?? NaN);
+
+  if (!name || Number.isNaN(illumination)) {
+    return null;
+  }
+
+  return { name, illumination };
+}
+
+function extractRemoteLunarInfo(payload: DayInfoPayload | null): LunarInfo | null {
+  if (!payload) return null;
+  const candidates = [
+    (payload as any)?.moon,
+    (payload as any)?.lunar,
+    (payload as any)?.moon_phase,
+    (payload as any)?.moonPhase,
+  ];
+
+  for (const candidate of candidates) {
+    const parsed = parseLunarCandidate(candidate);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function parseLunarCandidate(candidate: unknown): LunarInfo | null {
+  if (!candidate) return null;
+
+  if (typeof candidate === 'string') {
+    return { name: candidate, illumination: NaN };
+  }
+
+  if (typeof candidate === 'object') {
+    const record = candidate as Record<string, unknown>;
+    const name = pickString(record, ['name', 'phase', 'phase_name', 'phaseName']);
+    const illuminationRaw = pickNumber(record, ['illumination', 'percent', 'percentage']);
+    const fractionRaw = pickNumber(record, ['fraction', 'fractional']);
+    const illumination = normalizeIllumination(
+      Number.isFinite(illuminationRaw)
+        ? (illuminationRaw as number)
+        : Number.isFinite(fractionRaw)
+        ? (fractionRaw as number) * 100
+        : NaN,
+    );
+
+    if (name) {
+      return { name, illumination };
+    }
+  }
+
+  return null;
+}
+
+function computeLunarPhase(dateString: string | undefined): LunarInfo | null {
+  const baseDate = dateString ? new Date(`${dateString}T00:00:00`) : new Date();
+  if (Number.isNaN(baseDate.getTime())) {
+    return null;
+  }
+
+  const age = lunarAgeDays(baseDate);
+  const illumination = normalizeIllumination(phaseIllumination(age));
+  const name = phaseName(age);
+  return { name, illumination };
+}
+
+function lunarAgeDays(date: Date): number {
+  const diff = date.getTime() - KNOWN_NEW_MOON;
+  const days = diff / (1000 * 60 * 60 * 24);
+  let age = days % SYNODIC_MONTH;
+  if (age < 0) {
+    age += SYNODIC_MONTH;
+  }
+  return age;
+}
+
+function phaseIllumination(age: number): number {
+  const illumination = 0.5 * (1 - Math.cos((2 * Math.PI * age) / SYNODIC_MONTH));
+  return illumination * 100;
+}
+
+function phaseName(age: number): string {
+  const phases: Array<{ limit: number; label: string }> = [
+    { limit: 1.84566, label: 'Luna nueva' },
+    { limit: 5.53699, label: 'Luna creciente' },
+    { limit: 9.22831, label: 'Cuarto creciente' },
+    { limit: 12.91963, label: 'Gibosa creciente' },
+    { limit: 16.61096, label: 'Luna llena' },
+    { limit: 20.30228, label: 'Gibosa menguante' },
+    { limit: 23.99361, label: 'Cuarto menguante' },
+    { limit: 27.68493, label: 'Luna menguante' },
+  ];
+
+  for (const phase of phases) {
+    if (age < phase.limit) {
+      return phase.label;
+    }
+  }
+  return 'Luna nueva';
+}
+
+function normalizeIllumination(value: number): number {
+  if (!Number.isFinite(value)) return NaN;
+  let normalized = value;
+  if (normalized < 0) normalized = 0;
+  if (normalized <= 1) {
+    normalized *= 100;
+  }
+  if (normalized > 100) normalized = 100;
+  return normalized;
+}
+
+function pickString(source: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function pickNumber(source: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+

--- a/dash-ui/src/hooks/useSeasonMonth.ts
+++ b/dash-ui/src/hooks/useSeasonMonth.ts
@@ -23,7 +23,7 @@ interface UseSeasonMonthResult {
 
 const CACHE_KEY = 'seasonMonthCache_v1';
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
-const MAX_FORMAT_LENGTH = 220;
+const MAX_FORMAT_LENGTH = 160;
 const ERROR_RETRY_MS = 60 * 60 * 1000;
 
 let memoryCache: SeasonCacheRecord = { data: null, timestamp: null };
@@ -134,12 +134,6 @@ function formatSeasonLine(payload: SeasonMonthPayload | null): string | null {
   }
   if (frutas) {
     segments.push(`Frutas: ${frutas}`);
-  }
-  if (typeof payload.nota === 'string' && payload.nota.trim()) {
-    segments.push(payload.nota.trim());
-  }
-  if (typeof payload.tip === 'string' && payload.tip.trim()) {
-    segments.push(payload.tip.trim());
   }
   const fullLine = segments.join(' · ');
   return truncate(fullLine, MAX_FORMAT_LENGTH);

--- a/dash-ui/src/hooks/useWeeklyForecast.ts
+++ b/dash-ui/src/hooks/useWeeklyForecast.ts
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  fetchWeatherWeekly,
+  fetchWeatherToday,
+  type WeatherDay,
+  type WeatherToday,
+} from '../services/weather';
+
+interface WeeklyCacheRecord {
+  data: WeatherDay[] | null;
+  timestamp: number | null;
+  fallback: boolean;
+}
+
+interface WeeklyForecastResult {
+  days: WeatherDay[] | null;
+  text: string | null;
+  loading: boolean;
+}
+
+const CACHE_KEY = 'weeklyForecastCache_v1';
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hora
+const FALLBACK_TTL_MS = 15 * 60 * 1000; // 15 minutos si sólo tenemos datos parciales
+const ERROR_RETRY_MS = 15 * 60 * 1000;
+
+const ICON_MAP: Record<string, string> = {
+  sun: '☀️',
+  cloud: '☁️',
+  rain: '🌧️',
+  storm: '⛈️',
+  snow: '❄️',
+  fog: '🌫️',
+};
+
+const DOW_LABELS: Record<string, string> = {
+  Lun: 'Lu',
+  Mar: 'Ma',
+  Mié: 'Mi',
+  Mie: 'Mi',
+  Jue: 'Ju',
+  Vie: 'Vi',
+  Sáb: 'Sá',
+  Sab: 'Sá',
+  Dom: 'Do',
+  Mon: 'Lu',
+  Tue: 'Ma',
+  Wed: 'Mi',
+  Thu: 'Ju',
+  Fri: 'Vi',
+  Sat: 'Sá',
+  Sun: 'Do',
+};
+
+let memoryCache: WeeklyCacheRecord = { data: null, timestamp: null, fallback: false };
+let cacheHydrated = false;
+let inflightRequest: Promise<{ data: WeatherDay[]; fallback: boolean }> | null = null;
+
+function readCacheFromStorage(): WeeklyCacheRecord | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<WeeklyCacheRecord>;
+    if (!parsed) return null;
+    return {
+      data: Array.isArray(parsed.data) ? (parsed.data as WeatherDay[]) : null,
+      timestamp: typeof parsed.timestamp === 'number' ? parsed.timestamp : null,
+      fallback: Boolean(parsed.fallback),
+    };
+  } catch (error) {
+    console.warn('No se pudo leer caché de previsión semanal', error);
+    return null;
+  }
+}
+
+function persistCache(record: WeeklyCacheRecord): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (!record.timestamp) {
+      window.localStorage.removeItem(CACHE_KEY);
+      return;
+    }
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify(record));
+  } catch (error) {
+    console.warn('No se pudo persistir caché de previsión semanal', error);
+  }
+}
+
+function hydrateCache(): WeeklyCacheRecord {
+  if (!cacheHydrated) {
+    const stored = readCacheFromStorage();
+    if (stored) {
+      memoryCache = stored;
+    }
+    cacheHydrated = true;
+  }
+  return memoryCache;
+}
+
+function updateCache(data: WeatherDay[] | null, timestamp: number | null, fallback: boolean): void {
+  memoryCache = { data, timestamp, fallback: Boolean(fallback) };
+  persistCache(memoryCache);
+}
+
+async function requestWeeklyForecast(): Promise<{ data: WeatherDay[]; fallback: boolean }> {
+  if (!inflightRequest) {
+    inflightRequest = fetchWeatherWeekly()
+      .then((days) => {
+        inflightRequest = null;
+        if (!Array.isArray(days) || days.length === 0) {
+          throw new Error('Sin datos semanales');
+        }
+        return { data: days, fallback: false };
+      })
+      .catch(async (error) => {
+        inflightRequest = null;
+        console.warn('Fallo en previsión semanal, aplicando fallback', error);
+        try {
+          const today = await fetchWeatherToday();
+          const fallbackDay = buildFallbackDay(today);
+          return { data: fallbackDay ? [fallbackDay] : [], fallback: true };
+        } catch (fallbackError) {
+          console.warn('No se pudo generar fallback diario', fallbackError);
+          throw error instanceof Error ? error : new Error('No se pudo cargar previsión semanal');
+        }
+      });
+  }
+  return inflightRequest;
+}
+
+function buildFallbackDay(today: WeatherToday | null): WeatherDay | null {
+  if (!today) return null;
+  const now = new Date();
+  const iso = new Date(now.getFullYear(), now.getMonth(), now.getDate()).toISOString().slice(0, 10);
+  return {
+    day: 'Hoy',
+    date: iso,
+    min: today.min,
+    max: today.max,
+    rainProb: today.rainProb,
+    stormProb: 0,
+    condition: today.condition,
+    icon: today.icon,
+  };
+}
+
+function isExpired(record: WeeklyCacheRecord, now: number): boolean {
+  if (!record.timestamp) return true;
+  const ttl = record.fallback ? FALLBACK_TTL_MS : CACHE_TTL_MS;
+  if (now - record.timestamp >= ttl) return true;
+  return false;
+}
+
+function formatWeeklyLine(days: WeatherDay[] | null): string | null {
+  if (!days || days.length === 0) return null;
+  const segments = days.slice(0, 7).map((day) => {
+    const icon = ICON_MAP[day.icon] ?? '•';
+    const label = DOW_LABELS[day.day] ?? day.day.slice(0, 2);
+    const rain = Number.isFinite(day.rainProb) ? `${Math.round(day.rainProb)}%` : '—';
+    const max = Number.isFinite(day.max) ? `${Math.round(day.max)}°` : '—';
+    const min = Number.isFinite(day.min) ? `${Math.round(day.min)}°` : '—';
+    return `${icon} ${label} ${rain} ${max}/${min}`;
+  });
+  return segments.join(' · ');
+}
+
+export const useWeeklyForecast = (): WeeklyForecastResult => {
+  const initialCache = hydrateCache();
+  const [days, setDays] = useState<WeatherDay[] | null>(initialCache.data);
+  const [timestamp, setTimestamp] = useState<number | null>(initialCache.timestamp);
+  const [fallback, setFallback] = useState<boolean>(initialCache.fallback);
+  const [loading, setLoading] = useState<boolean>(() => !initialCache.timestamp);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => () => {
+    isMountedRef.current = false;
+  }, []);
+
+  const performFetch = useCallback(async () => {
+    try {
+      setLoading(true);
+      const result = await requestWeeklyForecast();
+      const now = Date.now();
+      updateCache(result.data, now, result.fallback);
+      if (!isMountedRef.current) return;
+      setDays(result.data);
+      setTimestamp(now);
+      setFallback(result.fallback);
+    } catch (err) {
+      console.warn('No se pudo actualizar la previsión semanal', err);
+      const now = Date.now();
+      const retryAt = Math.max(0, now - CACHE_TTL_MS + ERROR_RETRY_MS);
+      updateCache(null, retryAt, false);
+      if (!isMountedRef.current) return;
+      setDays(null);
+      setTimestamp(retryAt);
+      setFallback(false);
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const now = Date.now();
+    const expired = isExpired({ data: days, timestamp, fallback }, now);
+
+    const triggerFetch = () => {
+      if (cancelled) return;
+      void performFetch();
+    };
+
+    let timer: number | undefined;
+    if (expired) {
+      triggerFetch();
+    } else {
+      const ttl = fallback ? FALLBACK_TTL_MS : CACHE_TTL_MS;
+      const delay = Math.max(1, ttl - (now - (timestamp ?? 0)));
+      timer = window.setTimeout(() => {
+        triggerFetch();
+      }, delay);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer) {
+        window.clearTimeout(timer);
+      }
+    };
+  }, [days, fallback, performFetch, timestamp]);
+
+  const text = useMemo(() => formatWeeklyLine(days), [days]);
+
+  return { days, text, loading };
+};
+

--- a/dash-ui/src/services/config.ts
+++ b/dash-ui/src/services/config.ts
@@ -66,7 +66,7 @@ export interface StormConfig {
   enableExperimentalLightning?: boolean;
 }
 
-export type RotatingPanelSectionKey = 'weather' | 'calendar' | 'season';
+export type RotatingPanelSectionKey = 'calendar' | 'season' | 'weekly' | 'lunar';
 
 export interface RotatingPanelConfig {
   enabled?: boolean;


### PR DESCRIPTION
## Summary
- replace the rotating clock carousel with calendar, season, weekly forecast and lunar phase slides that fade between cached data sources
- add hooks for caching day brief, calendar status, weekly forecast and lunar phase information
- update configuration defaults and UI to manage the new set of rotating panel sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f856618d708326b0411b3d13f8b66c