### PR TITLE
Ensure OpenAI key sync and resilient background generation

### DIFF
--- a/etc/nginx/sites-available/pantalla
+++ b/etc/nginx/sites-available/pantalla
@@ -21,6 +21,12 @@ server {
     expires 7d;
   }
 
+  location /backgrounds/auto/ {
+    alias /opt/dash/assets/backgrounds/auto/;
+    access_log off;
+    add_header Cache-Control "public, max-age=60";
+  }
+
   location = /healthz {
     default_type text/plain;
     return 200 'ok';

--- a/system/pantalla-bg-generate.service
+++ b/system/pantalla-bg-generate.service
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-EnvironmentFile=/etc/pantalla-dash/env
+EnvironmentFile=-/etc/pantalla-dash/env
 WorkingDirectory=/opt/dash/scripts
 ExecStart=/usr/bin/python3 /opt/dash/scripts/generate_bg_daily.py
 Environment=PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
- sync OPENAI_API_KEY writes to /etc/pantalla-dash/env when secrets are updated
- harden the daily background generator to resolve API keys, handle OpenAI 4xx billing errors, and produce local placeholders
- expose /backgrounds/auto/ via nginx and ensure the generator service always loads the env file

## Testing
- python -m compileall backend/services/config_store.py opt/dash/scripts/generate_bg_daily.py

------
https://chatgpt.com/codex/tasks/task_e_68f99cc295d08326a687f1a2cb0a0e20