### PR TITLE
Adjust default Wi-Fi interface to wlan2

### DIFF
--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -16,7 +16,7 @@
     "city": "Vila-real"
   },
   "wifi": {
-    "preferredInterface": "wlan0"
+    "preferredInterface": "wlan2"
   },
   "theme": {
     "current": "cyberpunkNeon"

--- a/backend/config/config.json
+++ b/backend/config/config.json
@@ -15,7 +15,7 @@
     "city": "Vila-real"
   },
   "wifi": {
-    "preferredInterface": "wlan0"
+    "preferredInterface": "wlan2"
   },
   "theme": {
     "current": "cyberpunkNeon"

--- a/docs/DEPLOY_BACKEND.md
+++ b/docs/DEPLOY_BACKEND.md
@@ -101,7 +101,7 @@ sudo mkdir -p /etc/systemd/system/pantalla-bg-generate.timer.d
 Opcional: crea `/etc/pantalla-dash/ap.conf` para fijar interfaz del hotspot:
 
 ```
-PREFERRED_IFACE=wlan0
+PREFERRED_IFACE=wlan2
 ```
 
 Recarga y habilita servicios:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -364,7 +364,7 @@ cat > "$ENV_DIR/config.json" <<JSON
   },
   "weather": { "units": "metric", "city": "${CITY_NAME}" },
   "storm": { "threshold": 0.6, "enableExperimentalLightning": false },
-  "wifi": { "preferredInterface": "wlan0" },
+  "wifi": { "preferredInterface": "wlan2" },
   "background": { "intervalMinutes": 60, "mode": "daily", "retainDays": 7 },
   "locale": { "country": "ES", "autonomousCommunity": "Comunitat Valenciana", "province": "Castellón", "city": "${CITY_NAME}" }
 }


### PR DESCRIPTION
## Summary
- update configuration defaults to reference the wlan2 interface
- align deployment docs and installer script with the new Wi-Fi interface value

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fa047c6f008326b82bea3dd80d894d