### PR TITLE
Ensure background fallback resiliency and lighten overlays

### DIFF
--- a/dash-ui/src/components/DayStrip.tsx
+++ b/dash-ui/src/components/DayStrip.tsx
@@ -72,7 +72,7 @@ const DayStrip = () => {
 
   return (
     <aside
-      className="relative rounded-3xl border border-sky-400/20 bg-slate-900/60 px-5 py-4 text-sky-100/80 shadow-lg backdrop-blur"
+      className="relative rounded-3xl border border-sky-400/20 bg-slate-900/30 px-5 py-4 text-sky-100/80 shadow-lg backdrop-blur"
       data-depth-blur="true"
     >
       <button
@@ -99,7 +99,7 @@ const DayStrip = () => {
       </button>
 
       {open && info && (
-        <div className="absolute left-0 right-0 top-full z-20 mt-3 rounded-2xl border border-sky-400/30 bg-slate-950/90 p-5 text-sky-50 shadow-xl backdrop-blur">
+        <div className="absolute left-0 right-0 top-full z-20 mt-3 rounded-2xl border border-sky-400/30 bg-slate-950/35 p-5 text-sky-50 shadow-xl backdrop-blur">
           <h3 className="text-xs uppercase tracking-[0.4em] text-sky-300/70">{formatDate(info.date)}</h3>
           <div className="mt-3 space-y-4 text-sm text-sky-100/90">
             {info.efemerides.length > 0 && (

--- a/dash-ui/src/components/DynamicBackground.tsx
+++ b/dash-ui/src/components/DynamicBackground.tsx
@@ -1,5 +1,5 @@
 import { motion, AnimatePresence } from 'framer-motion';
-import { useBackgroundCycle } from '../hooks/useBackgroundCycle';
+import { buildVersionedSrc, useBackgroundCycle } from '../hooks/useBackgroundCycle';
 import { ENABLE_WEBGL } from '../utils/runtimeFlags';
 
 interface DynamicBackgroundProps {
@@ -9,37 +9,38 @@ interface DynamicBackgroundProps {
 const DynamicBackground = ({ refreshMinutes }: DynamicBackgroundProps) => {
   const { current, previous, cycleKey, isCrossfading } = useBackgroundCycle(refreshMinutes);
 
+  const currentSrc = current ? buildVersionedSrc(current) : '';
+  const previousSrc = previous ? buildVersionedSrc(previous) : '';
+
   return (
-    <div className="pointer-events-none absolute inset-0 overflow-hidden">
+    <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
       <AnimatePresence mode="sync">
-        {previous && (
-          <motion.div
-            key={`prev-${previous.generatedAt}`}
-            className="absolute inset-0 fade-layer"
+        {previous && previousSrc && (
+          <motion.img
+            key={`prev-${previous.generatedAt}-${previous.etag ?? 'none'}`}
+            className="fixed inset-0 h-full w-full object-cover fade-layer"
+            src={previousSrc}
+            alt=""
+            aria-hidden
             initial={{ opacity: 1 }}
             animate={{ opacity: 0 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 1.2, ease: 'easeInOut' }}
-            style={{
-              backgroundImage: `url(${previous.url})`,
-              backgroundSize: 'cover',
-              backgroundPosition: 'center',
-              filter: 'saturate(110%) contrast(105%)',
-            }}
+            style={{ filter: 'saturate(110%) contrast(105%)' }}
           />
         )}
-        {current.url && (
-          <motion.div
-            key={`current-${cycleKey}`}
-            className="absolute inset-0 fade-layer"
+        {currentSrc && (
+          <motion.img
+            key={`current-${cycleKey}-${current.etag ?? current.generatedAt}`}
+            className="fixed inset-0 h-full w-full object-cover fade-layer"
+            src={currentSrc}
+            alt=""
+            aria-hidden
             initial={{ opacity: isCrossfading ? 0 : 1 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 1.2, ease: 'easeInOut' }}
             style={{
-              backgroundImage: `url(${current.url})`,
-              backgroundSize: 'cover',
-              backgroundPosition: 'center',
               filter: ENABLE_WEBGL ? 'saturate(118%) contrast(110%)' : 'saturate(110%) contrast(105%)',
             }}
           />

--- a/dash-ui/src/components/FpsMeter.tsx
+++ b/dash-ui/src/components/FpsMeter.tsx
@@ -45,7 +45,7 @@ const FpsMeter = () => {
   }
 
   return (
-    <div className="pointer-events-none fixed bottom-4 right-6 z-40 select-none rounded-xl border border-cyan-400/30 bg-black/60 px-4 py-2 text-xs font-mono text-cyan-200/80 shadow-lg">
+    <div className="pointer-events-none fixed bottom-4 right-6 z-40 select-none rounded-xl border border-cyan-400/30 bg-black/30 px-4 py-2 text-xs font-mono text-cyan-200/80 shadow-lg">
       <span>FPS {fps.toFixed(1)}</span>
     </div>
   );

--- a/dash-ui/src/components/MonthTips.tsx
+++ b/dash-ui/src/components/MonthTips.tsx
@@ -121,7 +121,7 @@ const MonthTips = () => {
   return (
     <section
       ref={containerRef}
-      className="relative rounded-3xl bg-slate-900/40 p-4 text-sm text-slate-100/80 shadow-lg backdrop-blur"
+      className="relative rounded-3xl bg-slate-900/30 p-4 text-sm text-slate-100/80 shadow-lg backdrop-blur"
       data-depth-blur="true"
     >
       <header className="flex items-start justify-between gap-3">
@@ -143,7 +143,7 @@ const MonthTips = () => {
             aria-expanded={popoverOpen}
             aria-controls="month-tips-popover"
             onClick={() => setPopoverOpen((value) => !value)}
-            className="rounded-full border border-slate-500/40 bg-slate-900/60 px-2 py-1 text-xs text-slate-200/90 transition hover:bg-slate-800/80"
+            className="rounded-full border border-slate-500/40 bg-slate-900/30 px-2 py-1 text-xs text-slate-200/90 transition hover:bg-slate-800/60"
           >
             ℹ︎
           </button>
@@ -155,7 +155,7 @@ const MonthTips = () => {
           id="month-tips-popover"
           role="dialog"
           aria-modal="false"
-          className="absolute right-4 top-full z-20 mt-3 w-72 rounded-2xl border border-slate-500/30 bg-slate-900/95 p-4 text-xs text-slate-100 shadow-2xl backdrop-blur"
+          className="absolute right-4 top-full z-20 mt-3 w-72 rounded-2xl border border-slate-500/30 bg-slate-900/35 p-4 text-xs text-slate-100 shadow-2xl backdrop-blur"
         >
           <div className="space-y-4">
             <div>
@@ -189,7 +189,7 @@ const MonthTips = () => {
               )}
             </div>
             {season.nota && (
-              <p className="rounded-2xl border border-slate-500/20 bg-slate-800/60 p-3 text-[0.75rem] leading-relaxed text-slate-100/80">
+              <p className="rounded-2xl border border-slate-500/20 bg-slate-800/30 p-3 text-[0.75rem] leading-relaxed text-slate-100/80">
                 {season.nota}
               </p>
             )}

--- a/dash-ui/src/components/StatusBar.tsx
+++ b/dash-ui/src/components/StatusBar.tsx
@@ -49,7 +49,7 @@ const StatusBar = () => {
 
   return (
     <header
-      className="relative flex items-center justify-between rounded-3xl bg-black/40 px-6 py-4 text-xs uppercase tracking-[0.35em] text-slate-100/80 backdrop-blur"
+      className="relative flex items-center justify-between rounded-3xl bg-black/30 px-6 py-4 text-xs uppercase tracking-[0.35em] text-slate-100/80 backdrop-blur"
       data-depth-blur="true"
     >
       <div className="flex items-center gap-4 text-shadow-soft">

--- a/dash-ui/src/components/Weather.tsx
+++ b/dash-ui/src/components/Weather.tsx
@@ -69,7 +69,7 @@ const Weather = () => {
 
   return (
     <section
-      className="flex h-full w-full flex-col rounded-3xl bg-slate-900/40 p-8 text-shadow-soft backdrop-blur"
+      className="flex h-full w-full flex-col rounded-3xl bg-slate-900/30 p-8 text-shadow-soft backdrop-blur"
       data-depth-blur="true"
     >
       <header className="flex items-center justify-between gap-4">

--- a/dash-ui/src/components/WeatherBrief.tsx
+++ b/dash-ui/src/components/WeatherBrief.tsx
@@ -64,7 +64,7 @@ const WeatherBrief = () => {
 
   return (
     <aside
-      className="rounded-3xl border border-cyan-400/20 bg-slate-900/60 px-5 py-4 text-cyan-100/80 shadow-lg backdrop-blur"
+      className="rounded-3xl border border-cyan-400/20 bg-slate-900/30 px-5 py-4 text-cyan-100/80 shadow-lg backdrop-blur"
       data-depth-blur="true"
     >
       <button

--- a/dash-ui/src/pages/Settings.tsx
+++ b/dash-ui/src/pages/Settings.tsx
@@ -476,7 +476,7 @@ const Settings = () => {
               </div>
               {wifiMessage && <p className="text-xs text-white/70">{wifiMessage}</p>}
               {wifiRaw && (
-                <pre className="max-h-32 overflow-y-auto rounded-2xl bg-black/40 px-3 py-2 text-[11px] text-white/50">
+                <pre className="max-h-32 overflow-y-auto rounded-2xl bg-black/25 px-3 py-2 text-[11px] text-white/50">
                   {wifiRaw}
                 </pre>
               )}
@@ -484,7 +484,7 @@ const Settings = () => {
           </section>
         </div>
         {loading && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/40 text-white">
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/25 text-white">
             Cargando ajustes...
           </div>
         )}

--- a/dash-ui/src/styles/globals.css
+++ b/dash-ui/src/styles/globals.css
@@ -104,13 +104,13 @@ body.power-save {
 }
 
 .glass {
-  background: rgba(12, 17, 28, 0.55);
+  background: rgba(12, 17, 28, 0.32); /* reduced opacity for background visibility */
 }
 
 .glass-light {
-  background: rgba(255, 255, 255, 0.22);
-  border-color: rgba(255, 255, 255, 0.35);
-  box-shadow: 0 14px 40px rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.28); /* reduced opacity for background visibility */
+  border-color: rgba(255, 255, 255, 0.32);
+  box-shadow: 0 14px 40px rgba(148, 163, 184, 0.28);
 }
 
 .glass-surface {
@@ -124,7 +124,7 @@ body.power-save {
   inset: 0;
   pointer-events: none;
   background: linear-gradient(120deg, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0.08) 45%, rgba(255, 255, 255, 0) 100%);
-  opacity: 0.18;
+  opacity: 0.11; /* reduced opacity for background visibility */
   mix-blend-mode: screen;
 }
 

--- a/opt/dash/scripts/check_backgrounds.sh
+++ b/opt/dash/scripts/check_backgrounds.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+set -uo pipefail
+
+API_URL="http://127.0.0.1/api/backgrounds/current"
+ASSETS_DIR="/opt/dash/assets/backgrounds/auto"
+LOG_PATH="/var/log/pantalla-dash/bg.log"
+NGINX_URL_PREFIX="http://127.0.0.1"
+BACKEND_URL_PREFIX="http://127.0.0.1:8081"
+MIN_BYTES=50000
+
+failures=()
+outputs=()
+
+run_maybe_sudo() {
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+record_failure() {
+  failures+=("$1")
+}
+
+append_output() {
+  outputs+=("$1")
+}
+
+api_response="$(curl -fsS "$API_URL" || true)"
+if [[ -z "$api_response" ]]; then
+  record_failure "API sin respuesta"
+else
+  append_output "API response: $api_response"
+fi
+
+background_url="$(python3 - <<'PY'
+import json,sys
+try:
+    payload=json.loads(sys.stdin.read())
+except Exception:
+    print("", end="")
+    sys.exit(0)
+url=payload.get("url") if isinstance(payload, dict) else None
+print(url or "", end="")
+PY
+<<<"$api_response")"
+
+if [[ -z "$background_url" ]]; then
+  record_failure "JSON sin campo url"
+fi
+
+strip_query="${background_url%%\?*}"
+filename="${strip_query##*/}"
+if [[ -z "$filename" ]]; then
+  record_failure "No se pudo obtener nombre de archivo"
+fi
+
+check_headers() {
+  local label="$1"
+  local url="$2"
+  local headers
+  headers="$(curl -fsSI "$url" || true)"
+  if [[ -z "$headers" ]]; then
+    record_failure "${label}: sin respuesta"
+    return
+  fi
+  local status
+  status="$(printf '%s' "$headers" | head -n1)"
+  if [[ "$status" != *"200"* ]]; then
+    record_failure "${label}: estado inesperado -> $status"
+  fi
+  local ctype
+  ctype="$(printf '%s' "$headers" | awk 'BEGIN{IGNORECASE=1}/^Content-Type:/ {print tolower($0)}' | tail -n1)"
+  if [[ "$ctype" != *"image/webp"* ]]; then
+    record_failure "${label}: Content-Type inesperado ($ctype)"
+  fi
+  local clen
+  clen="$(printf '%s' "$headers" | awk 'BEGIN{IGNORECASE=1}/^Content-Length:/ {print $2}' | tail -n1)"
+  if [[ -z "$clen" || "$clen" -le $MIN_BYTES ]]; then
+    record_failure "${label}: Content-Length <= $MIN_BYTES"
+  fi
+  append_output "${label} headers:\n$headers"
+}
+
+if [[ -n "$background_url" ]]; then
+  check_headers "nginx" "$NGINX_URL_PREFIX$background_url"
+  check_headers "backend" "$BACKEND_URL_PREFIX$background_url"
+fi
+
+if [[ -n "$filename" ]]; then
+  full_path="$ASSETS_DIR/$filename"
+  if [[ -f "$full_path" ]]; then
+    size="$(stat -c %s "$full_path")"
+    mtime="$(stat -c %y "$full_path")"
+    if [[ "$size" -le $MIN_BYTES ]]; then
+      record_failure "Archivo $filename demasiado pequeño ($size bytes)"
+    fi
+    append_output "Archivo: $full_path ($size bytes, mtime $mtime)"
+  else
+    record_failure "Archivo $full_path no encontrado"
+  fi
+fi
+
+log_tail="$(run_maybe_sudo tail -n 40 "$LOG_PATH" 2>/dev/null || true)"
+if [[ -n "$log_tail" ]]; then
+  if printf '%s' "$log_tail" | grep -E "ERROR|Traceback" >/dev/null 2>&1; then
+    record_failure "Log contiene errores recientes"
+  fi
+  append_output "Log tail:\n$log_tail"
+else
+  record_failure "No se pudo leer $LOG_PATH"
+fi
+
+nginx_locations="$(run_maybe_sudo nginx -T 2>/dev/null | grep -n "location /backgrounds/auto/" || true)"
+if [[ -z "$nginx_locations" ]]; then
+  record_failure "Bloques location /backgrounds/auto/ no encontrados"
+else
+  append_output "Nginx locations:\n$nginx_locations"
+fi
+
+css_report="$(python3 - <<'PY'
+import glob
+import json
+import re
+from pathlib import Path
+
+paths = glob.glob('/var/www/html/assets/*.css')
+results = []
+pattern = re.compile(r'rgba\([^)]*?([01]?(?:\.\d+)?)\)')
+targets = {'glass', 'glass-light', 'glass-surface::after'}
+for css_path in paths:
+    text = Path(css_path).read_text(encoding='utf-8', errors='ignore')
+    for selector in targets:
+        for match in re.finditer(rf'{re.escape(selector)}[^{{]*{{([^}}]+)}}', text, re.MULTILINE | re.DOTALL):
+            section = match.group(1)
+            alphas = [float(a) for a in re.findall(r'rgba\([^,]+,[^,]+,[^,]+,\s*([0-9.]+)\)', section)]
+            if not alphas:
+                continue
+            max_alpha = max(alphas)
+            limit = 0.35 if selector != 'glass-surface::after' else 0.12
+            if max_alpha > limit + 1e-6:
+                results.append({'file': css_path, 'selector': selector, 'max_alpha': max_alpha, 'limit': limit})
+
+print(json.dumps(results))
+PY
+)"
+if [[ "$css_report" != "[]" ]]; then
+  record_failure "CSS con alpha fuera de rango: $css_report"
+else
+  append_output "CSS overlay transparency verificada"
+fi
+
+if [[ ${#outputs[@]} -gt 0 ]]; then
+  printf '%s\n\n' "${outputs[@]}"
+fi
+
+if [[ ${#failures[@]} -gt 0 ]]; then
+  printf 'Resultado: FAIL\n' >&2
+  printf '%s\n' "${failures[@]}" >&2
+  exit 1
+else
+  printf 'Resultado: OK\n'
+fi


### PR DESCRIPTION
## Summary
- harden the daily background generator with fallback webp creation, latest.json validation, and a --force flag
- add an idempotent background verification script for post-deploy checks
- reduce glass/overlay opacity and ensure background images cache-bust in the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa5b8f99688326ae38924f9e7f578d