### PR TITLE
Add Google Calendar integration with device flow support

### DIFF
--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -33,10 +33,14 @@
   "calendar": {
     "enabled": false,
     "mode": "url",
+    "provider": "url",
     "url": "https://calendar.google.com/calendar/ical/tu_id_privado/basic.ics",
     "icsPath": "/etc/pantalla-dash/calendar/calendar.ics",
     "maxEvents": 3,
-    "notifyMinutesBefore": 15
+    "notifyMinutesBefore": 15,
+    "google": {
+      "calendarId": "primary"
+    }
   },
   "locale": {
     "country": "ES",

--- a/backend/services/google_calendar.py
+++ b/backend/services/google_calendar.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+from zoneinfo import ZoneInfo
+
+from urllib.parse import quote
+
+from .google_oauth import GoogleOAuthDeviceFlowManager, GoogleOAuthError
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CACHE_DIR = PROJECT_ROOT / "storage" / "cache"
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+CACHE_PATH = CACHE_DIR / "calendar_google_upcoming.json"
+CACHE_TTL_SECONDS = 300
+HTTP_TIMEOUT = httpx.Timeout(10.0, connect=10.0, read=10.0)
+CALENDAR_LIST_URL = "https://www.googleapis.com/calendar/v3/users/me/calendarList"
+EVENTS_URL_TEMPLATE = "https://www.googleapis.com/calendar/v3/calendars/{calendar_id}/events"
+MAX_RESULTS = 40
+
+
+class GoogleCalendarError(Exception):
+    """Raised when the Google Calendar service fails."""
+
+
+@dataclass
+class CachedPayload:
+    payload: Dict[str, Any]
+    expires_at: float
+    calendar_id: str
+    days: int
+    timezone: str
+
+
+class GoogleCalendarService:
+    def __init__(
+        self,
+        oauth_manager: GoogleOAuthDeviceFlowManager,
+        *,
+        cache_path: Path = CACHE_PATH,
+        cache_ttl: int = CACHE_TTL_SECONDS,
+    ) -> None:
+        self._oauth = oauth_manager
+        self._cache_path = cache_path
+        self._cache_ttl = max(60, cache_ttl)
+        self._client = httpx.AsyncClient(timeout=HTTP_TIMEOUT)
+        self._cache_lock = asyncio.Lock()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def list_calendars(self) -> List[Dict[str, Any]]:
+        for attempt in range(2):
+            try:
+                await self._oauth.get_access_token(force_refresh=attempt > 0)
+                headers = self._oauth.authorization_header()
+            except GoogleOAuthError as exc:
+                raise GoogleCalendarError(str(exc)) from exc
+
+            page_token: Optional[str] = None
+            calendars: List[Dict[str, Any]] = []
+            unauthorized = False
+            while True:
+                params: Dict[str, Any] = {"maxResults": MAX_RESULTS}
+                if page_token:
+                    params["pageToken"] = page_token
+                try:
+                    response = await self._client.get(CALENDAR_LIST_URL, headers=headers, params=params)
+                except httpx.HTTPError as exc:  # pragma: no cover - red externa
+                    logger.error("Google Calendar: fallo de red al listar calendarios: %s", exc)
+                    raise GoogleCalendarError("No se pudo listar los calendarios de Google") from exc
+
+                if response.status_code == 401 and attempt == 0:
+                    unauthorized = True
+                    logger.info("Google Calendar: token caducado, reintentando")
+                    break
+                if response.status_code != 200:
+                    logger.error(
+                        "Google Calendar: respuesta inesperada %s al listar calendarios", response.status_code
+                    )
+                    raise GoogleCalendarError("No se pudo listar los calendarios de Google")
+
+                payload = response.json()
+                for item in payload.get("items", []):
+                    if not isinstance(item, dict):
+                        continue
+                    calendars.append(
+                        {
+                            "id": item.get("id"),
+                            "summary": item.get("summary"),
+                            "primary": bool(item.get("primary")),
+                        }
+                    )
+                page_token = payload.get("nextPageToken")
+                if not page_token:
+                    logger.info("Google Calendar: listado %d calendarios", len(calendars))
+                    return calendars
+
+            if unauthorized and attempt == 0:
+                page_token = None
+                continue
+        raise GoogleCalendarError("No se pudo renovar el token de Google Calendar")
+
+    async def upcoming_events(
+        self,
+        calendar_id: str,
+        *,
+        days: int,
+        timezone_name: str,
+    ) -> Dict[str, Any]:
+        tzinfo = _safe_timezone(timezone_name)
+        now = datetime.now(tz=tzinfo)
+        async with self._cache_lock:
+            cached = self._load_cache()
+            if (
+                cached
+                and cached.calendar_id == calendar_id
+                and cached.days == days
+                and cached.timezone == timezone_name
+                and time.monotonic() < cached.expires_at
+            ):
+                payload = dict(cached.payload)
+                payload["cached"] = True
+                return payload
+
+        events_payload = await self._fetch_remote_events(calendar_id, days=days, tzinfo=tzinfo)
+        payload = {
+            "provider": "google",
+            "calendarId": calendar_id,
+            "items": events_payload,
+            "updated_at": int(time.time()),
+            "cached": False,
+        }
+
+        async with self._cache_lock:
+            self._store_cache(payload, calendar_id=calendar_id, days=days, timezone_name=timezone_name)
+
+        return payload
+
+    async def _fetch_remote_events(
+        self,
+        calendar_id: str,
+        *,
+        days: int,
+        tzinfo: ZoneInfo,
+    ) -> List[Dict[str, Any]]:
+        time_min = datetime.now(tz=tzinfo)
+        time_max = time_min + timedelta(days=days)
+
+        params = {
+            "singleEvents": "true",
+            "orderBy": "startTime",
+            "timeMin": _format_datetime(time_min),
+            "timeMax": _format_datetime(time_max),
+            "maxResults": MAX_RESULTS,
+        }
+
+        events: List[Dict[str, Any]] = []
+        page_token: Optional[str] = None
+        for attempt in range(2):
+            try:
+                await self._oauth.get_access_token(force_refresh=attempt > 0)
+                headers = self._oauth.authorization_header()
+            except GoogleOAuthError as exc:
+                raise GoogleCalendarError(str(exc)) from exc
+
+            unauthorized = False
+            while True:
+                query = dict(params)
+                if page_token:
+                    query["pageToken"] = page_token
+                encoded_calendar = quote(calendar_id, safe="@._-+/=%")
+                url = EVENTS_URL_TEMPLATE.format(calendar_id=encoded_calendar)
+                try:
+                    response = await self._client.get(url, headers=headers, params=query)
+                except httpx.HTTPError as exc:  # pragma: no cover - red externa
+                    logger.error("Google Calendar: fallo de red al obtener eventos: %s", exc)
+                    raise GoogleCalendarError("No se pudieron obtener eventos del calendario") from exc
+
+                if response.status_code == 401 and attempt == 0:
+                    unauthorized = True
+                    logger.info("Google Calendar: token caducado al obtener eventos, reintentando")
+                    break
+                if response.status_code != 200:
+                    logger.error(
+                        "Google Calendar: respuesta inesperada %s al obtener eventos", response.status_code
+                    )
+                    raise GoogleCalendarError("No se pudieron obtener eventos del calendario")
+
+                data = response.json()
+                for item in data.get("items", []):
+                    event = _normalize_event(item, tzinfo)
+                    if event:
+                        events.append(event)
+                page_token = data.get("nextPageToken")
+                if not page_token:
+                    logger.info("Google Calendar: fetched %d items for %s", len(events), calendar_id)
+                    return events
+
+            if unauthorized and attempt == 0:
+                page_token = None
+                continue
+        raise GoogleCalendarError("No se pudo renovar el token de Google Calendar")
+
+    def _load_cache(self) -> Optional[CachedPayload]:
+        if not self._cache_path.exists():
+            return None
+        try:
+            raw = self._cache_path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+            payload = data.get("payload")
+            if not isinstance(payload, dict):
+                return None
+            return CachedPayload(
+                payload=payload,
+                expires_at=float(data.get("expires_at", 0.0)),
+                calendar_id=str(data.get("calendar_id", "")),
+                days=int(data.get("days", 0)),
+                timezone=str(data.get("timezone", "")),
+            )
+        except (OSError, ValueError):
+            return None
+
+    def _store_cache(
+        self,
+        payload: Dict[str, Any],
+        *,
+        calendar_id: str,
+        days: int,
+        timezone_name: str,
+    ) -> None:
+        cache_entry = {
+            "payload": payload,
+            "expires_at": time.monotonic() + self._cache_ttl,
+            "calendar_id": calendar_id,
+            "days": days,
+            "timezone": timezone_name,
+        }
+        tmp_path = self._cache_path.with_suffix(".tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as handle:
+                json.dump(cache_entry, handle, ensure_ascii=False)
+            tmp_path.replace(self._cache_path)
+        except OSError:
+            logger.debug("Google Calendar: no se pudo escribir caché", exc_info=True)
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:  # pragma: no cover - best effort
+                pass
+
+
+def _safe_timezone(name: str) -> ZoneInfo:
+    try:
+        return ZoneInfo(name)
+    except Exception:  # pragma: no cover - fallback
+        return ZoneInfo("UTC")
+
+
+def _format_datetime(value: datetime) -> str:
+    iso = value.isoformat()
+    if value.tzinfo is None:
+        return f"{iso}+00:00"
+    return iso
+
+
+def _normalize_event(item: Dict[str, Any], tzinfo: ZoneInfo) -> Optional[Dict[str, Any]]:
+    if not isinstance(item, dict):
+        return None
+    summary = item.get("summary") or item.get("description")
+    if not isinstance(summary, str):
+        summary = "Sin título"
+
+    start_info = item.get("start") or {}
+    end_info = item.get("end") or {}
+
+    start_dt, all_day = _parse_event_datetime(start_info, tzinfo)
+    if not start_dt:
+        return None
+    end_dt, _ = _parse_event_datetime(end_info, tzinfo, all_day=all_day, default_start=start_dt)
+    if all_day:
+        if end_dt is None:
+            end_dt = start_dt + timedelta(days=1)
+    else:
+        if end_dt is None:
+            end_dt = start_dt
+
+    location = item.get("location") if isinstance(item.get("location"), str) else None
+    status = item.get("status") if isinstance(item.get("status"), str) else "confirmed"
+
+    return {
+        "id": item.get("id"),
+        "title": summary,
+        "start": start_dt.isoformat(),
+        "end": end_dt.isoformat() if end_dt else None,
+        "allDay": all_day,
+        "location": location,
+        "status": status,
+    }
+
+
+def _parse_event_datetime(
+    info: Dict[str, Any],
+    tzinfo: ZoneInfo,
+    *,
+    all_day: bool = False,
+    default_start: Optional[datetime] = None,
+) -> tuple[Optional[datetime], bool]:
+    if not isinstance(info, dict):
+        return default_start, all_day
+    if "dateTime" in info:
+        raw = info.get("dateTime")
+        if isinstance(raw, str):
+            try:
+                dt = _parse_rfc3339(raw)
+            except ValueError:
+                return default_start, all_day
+            tz_override = info.get("timeZone")
+            if isinstance(tz_override, str) and tz_override:
+                try:
+                    dt = dt.astimezone(ZoneInfo(tz_override))
+                except Exception:  # pragma: no cover - fallback
+                    dt = dt.astimezone(tzinfo)
+            else:
+                dt = dt.astimezone(tzinfo)
+            return dt, False
+        return default_start, all_day
+    if "date" in info:
+        raw = info.get("date")
+        if isinstance(raw, str):
+            try:
+                day = datetime.fromisoformat(raw).date()
+            except ValueError:
+                return default_start, True
+            dt = datetime.combine(day, datetime.min.time(), tzinfo)
+            return dt, True
+    return default_start, all_day
+
+
+def _parse_rfc3339(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.fromisoformat(value)

--- a/backend/services/google_oauth.py
+++ b/backend/services/google_oauth.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence
+
+import httpx
+
+from .config_store import read_google_secrets, write_google_refresh_token
+
+logger = logging.getLogger(__name__)
+
+DEVICE_CODE_URL = "https://oauth2.googleapis.com/device/code"
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo"
+DEFAULT_SCOPES = ("https://www.googleapis.com/auth/calendar.readonly",)
+HTTP_TIMEOUT = httpx.Timeout(10.0, connect=10.0, read=10.0)
+
+
+class GoogleOAuthError(Exception):
+    """Generic Google OAuth error."""
+
+
+@dataclass
+class DeviceFlowState:
+    device_code: str
+    user_code: str
+    verification_url: str
+    interval: int
+    expires_at: float
+    scopes: tuple[str, ...]
+    created_at: float
+    last_error: Optional[str] = None
+    authorized: bool = False
+    email: Optional[str] = None
+
+
+@dataclass
+class TokenBundle:
+    access_token: str
+    expires_in: int
+    refresh_token: Optional[str]
+    token_type: str
+    scope: Optional[str]
+
+
+class GoogleOAuthDeviceFlowManager:
+    def __init__(self) -> None:
+        self._client = httpx.AsyncClient(timeout=HTTP_TIMEOUT)
+        self._lock = asyncio.Lock()
+        self._state: DeviceFlowState | None = None
+        self._poll_task: asyncio.Task[None] | None = None
+        self._access_token: str | None = None
+        self._access_token_expiry: float = 0.0
+        self._token_type: str = "Bearer"
+        self._refresh_token: str | None = None
+        self._last_email: str | None = None
+        self._client_id: str | None = None
+        self._client_secret: str | None = None
+        self._load_secrets()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    def _load_secrets(self) -> None:
+        secrets = read_google_secrets()
+        self._client_id = secrets.get("client_id")
+        self._client_secret = secrets.get("client_secret")
+        refresh_token = secrets.get("refresh_token")
+        if refresh_token:
+            self._refresh_token = refresh_token
+
+    async def start_device_flow(self, scopes: Sequence[str] | None = None) -> Dict[str, Any]:
+        scope_values = tuple(scopes) if scopes else DEFAULT_SCOPES
+        async with self._lock:
+            self._load_secrets()
+            if not self._client_id or not self._client_secret:
+                raise GoogleOAuthError("Credenciales de Google no configuradas")
+
+            if self._poll_task is not None:
+                self._poll_task.cancel()
+                self._poll_task = None
+
+            data = {
+                "client_id": self._client_id,
+                "scope": " ".join(scope_values),
+            }
+
+        try:
+            response = await self._client.post(DEVICE_CODE_URL, data=data)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:  # pragma: no cover - red externa
+            logger.error("Google OAuth device: error iniciando flujo: %s", exc)
+            raise GoogleOAuthError("No se pudo iniciar el flujo de dispositivo de Google") from exc
+
+        payload = response.json()
+        device_code = payload.get("device_code")
+        user_code = payload.get("user_code")
+        verification_url = payload.get("verification_uri") or payload.get("verification_url")
+        interval = int(payload.get("interval", 5))
+        expires_in = int(payload.get("expires_in", 1800))
+
+        if not device_code or not user_code or not verification_url:
+            raise GoogleOAuthError("Respuesta inválida al iniciar flujo de dispositivo")
+
+        state = DeviceFlowState(
+            device_code=str(device_code),
+            user_code=str(user_code),
+            verification_url=str(verification_url),
+            interval=max(1, interval),
+            expires_at=time.monotonic() + max(30, expires_in),
+            scopes=scope_values,
+            created_at=time.time(),
+        )
+
+        async with self._lock:
+            self._state = state
+            self._access_token = None
+            self._access_token_expiry = 0.0
+            self._token_type = "Bearer"
+            self._last_email = None
+            self._poll_task = asyncio.create_task(self._poll_device_code(state))
+
+        logger.info(
+            "Google OAuth device: started. user_code=%s url=%s",
+            _mask_value(state.user_code),
+            state.verification_url,
+        )
+
+        return {
+            "user_code": state.user_code,
+            "verification_url": state.verification_url,
+            "device_code": state.device_code,
+            "interval": state.interval,
+            "expires_in": expires_in,
+        }
+
+    async def _poll_device_code(self, state: DeviceFlowState) -> None:
+        interval = state.interval
+        while True:
+            await asyncio.sleep(interval)
+            async with self._lock:
+                if self._state is not state:
+                    return
+                if time.monotonic() >= state.expires_at:
+                    logger.warning("Google OAuth device: código expirado")
+                    self._state = None
+                    self._poll_task = None
+                    return
+                client_id = self._client_id
+                client_secret = self._client_secret
+                device_code = state.device_code
+            if not client_id or not client_secret:
+                logger.error("Google OAuth device: credenciales ausentes durante polling")
+                return
+
+            data = {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "device_code": device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            }
+
+            try:
+                response = await self._client.post(TOKEN_URL, data=data)
+            except httpx.HTTPError as exc:  # pragma: no cover - red externa
+                logger.error("Google OAuth device: error en polling: %s", exc)
+                continue
+
+            if response.status_code == 200:
+                token_bundle = self._parse_token_response(response.json())
+                email = await self._maybe_fetch_user_email(token_bundle)
+                async with self._lock:
+                    if self._state is state:
+                        self._apply_token_bundle(token_bundle, email=email)
+                        state.authorized = True
+                        state.email = email
+                        self._state = None
+                        self._poll_task = None
+                logger.info("Google OAuth device: authorized. refresh_token stored.")
+                return
+
+            try:
+                error_payload = response.json()
+            except ValueError:  # pragma: no cover - defensivo
+                error_payload = {}
+            error_code = (error_payload.get("error") or "").lower()
+            if error_code == "authorization_pending":
+                continue
+            if error_code == "slow_down":
+                interval = min(interval + 5, 30)
+                continue
+            if error_code in {"access_denied", "expired_token"}:
+                logger.warning("Google OAuth device: flujo cancelado (%s)", error_code)
+                async with self._lock:
+                    if self._state is state:
+                        state.last_error = error_code
+                        self._state = None
+                        self._poll_task = None
+                return
+            logger.error("Google OAuth device: error inesperado %s", error_code or response.text)
+            async with self._lock:
+                if self._state is state:
+                    state.last_error = error_code or "unexpected_error"
+                    self._state = None
+                    self._poll_task = None
+            return
+
+    def _parse_token_response(self, payload: Dict[str, Any]) -> TokenBundle:
+        access_token = payload.get("access_token")
+        expires_in = int(payload.get("expires_in", 3600))
+        refresh_token = payload.get("refresh_token")
+        token_type = payload.get("token_type", "Bearer")
+        scope = payload.get("scope")
+        if not isinstance(access_token, str) or not access_token:
+            raise GoogleOAuthError("Respuesta de token inválida")
+        return TokenBundle(
+            access_token=access_token,
+            expires_in=max(60, expires_in),
+            refresh_token=refresh_token if isinstance(refresh_token, str) and refresh_token else None,
+            token_type=_normalize_token_type(token_type if isinstance(token_type, str) else None),
+            scope=scope if isinstance(scope, str) else None,
+        )
+
+    async def _maybe_fetch_user_email(self, bundle: TokenBundle) -> Optional[str]:
+        headers = {"Authorization": f"{bundle.token_type} {bundle.access_token}"}
+        try:
+            response = await self._client.get(USERINFO_URL, headers=headers)
+            if response.status_code != 200:
+                return None
+            data = response.json()
+            email = data.get("email")
+            if isinstance(email, str) and email:
+                return email
+        except httpx.HTTPError:
+            return None
+        except ValueError:  # pragma: no cover - defensivo
+            return None
+        return None
+
+    async def get_access_token(self, *, scopes: Sequence[str] | None = None, force_refresh: bool = False) -> str:
+        async with self._lock:
+            self._load_secrets()
+            if not force_refresh and self._access_token and time.monotonic() < self._access_token_expiry:
+                return self._access_token
+            refresh_token = self._refresh_token
+            client_id = self._client_id
+            client_secret = self._client_secret
+            if not refresh_token or not client_id or not client_secret:
+                raise GoogleOAuthError("No hay token de actualización disponible")
+
+        data = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+        }
+        try:
+            response = await self._client.post(TOKEN_URL, data=data)
+        except httpx.HTTPError as exc:  # pragma: no cover - red externa
+            raise GoogleOAuthError("No se pudo refrescar el token de Google") from exc
+
+        if response.status_code != 200:
+            error = response.json() if response.headers.get("content-type", "").startswith("application/json") else {}
+            error_code = (error.get("error") or "").lower() if isinstance(error, dict) else ""
+            if error_code == "invalid_grant":
+                async with self._lock:
+                    self._refresh_token = None
+                    write_google_refresh_token(None)
+                raise GoogleOAuthError("Token de actualización inválido")
+            raise GoogleOAuthError("No se pudo refrescar el token de Google")
+
+        token_bundle = self._parse_token_response(response.json())
+        async with self._lock:
+            self._apply_token_bundle(token_bundle)
+            return self._access_token or ""
+
+    async def cancel(self) -> bool:
+        async with self._lock:
+            state = self._state
+            task = self._poll_task
+            self._state = None
+            self._poll_task = None
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:  # pragma: no cover - esperado
+                pass
+        return state is not None
+
+    async def status(self) -> Dict[str, Any]:
+        async with self._lock:
+            self._load_secrets()
+            now = time.monotonic()
+            state = self._state
+            if state and now >= state.expires_at and not state.authorized:
+                state = None
+                self._state = None
+                self._poll_task = None
+            has_refresh = bool(self._refresh_token)
+            authorized = has_refresh or (self._access_token and now < self._access_token_expiry)
+            needs_action = bool(state and not authorized)
+            user_code = state.user_code if needs_action else None
+            verification_url = state.verification_url if needs_action else None
+            email = state.email if state and state.authorized else self._last_email if authorized else None
+            credentials_ready = bool(self._client_id and self._client_secret)
+            return {
+                "authorized": bool(authorized),
+                "needs_action": needs_action,
+                "user_code": user_code,
+                "verification_url": verification_url,
+                "email": email,
+                "has_credentials": credentials_ready,
+                "has_refresh_token": has_refresh,
+            }
+
+    def _apply_token_bundle(self, bundle: TokenBundle, *, email: Optional[str] = None) -> None:
+        self._access_token = bundle.access_token
+        self._access_token_expiry = time.monotonic() + max(30.0, bundle.expires_in - 10)
+        self._token_type = _normalize_token_type(bundle.token_type)
+        if bundle.refresh_token:
+            self._refresh_token = bundle.refresh_token
+            write_google_refresh_token(bundle.refresh_token)
+        if email:
+            self._last_email = email
+
+    def authorization_header(self) -> Dict[str, str]:
+        if not self._access_token:
+            raise GoogleOAuthError("No hay token activo")
+        token_type = _normalize_token_type(self._token_type)
+        return {"Authorization": f"{token_type} {self._access_token}"}
+
+
+def _mask_value(value: str) -> str:
+    if len(value) <= 4:
+        return "****"
+    return f"{value[:2]}…{value[-2:]}"
+
+
+def _normalize_token_type(value: Optional[str]) -> str:
+    if not value:
+        return "Bearer"
+    token = value.strip()
+    if not token:
+        return "Bearer"
+    if token.lower() == "bearer":
+        return "Bearer"
+    return token

--- a/dash-ui/src/services/calendar.ts
+++ b/dash-ui/src/services/calendar.ts
@@ -8,18 +8,66 @@ export interface CalendarEvent {
   notify: boolean;
 }
 
+export type CalendarProvider = 'none' | 'ics' | 'url' | 'google';
+
 export interface CalendarStatus {
+  enabled?: boolean;
   mode: 'url' | 'ics';
+  provider?: CalendarProvider;
   url?: string | null;
   icsPath?: string | null;
   exists: boolean;
   size?: number | null;
   mtime?: string | null;
+  google?: { calendarId?: string | null };
 }
 
 export interface CalendarOperationResponse extends CalendarStatus {
   ok: boolean;
   message?: string;
+}
+
+export interface GoogleDeviceStartResponse {
+  user_code: string;
+  verification_url: string;
+  device_code: string;
+  interval: number;
+  expires_in: number;
+}
+
+export interface GoogleDeviceStatus {
+  authorized: boolean;
+  needs_action: boolean;
+  user_code?: string | null;
+  verification_url?: string | null;
+  email?: string | null;
+  has_credentials?: boolean;
+  has_refresh_token?: boolean;
+}
+
+export interface GoogleCalendarListItem {
+  id?: string;
+  summary?: string;
+  primary?: boolean;
+}
+
+export interface CalendarUpcomingEvent {
+  id?: string;
+  title?: string;
+  start?: string | null;
+  end?: string | null;
+  allDay?: boolean;
+  location?: string | null;
+  status?: string | null;
+}
+
+export interface CalendarEventsResponse {
+  provider: CalendarProvider;
+  calendarId?: string;
+  items: CalendarUpcomingEvent[];
+  note?: string | null;
+  updated_at: number;
+  cached?: boolean;
 }
 
 export async function fetchTodayEvents(): Promise<CalendarEvent[]> {
@@ -34,6 +82,34 @@ export async function deleteCalendarFile(): Promise<CalendarOperationResponse> {
   return await apiRequest<CalendarOperationResponse>('/calendar/file', {
     method: 'DELETE',
   });
+}
+
+export async function startGoogleDeviceFlow(scopes?: string[]): Promise<GoogleDeviceStartResponse> {
+  const body = scopes && scopes.length > 0 ? { scopes } : undefined;
+  return await apiRequest<GoogleDeviceStartResponse>('/calendar/google/device/start', {
+    method: 'POST',
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+export async function fetchGoogleDeviceStatus(): Promise<GoogleDeviceStatus> {
+  return await apiRequest<GoogleDeviceStatus>('/calendar/google/device/status');
+}
+
+export async function cancelGoogleDeviceFlow(): Promise<{ cancelled: boolean }> {
+  return await apiRequest<{ cancelled: boolean }>('/calendar/google/device/cancel', {
+    method: 'POST',
+  });
+}
+
+export async function fetchGoogleCalendars(): Promise<GoogleCalendarListItem[]> {
+  const response = await apiRequest<{ items: GoogleCalendarListItem[] }>('/calendar/google/calendars');
+  return Array.isArray(response?.items) ? response.items : [];
+}
+
+export async function fetchCalendarEvents(days = 7): Promise<CalendarEventsResponse> {
+  const params = new URLSearchParams({ days: String(days) });
+  return await apiRequest<CalendarEventsResponse>(`/calendar/events?${params.toString()}`);
 }
 
 export function uploadCalendarFile(

--- a/dash-ui/src/services/config.ts
+++ b/dash-ui/src/services/config.ts
@@ -39,11 +39,15 @@ export interface WifiConfig {
 export interface CalendarConfig {
   enabled?: boolean;
   mode?: 'url' | 'ics';
+  provider?: 'none' | 'ics' | 'url' | 'google';
   url?: string | null;
   icsPath?: string | null;
   maxEvents?: number;
   notifyMinutesBefore?: number;
   icsConfigured?: boolean;
+  google?: {
+    calendarId?: string | null;
+  };
 }
 
 export interface LocaleConfig {


### PR DESCRIPTION
## Summary
- add FastAPI endpoints and services to support Google Calendar device flow and event retrieval with caching
- extend config and secrets handling to persist Google provider settings and tokens
- update the React configuration UI and calendar summary hook to drive the Google connection workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f860a6a96083269c3fdc4cd4055331