### PR TITLE
docs: detalla la integración con Google Calendar

### DIFF
--- a/dash-ui/README.md
+++ b/dash-ui/README.md
@@ -41,12 +41,13 @@ Activa el modo de ahorro ajustando `powerSave` a `true` en `src/services/config.
 
 ## Integración con backend
 
-La UI consume el backend local en `http://127.0.0.1:8787/api`:
+La UI consume el backend local en `http://127.0.0.1:8081/api`:
 
 - `src/services/weather.ts` realiza polling cada 12 minutos con backoff exponencial y cachea el último dato en `localStorage`.
 - `src/services/wifi.ts` y `src/components/SettingsPanel.tsx` ofrecen gestión completa de Wi-Fi vía `nmcli`.
 - `src/services/tts.ts` permite listar voces y lanzar pruebas de audio.
 - `src/context/DashboardConfigContext.tsx` centraliza la configuración compartida (tema, fondos, voz, etc.).
+- `src/services/calendar.ts` implementa el flujo OAuth de Google Calendar (`startGoogleDeviceFlow`, `fetchGoogleCalendars`, etc.).
 
 ## Bundle objetivo
 

--- a/docs/DEPLOY_BACKEND.md
+++ b/docs/DEPLOY_BACKEND.md
@@ -29,7 +29,8 @@ Instala la plantilla y ajusta permisos:
 sudo groupadd -f pantalla
 sudo install -d -m2770 -o root -g pantalla /etc/pantalla-dash
 sudo install -m660 backend/config/config.example.json /etc/pantalla-dash/config.json
-sudo chown dani:pantalla /etc/pantalla-dash/config.json
+sudo install -m600 /dev/null /etc/pantalla-dash/secrets.json
+sudo chown dani:pantalla /etc/pantalla-dash/config.json /etc/pantalla-dash/secrets.json
 ```
 
 Asegura que el usuario del backend pertenezca al grupo `pantalla` y que el
@@ -40,8 +41,7 @@ sudo usermod -aG pantalla dani
 sudo chgrp -R pantalla /etc/pantalla-dash
 sudo chown dani:pantalla /etc/pantalla-dash/backend.env /etc/pantalla-dash/env
 sudo chmod 660 /etc/pantalla-dash/backend.env /etc/pantalla-dash/env /etc/pantalla-dash/config.json
-sudo chown dani:pantalla /etc/pantalla-dash/secrets.json
-sudo chmod 660 /etc/pantalla-dash/secrets.json
+sudo chmod 600 /etc/pantalla-dash/secrets.json
 ```
 
 Recuerda reiniciar sesión (o `newgrp pantalla`) tras añadir el usuario al grupo
@@ -53,6 +53,7 @@ Edita `/etc/pantalla-dash/config.json`:
 - `weather.city` y `weather.units` para la UI.
 - `storm.threshold` para el aviso de tormentas (0-1).
 - `wifi.preferredInterface` si no quieres autoselección.
+- `calendar.provider` (`url`, `ics` o `google`), junto a `calendar.google.calendarId` si vas a usar Google Calendar.
 
 Activa `systemd-timesyncd` para garantizar hora correcta:
 
@@ -128,12 +129,12 @@ sudo cat /var/lib/pantalla/ap_pass
 Comprueba que el backend responde:
 
 ```bash
-curl -s http://127.0.0.1:8787/api/weather/today
-curl -s http://127.0.0.1:8787/api/network/status
-curl -s http://127.0.0.1:8787/api/storms/status
+curl -s http://127.0.0.1:8081/api/weather/today
+curl -s http://127.0.0.1:8081/api/network/status
+curl -s http://127.0.0.1:8081/api/storms/status
 ```
 
-Desde un cliente conectado al AP visita `http://10.42.0.1:8787/setup` para usar
+Desde un cliente conectado al AP visita `http://10.42.0.1:8081/setup` para usar
 la mini-web de configuración (escaneo Wi-Fi y conexión con password).
 
 ## 6. Troubleshooting
@@ -154,5 +155,13 @@ sudo -u dashsvc git pull (si clonado) o vuelve a sincronizar archivos
 sudo systemctl restart pantalla-dash-backend.service
 ```
 
-La UI (frontend) debe apuntar a `http://127.0.0.1:8787` y servirse en kiosk
+La UI (frontend) debe apuntar a `http://127.0.0.1:8081` y servirse en kiosk
 modo pantalla completa.
+
+### Credenciales para Google Calendar
+
+1. Define las credenciales OAuth en `/etc/pantalla-dash/secrets.json` (`client_id`, `client_secret`).
+2. Elige **Google** como proveedor en `/#/config` y sigue el flujo de código de dispositivo.
+3. El `refresh_token` se guarda automáticamente en `secrets.json` con permisos `600`.
+
+Consulta [google-calendar.md](./google-calendar.md) para un desglose paso a paso de la integración.

