### PR TITLE
Improve background generation fallbacks and static serving

### DIFF
--- a/dash-ui/src/components/DynamicBackground.tsx
+++ b/dash-ui/src/components/DynamicBackground.tsx
@@ -45,7 +45,7 @@ const DynamicBackground = ({ refreshMinutes }: DynamicBackgroundProps) => {
           />
         )}
       </AnimatePresence>
-      <div className="absolute inset-0 bg-gradient-to-br from-black/65 via-black/35 to-black/75" aria-hidden />
+      <div className="absolute inset-0 bg-gradient-to-br from-black/30 via-black/15 to-black/35" aria-hidden />
       <div className="absolute inset-0" style={{ background: 'radial-gradient(circle at 20% 20%, rgba(56, 249, 255, 0.18), transparent 55%)' }} aria-hidden />
     </div>
   );

--- a/etc/nginx/sites-available/pantalla
+++ b/etc/nginx/sites-available/pantalla
@@ -24,6 +24,8 @@ server {
   location /backgrounds/auto/ {
     alias /opt/dash/assets/backgrounds/auto/;
     access_log off;
+    types { image/webp webp; }
+    default_type image/webp;
     add_header Cache-Control "public, max-age=60";
   }
 


### PR DESCRIPTION
## Summary
- update the background generator to remove unsupported parameters, support multiple OpenAI image payload formats, and always fall back to a placeholder image on errors
- relax the UI background overlay gradient so generated images remain visible
- ensure nginx serves /backgrounds/auto/ assets with the correct WebP content type

## Testing
- python3 -m compileall opt/dash/scripts/generate_bg_daily.py
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9ae36ec3c83269f79384224d055a0