### PR TITLE
Preserve background URL query params when appending cache buster

### DIFF
--- a/dash-ui/src/hooks/useBackgroundCycle.ts
+++ b/dash-ui/src/hooks/useBackgroundCycle.ts
@@ -173,13 +173,16 @@ export function useBackgroundCycle(refreshMinutes = DEFAULT_REFRESH_MINUTES): Ba
 }
 
 export function buildVersionedSrc(slot: BackgroundSlot): string {
-  const base = slot.url.split('?')[0];
   const version = slot.etag ?? slot.generatedAt;
   if (!version) {
-    return base;
+    return slot.url;
   }
-  const separator = slot.url.includes('?') ? '&' : '?';
-  return `${base}${separator}v=${encodeURIComponent(String(version))}`;
+  const hashIndex = slot.url.indexOf('#');
+  const hash = hashIndex >= 0 ? slot.url.slice(hashIndex) : '';
+  const base = hashIndex >= 0 ? slot.url.slice(0, hashIndex) : slot.url;
+  const separator = base.includes('?') ? '&' : '?';
+  const versioned = `${base}${separator}v=${encodeURIComponent(String(version))}`;
+  return `${versioned}${hash}`;
 }
 
 async function preloadImage(slot: BackgroundSlot): Promise<void> {


### PR DESCRIPTION
## Summary
- preserve existing query parameters when appending cache-busting version info to background URLs
- ensure hash fragments are retained alongside the new version parameter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fa5f841ca08326b54d4f65d29165b3