--- a/docs/google-calendar.md
+++ b/docs/google-calendar.md
@@ -1,0 +1,74 @@
+# Integración con Google Calendar
+
+Esta guía cubre cómo habilitar el proveedor **Google** para el widget de calendario.
+El backend utiliza el flujo OAuth 2.0 *Device Authorization Grant* para evitar que
+la Raspberry Pi tenga que iniciar sesión en un navegador tradicional.
+
+## 1. Crear credenciales en Google Cloud
+
+1. Accede a [Google Cloud Console](https://console.cloud.google.com/).
+2. Crea (o reutiliza) un proyecto y habilita la API **Google Calendar**.
+3. En **APIs & Services → Credentials** crea un OAuth client:
+   - Tipo de aplicación: **TVs and Limited Input devices** (o **Desktop** si no está disponible).
+   - Copia el `client_id` y el `client_secret` generados.
+4. En **OAuth consent screen** añade al menos un usuario de prueba (el mismo que
+   usará la autorización) y guarda los cambios.
+
+## 2. Configurar `/etc/pantalla-dash/secrets.json`
+
+El backend lee las credenciales desde `secrets.json` con permisos `0600`.
+Añade la sección `google` (o edítala desde `/#/config` → pestaña **Credenciales**).
+
+```json
+{
+  "google": {
+    "client_id": "TU_CLIENT_ID.apps.googleusercontent.com",
+    "client_secret": "TU_CLIENT_SECRET"
+  }
+}
+```
+
+> El archivo puede contener otras claves (`openai`, etc.). Respeta el formato JSON.
+
+## 3. Seleccionar proveedor desde la UI
+
+1. Abre la pantalla de configuración en la Raspberry (`/#/config`).
+2. En la tarjeta **Calendario** elige **Google** como proveedor.
+3. Si las credenciales son válidas aparecerá el botón **Conectar con Google**.
+
+Al pulsarlo el backend llamará a `POST /api/calendar/google/device/start` y la UI
+mostrará el código de usuario y la URL `https://www.google.com/device`.
+
+## 4. Completar la autorización
+
+1. Desde un ordenador o móvil abre `https://www.google.com/device`.
+2. Introduce el código mostrado en la pantalla.
+3. Acepta los permisos de lectura (`Google Calendar API - read only`).
+4. El backend guardará el `refresh_token` en `secrets.json` y la UI indicará el
+   correo autorizado.
+
+Puedes listar calendarios adicionales con el botón **Actualizar** (UI) que
+invoca `GET /api/calendar/google/calendars`. Selecciona el calendario deseado en
+el desplegable; el identificador se guarda en `config.calendar.google.calendarId`.
+
+## 5. Funcionamiento interno y mantenimiento
+
+- Los eventos se solicitan mediante `GET /api/calendar/upcoming` con `provider=google`.
+- Se cachean durante 5 minutos en `backend/storage/cache/calendar_google_upcoming.json`.
+- Si necesitas revocar la sesión elimina `refresh_token` de `secrets.json` o
+  pulsa **Cancelar** en la UI (llama a `POST /api/calendar/google/device/cancel`).
+- El endpoint `GET /api/calendar/google/device/status` devuelve el estado actual:
+  `{ authorized, needs_action, user_code, verification_url, email, has_credentials, has_refresh_token }`.
+- Todos los eventos relevantes se registran en `/var/log/pantalla-dash/calendar.log`.
+
+## 6. Resolución de problemas
+
+| Síntoma | Posible causa | Acción |
+| --- | --- | --- |
+| La UI muestra “Configura client_id…” | Falta `client_id` o `client_secret` | Revisa `secrets.json` y permisos (`sudo chmod 600`). |
+| Error “No se pudo iniciar la autorización” | Proyecto sin Calendar API o credenciales inválidas | Comprueba que la API esté habilitada y que el tipo de cliente sea correcto. |
+| Eventos no se actualizan | Token caducado o revocado | Elimina el `refresh_token` y repite la autorización. |
+| Código expira antes de introducirlo | Tiempo excedido (30 min) | Pulsa **Conectar con Google** de nuevo para generar uno nuevo. |
+
+Con estos pasos el calendario de Google quedará sincronizado de forma segura con
+el dashboard.


### PR DESCRIPTION
## Summary
- describe la nueva documentación del flujo OAuth de Google Calendar y enlaza una guía dedicada
- sincroniza los puertos y referencias del backend/UI con 127.0.0.1:8081
- ajusta la guía de despliegue para crear secrets.json, configurar el proveedor Google y enlazar la guía específica

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f8bca893488326aa6d6169f5df8502