### PR TITLE
Make UI glass surfaces fully transparent

### DIFF
--- a/dash-ui/index.html
+++ b/dash-ui/index.html
@@ -11,7 +11,7 @@
       rel="stylesheet"
     />
   </head>
-  <body class="bg-black">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/dash-ui/src/components/DynamicBackground.tsx
+++ b/dash-ui/src/components/DynamicBackground.tsx
@@ -46,8 +46,6 @@ const DynamicBackground = ({ refreshMinutes }: DynamicBackgroundProps) => {
           />
         )}
       </AnimatePresence>
-      <div className="absolute inset-0 bg-gradient-to-br from-black/15 via-black/10 to-black/25" aria-hidden />
-      <div className="absolute inset-0" style={{ background: 'radial-gradient(circle at 20% 20%, rgba(56, 249, 255, 0.18), transparent 55%)' }} aria-hidden />
     </div>
   );
 };

--- a/dash-ui/src/components/GlassPanel.tsx
+++ b/dash-ui/src/components/GlassPanel.tsx
@@ -6,7 +6,7 @@ interface GlassPanelProps extends PropsWithChildren {
 
 const GlassPanel = ({ children, className }: GlassPanelProps) => (
   <div
-    className={`glass-panel flex h-full w-full flex-col gap-4 rounded-[28px] border border-white/15 bg-[rgba(14,18,28,0.22)] p-8 text-white shadow-[0_20px_45px_rgba(0,0,0,0.35)] backdrop-blur-lg backdrop-brightness-[0.95] ${className ?? ''}`}
+    className={`glass-panel flex h-full w-full flex-col gap-4 rounded-[28px] border border-white/15 bg-transparent p-8 text-white ${className ?? ''}`}
   >
     {children}
   </div>

--- a/dash-ui/src/components/Layout.tsx
+++ b/dash-ui/src/components/Layout.tsx
@@ -11,14 +11,13 @@ interface LayoutProps {
 
 const Layout = ({ theme, powerSave, children, header, footer }: LayoutProps) => {
   const decorationClass = theme.decorations.className;
-  const overlayClass = theme.decorations.overlay;
   const glassClass = theme.glassTone === 'light' ? 'glass-light' : 'glass';
 
   return (
-    <div className={`relative min-h-screen w-full overflow-hidden ${powerSave ? 'power-save' : ''}`}
+    <div
+      className={`relative min-h-screen w-full overflow-hidden ${powerSave ? 'power-save' : ''}`}
       style={{ color: theme.text }}
     >
-      <div className="absolute inset-0 bg-neutral-950" aria-hidden />
       {header && (
         <header
           className={`relative z-20 mx-auto mt-6 flex w-full max-w-5xl items-center justify-between gap-6 rounded-[24px] px-6 py-4 text-sm uppercase tracking-[0.2em] glass-surface ${glassClass}`}
@@ -31,7 +30,6 @@ const Layout = ({ theme, powerSave, children, header, footer }: LayoutProps) => 
         <div
           className={`glass-surface relative mx-auto flex w-full max-w-5xl flex-1 flex-col items-center justify-center gap-8 px-8 py-10 reduced-motion ${glassClass} ${decorationClass}`}
         >
-          {overlayClass && <div className={`pointer-events-none absolute inset-0 ${overlayClass}`} aria-hidden />}
           <div className="relative z-10 flex w-full flex-col items-center gap-8">{children}</div>
         </div>
       </main>

--- a/dash-ui/src/styles/globals.css
+++ b/dash-ui/src/styles/globals.css
@@ -6,6 +6,12 @@
   color-scheme: dark;
 }
 
+:root,
+body,
+#root {
+  --dash-text-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+}
+
 html,
 body,
 #root {
@@ -14,16 +20,33 @@ body,
   overflow: hidden;
 }
 
+html,
+body,
+#root,
+.app-root {
+  background: transparent !important;
+}
+
 body {
-  @apply bg-black text-white font-sans h-screen w-screen overflow-hidden antialiased;
+  @apply font-sans h-screen w-screen overflow-hidden antialiased;
+  color: inherit;
 }
 
 .text-shadow-soft {
-  text-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+  text-shadow: var(--dash-text-shadow);
 }
 
 .text-shadow-strong {
   text-shadow: 0 12px 32px rgba(0, 0, 0, 0.7);
+}
+
+.card *,
+.panel *,
+.widget *,
+.glass *,
+.glass-light *,
+.glass-panel * {
+  text-shadow: var(--dash-text-shadow);
 }
 
 .theme-cyberpunkNeon {
@@ -48,29 +71,11 @@ body {
   color-scheme: light;
 }
 
-.theme-crtRetro .crt-overlay::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: repeating-linear-gradient(
-      to bottom,
-      rgba(138, 255, 122, 0.15) 0,
-      rgba(138, 255, 122, 0.15) 2px,
-      transparent 2px,
-      transparent 4px
-    ),
-    radial-gradient(circle at center, transparent 50%, rgba(0, 0, 0, 0.35) 100%);
-  mix-blend-mode: screen;
-}
-
+.theme-crtRetro .crt-overlay::after,
 .theme-crtRetro .crt-overlay::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: rgba(0, 0, 0, 0.2);
-  mix-blend-mode: multiply;
+  content: none !important;
+  background: none !important;
+  mix-blend-mode: normal !important;
 }
 
 .theme-cyberpunkNeon .neon-glow {
@@ -90,27 +95,19 @@ body {
 }
 
 body.power-save {
-  @apply bg-neutral-950 text-neutral-100;
+  @apply text-neutral-100;
+  background: transparent !important;
 }
 
 .glass,
 .glass-light {
   border-radius: 1.5rem;
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
   transition: background 0.6s ease, border-color 0.6s ease, box-shadow 0.6s ease;
+  background: transparent !important;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.35);
-}
-
-.glass {
-  background: rgba(12, 17, 28, 0.32); /* reduced opacity for background visibility */
-}
-
-.glass-light {
-  background: rgba(255, 255, 255, 0.28); /* reduced opacity for background visibility */
-  border-color: rgba(255, 255, 255, 0.32);
-  box-shadow: 0 14px 40px rgba(148, 163, 184, 0.28);
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
 }
 
 .glass-surface {
@@ -119,24 +116,16 @@ body.power-save {
 }
 
 .glass-surface::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0.08) 45%, rgba(255, 255, 255, 0) 100%);
-  opacity: 0.11; /* reduced opacity for background visibility */
-  mix-blend-mode: screen;
+  content: none !important;
+  background: none !important;
+  opacity: 0 !important;
 }
 
 .theme-lightMinimal .glass {
-  background: rgba(255, 255, 255, 0.24);
+  background: transparent !important;
   border-color: rgba(148, 163, 184, 0.35);
-  box-shadow: 0 16px 42px rgba(15, 23, 42, 0.18);
+  box-shadow: none !important;
   color: #0f172a;
-}
-
-.theme-lightMinimal .glass::after {
-  mix-blend-mode: normal;
 }
 
 .glass input,
@@ -187,21 +176,18 @@ body.power-save {
 }
 
 .with-depth-blur [data-depth-blur='true'] {
-  backdrop-filter: blur(22px) saturate(140%);
-  -webkit-backdrop-filter: blur(22px) saturate(140%);
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
   position: relative;
   overflow: hidden;
 }
 
 .with-depth-blur [data-depth-blur='true']::before {
-  content: '';
-  position: absolute;
-  inset: -20%;
-  background: radial-gradient(circle at 30% 20%, rgba(255, 255, 255, 0.08), transparent 60%),
-    linear-gradient(140deg, rgba(56, 249, 255, 0.08), transparent 40%);
-  opacity: 0.55;
+  content: none !important;
+  background: none !important;
+  opacity: 0 !important;
   pointer-events: none;
-  mix-blend-mode: screen;
+  mix-blend-mode: normal !important;
 }
 
 .marquee-container {

--- a/dash-ui/src/styles/theme.ts
+++ b/dash-ui/src/styles/theme.ts
@@ -11,7 +11,6 @@ export interface ThemeDefinition {
   muted: string;
   decorations: {
     className: string;
-    overlay?: string;
   };
   glassTone: 'light' | 'dark';
 }
@@ -27,8 +26,7 @@ export const THEMES: ThemeDefinition[] = [
     text: 'var(--text-primary)',
     muted: 'rgba(148, 163, 184, 0.75)',
     decorations: {
-      className: 'neon-glow',
-      overlay: 'rounded-[32px] bg-cyan-400/10 blur-3xl'
+      className: 'neon-glow'
     },
     glassTone: 'dark'
   },
@@ -42,8 +40,7 @@ export const THEMES: ThemeDefinition[] = [
     text: 'var(--text-primary)',
     muted: 'rgba(203, 213, 225, 0.75)',
     decorations: {
-      className: 'crt-overlay',
-      overlay: 'rounded-[32px] bg-emerald-400/8 mix-blend-color-dodge'
+      className: 'crt-overlay'
     },
     glassTone: 'dark'
   },
@@ -57,8 +54,7 @@ export const THEMES: ThemeDefinition[] = [
     text: 'var(--text-primary)',
     muted: 'rgba(51, 65, 85, 0.7)',
     decorations: {
-      className: 'shadow-lg shadow-slate-200/40',
-      overlay: 'rounded-[32px] bg-white/60 backdrop-blur-lg mix-blend-luminosity'
+      className: 'shadow-lg shadow-slate-200/40'
     },
     glassTone: 'light'
   }


### PR DESCRIPTION
## Summary
- remove page-level backdrops while centralizing a shared text-shadow token for readability
- strip glass-related components and themes of gradient overlays and blur effects to make panels transparent
- drop extra background layers from the animated background so the wallpaper shows through unobstructed

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fa5e6433e88326b1ff3a35c6dbf834