### PR TITLE
Actualiza documentación para mini PC en lugar de Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Pantalla Futurista
 
-Dashboard futurista para Raspberry Pi que muestra reloj, clima y controles de
-configuración. La UI (React + Vite) se sirve como estático (Busybox/NGINX) y
+Dashboard futurista para mini PC con Linux que muestra reloj, clima y controles
+de configuración. La UI (React + Vite) se sirve como estático (Busybox/NGINX) y
 usa un backend local mínimo (FastAPI) en `127.0.0.1:8081` para integrar
 OpenWeatherMap, gestión de Wi-Fi y TTS offline.
 
@@ -104,7 +104,7 @@ Endpoints adicionales destacados:
 Consulta `backend/README.md` y `docs/DEPLOY_BACKEND.md` para detalles de
 permisos, systemd y endurecimiento.
 
-## Despliegue en Raspberry Pi
+## Despliegue en mini PC
 
 1. Sigue la guía `docs/DEPLOY_BACKEND.md` para instalar dependencias, crear el
    usuario de servicio (por ejemplo `dani`) y registrar

--- a/dash-ui/README.md
+++ b/dash-ui/README.md
@@ -1,6 +1,6 @@
 # Dash UI Futurista
 
-UI estática diseñada para funcionar en Raspberry Pi 4/5 (Chromium en modo kiosk) sirviendo archivos desde `/opt/dash` con `busybox httpd`.
+UI estática diseñada para funcionar en un mini PC con Linux (Chromium en modo kiosk) sirviendo archivos desde `/opt/dash` con `busybox httpd`.
 
 ## Requisitos
 
@@ -17,10 +17,10 @@ npm run build
 
 `npm run dev` levanta el servidor de desarrollo de Vite en `http://localhost:5173`.
 
-## Despliegue en Raspberry Pi
+## Despliegue en mini PC
 
 1. Ejecuta `npm run build`. El artefacto se generará en `dist/`.
-2. Copia el contenido de `dist/` a `/opt/dash` en la Raspberry Pi (por ejemplo con `rsync` o `scp`).
+2. Copia el contenido de `dist/` a `/opt/dash` en el mini PC (por ejemplo con `rsync` o `scp`).
 3. Sirve la UI con Busybox:
 
    ```bash
@@ -37,7 +37,7 @@ npm run build
 
 ## Power Save
 
-Activa el modo de ahorro ajustando `powerSave` a `true` en `src/services/config.ts`. Esto reduce las animaciones, elimina filtros pesados y prioriza la estabilidad en Raspberry Pi 4.
+Activa el modo de ahorro ajustando `powerSave` a `true` en `src/services/config.ts`. Esto reduce las animaciones, elimina filtros pesados y prioriza la estabilidad en hardware de bajos recursos.
 
 ## Integración con backend
 

--- a/docs/DEPLOY_BACKEND.md
+++ b/docs/DEPLOY_BACKEND.md
@@ -1,7 +1,7 @@
 # Guía de despliegue – Backend Pantalla 8.8"
 
 Pasos para dejar operativo el backend FastAPI (clima AEMET, Wi-Fi, setup web) en
-una Raspberry Pi o equipo Linux con NetworkManager.
+un mini PC con Linux y NetworkManager.
 
 ## 1. Usuario y permisos
 

--- a/docs/google-calendar.md
+++ b/docs/google-calendar.md
@@ -2,7 +2,7 @@
 
 Esta guía cubre cómo habilitar el proveedor **Google** para el widget de calendario.
 El backend utiliza el flujo OAuth 2.0 *Device Authorization Grant* para evitar que
-la Raspberry Pi tenga que iniciar sesión en un navegador tradicional.
+el mini PC tenga que iniciar sesión en un navegador tradicional.
 
 ## 1. Crear credenciales en Google Cloud
 
@@ -32,7 +32,7 @@ Añade la sección `google` (o edítala desde `/#/config` → pestaña **Credenc
 
 ## 3. Seleccionar proveedor desde la UI
 
-1. Abre la pantalla de configuración en la Raspberry (`/#/config`).
+1. Abre la pantalla de configuración en el mini PC (`/#/config`).
 2. En la tarjeta **Calendario** elige **Google** como proveedor.
 3. Si las credenciales son válidas aparecerá el botón **Conectar con Google**.
 


### PR DESCRIPTION
## Summary
- actualiza la documentación principal para indicar que el despliegue se realiza en un mini PC con Linux
- ajusta las guías de backend y Google Calendar para referirse al mini PC en lugar de Raspberry Pi
- sincroniza la guía del frontend con la nueva plataforma objetivo y matiza el modo de ahorro

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f9ccce780c83268e7f21b3629de3d5