### PR TITLE
Serve auto backgrounds as WebP

### DIFF
--- a/etc/nginx/sites-available/pantalla
+++ b/etc/nginx/sites-available/pantalla
@@ -16,11 +16,13 @@ server {
 
   location /assets/backgrounds/auto/ {
     alias /opt/dash/assets/backgrounds/auto/;
+    types { image/webp webp; }
     access_log off;
   }
 
   location /backgrounds/auto/ {
     alias /opt/dash/assets/backgrounds/auto/;
+    types { image/webp webp; }
     access_log off;
   }
 


### PR DESCRIPTION
## Summary
- ensure the existing auto backgrounds aliases explicitly serve WebP assets
- keep the /backgrounds/auto/ alias in sync with /assets/backgrounds/auto/

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fa1fab9a9883268289112e46a2682a