### PR TITLE
Fix syntax error in daily background generator

### DIFF
--- a/opt/dash/scripts/generate_bg_daily.py
+++ b/opt/dash/scripts/generate_bg_daily.py
@@ -272,7 +272,15 @@ def build_contextual_prompt(context: Dict[str, Any]) -> Optional[Dict[str, Any]]
         f"Negative prompt: {NEGATIVE_PROMPT}."
     )
 
-    primary = "storm" if signals.get("storm") else "rain" if signals.get("rain") else "wind" if signals.get("wind") else str(today.get("icon") or "clear")
+    primary = (
+        "storm"
+        if signals.get("storm")
+        else "rain"
+        if signals.get("rain")
+        else "wind"
+        if signals.get("wind")
+        else str(today.get("icon") or "clear")
+    )
     key_descriptor = f"{day_period}-{primary}".replace(" ", "-")
     context_meta: Dict[str, Any] = {"dayPeriod": day_period, "storm": bool(signals.get("storm"))}
     if event_meta:


### PR DESCRIPTION
## Summary
- rewrite the weather prompt primary descriptor selection to avoid the stray split token that caused a syntax error

## Testing
- python -m py_compile opt/dash/scripts/generate_bg_daily.py

------
https://chatgpt.com/codex/tasks/task_e_68f9065229088326a4765a47b8ed8966