### PR TITLE
Add Blitzortung lightning ingestion and radar overlay

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ requests>=2.32.0
 Pillow==10.2.0
 Jinja2==3.1.3
 feedparser>=6.0.11
+paho-mqtt>=2.0.0

--- a/backend/services/blitzortung_store.py
+++ b/backend/services/blitzortung_store.py
@@ -1,0 +1,53 @@
+"""In-memory store for Blitzortung lightning strikes."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from threading import Lock
+from time import time
+from typing import Deque, List, Optional, Tuple
+
+
+@dataclass
+class Strike:
+    """Represents a lightning strike."""
+
+    lat: float
+    lon: float
+    ts: float  # epoch seconds
+
+
+class BlitzStore:
+    """Thread-safe store with TTL-based eviction for lightning strikes."""
+
+    def __init__(self, ttl_seconds: int = 1800, max_len: int = 2000) -> None:
+        self.ttl = ttl_seconds
+        self.max_len = max_len
+        self._queue: Deque[Strike] = deque(maxlen=max_len)
+        self._lock = Lock()
+
+    def add(self, lat: float, lon: float, ts: Optional[float] = None) -> None:
+        """Append a strike and evict stale entries."""
+
+        timestamp = ts or time()
+        with self._lock:
+            self._queue.append(Strike(lat, lon, timestamp))
+            self._gc_locked()
+
+    def recent(self) -> List[Tuple[float, float]]:
+        """Return recent strikes as (lat, lon) pairs, pruning stale entries."""
+
+        with self._lock:
+            self._gc_locked()
+            return [(strike.lat, strike.lon) for strike in self._queue]
+
+    def _gc_locked(self) -> None:
+        cutoff = time() - self.ttl
+        while self._queue and self._queue[0].ts < cutoff:
+            self._queue.popleft()
+
+    def clear(self) -> None:
+        """Clear all stored strikes."""
+
+        with self._lock:
+            self._queue.clear()

--- a/backend/services/mqtt_client.py
+++ b/backend/services/mqtt_client.py
@@ -1,0 +1,189 @@
+"""Simple MQTT client wrapper for Blitzortung lightning events."""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from typing import Callable, Optional
+
+try:  # pragma: no cover - optional dependency
+    import paho.mqtt.client as mqtt
+except Exception:  # pragma: no cover - executed when dependency missing
+    mqtt = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_float(value) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_timestamp(value) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        ts = float(value)
+    except (TypeError, ValueError):
+        return None
+    if ts > 1e12:
+        ts /= 1000.0
+    return ts
+
+
+class MQTTClient:
+    """Background MQTT consumer that forwards Blitzortung strikes."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        topic_base: str,
+        on_strike: Callable[[float, float, Optional[float]], None],
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.topic_base = topic_base.rstrip("/") or "blitzortung/1.1"
+        self._topic = f"{self.topic_base}/#"
+        self._on_strike = on_strike
+        self._client: Optional["mqtt.Client"] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def is_supported() -> bool:
+        """Return ``True`` if paho-mqtt is available."""
+
+        return mqtt is not None
+
+    def matches(self, host: str, port: int, topic_base: str) -> bool:
+        return (
+            self.host == host
+            and self.port == port
+            and self.topic_base.rstrip("/") == topic_base.rstrip("/")
+        )
+
+    def start(self) -> None:
+        """Start the MQTT background loop if possible."""
+
+        if mqtt is None:
+            logger.warning("paho-mqtt no disponible; no se inicia el cliente MQTT")
+            return
+
+        with self._lock:
+            if self._thread and self._thread.is_alive():
+                return
+            self._stop.clear()
+            self._thread = threading.Thread(target=self._run, name="BlitzMQTT", daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the background loop and disconnect."""
+
+        with self._lock:
+            self._stop.set()
+            thread = self._thread
+            client = self._client
+        if thread and thread.is_alive():
+            thread.join(timeout=5)
+        if client is not None:
+            try:
+                client.disconnect()
+            except Exception:  # pragma: no cover - defensive
+                logger.debug("Error al desconectar MQTT", exc_info=True)
+        with self._lock:
+            self._thread = None
+            self._client = None
+
+    # Internal API -----------------------------------------------------
+    def _run(self) -> None:
+        if mqtt is None:
+            return
+        try:
+            callback_api_version = getattr(mqtt, "CallbackAPIVersion", None)
+            if callback_api_version is not None:
+                client = mqtt.Client(callback_api_version=callback_api_version.VERSION2)
+            else:  # pragma: no cover - legacy fallback
+                client = mqtt.Client()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("No se pudo crear cliente MQTT: %s", exc)
+            return
+
+        client.enable_logger(logger)
+        client.on_connect = self._on_connect  # type: ignore[assignment]
+        client.on_message = self._on_message  # type: ignore[assignment]
+        try:
+            client.connect(self.host, self.port, keepalive=30)
+        except Exception as exc:  # pragma: no cover - conexión fallida
+            logger.error("No se pudo conectar a MQTT %s:%s: %s", self.host, self.port, exc)
+            return
+
+        with self._lock:
+            self._client = client
+
+        while not self._stop.is_set():
+            try:
+                client.loop(timeout=1.0)
+            except Exception:  # pragma: no cover - defensivo
+                logger.debug("Error en loop MQTT", exc_info=True)
+                break
+
+        try:
+            client.disconnect()
+        except Exception:  # pragma: no cover - defensivo
+            logger.debug("Error al desconectar MQTT", exc_info=True)
+
+    # Callbacks --------------------------------------------------------
+    def _on_connect(self, client, userdata, flags, reason_code, properties=None):  # noqa: D401
+        del userdata, flags, reason_code, properties
+        try:
+            client.subscribe(self._topic, qos=0)
+        except Exception:  # pragma: no cover - defensivo
+            logger.debug("No se pudo suscribir a %s", self._topic, exc_info=True)
+
+    def _on_message(self, client, userdata, message):  # noqa: D401
+        del client, userdata
+        try:
+            payload = message.payload.decode("utf-8", "ignore")
+            data = json.loads(payload)
+        except Exception:
+            logger.debug("Mensaje MQTT inválido en %s", message.topic, exc_info=True)
+            return
+
+        lat = self._extract_lat(data)
+        lon = self._extract_lon(data)
+        if lat is None or lon is None:
+            return
+        timestamp = self._extract_timestamp(data)
+        self._on_strike(lat, lon, timestamp)
+
+    # Parsing helpers --------------------------------------------------
+    @staticmethod
+    def _extract_lat(data) -> Optional[float]:
+        for key in ("lat", "latitude", "latitud"):
+            if key in data:
+                return _coerce_float(data[key])
+        position = data.get("position") if isinstance(data, dict) else None
+        if isinstance(position, dict):
+            return _coerce_float(position.get("lat"))
+        return None
+
+    @staticmethod
+    def _extract_lon(data) -> Optional[float]:
+        for key in ("lon", "longitude", "longitud"):
+            if key in data:
+                return _coerce_float(data[key])
+        position = data.get("position") if isinstance(data, dict) else None
+        if isinstance(position, dict):
+            return _coerce_float(position.get("lon"))
+        return None
+
+    @staticmethod
+    def _extract_timestamp(data) -> Optional[float]:
+        for key in ("time", "timestamp", "ts", "datetime"):
+            if key in data:
+                return _coerce_timestamp(data[key])
+        return None

--- a/dash-ui/src/components/StormOverlay.tsx
+++ b/dash-ui/src/components/StormOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { BACKEND_BASE_URL } from '../services/config';
 import { useStormStatus } from '../context/StormStatusContext';
@@ -7,12 +7,29 @@ import { fetchRadarAnimation, type RadarFrame } from '../services/storms';
 const FRAME_INTERVAL_MS = 650;
 const RADAR_REFRESH_MS = 5 * 60 * 1000;
 
+const GEO_BOUNDS = {
+  minLat: 27.0,
+  maxLat: 44.5,
+  minLon: -9.5,
+  maxLon: 4.5,
+};
+
 const StormOverlay = () => {
   const { status, error } = useStormStatus();
   const [frames, setFrames] = useState<RadarFrame[]>([]);
   const [frameIndex, setFrameIndex] = useState(0);
   const [radarError, setRadarError] = useState<string | null>(null);
   const backendBase = useMemo(() => BACKEND_BASE_URL.replace(/\/$/, ''), []);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [canvasSize, setCanvasSize] = useState<{ width: number; height: number }>({ width: 0, height: 0 });
+
+  const strikeCoords = useMemo(() => {
+    if (!status || status.provider !== 'blitzortung') {
+      return [];
+    }
+    return status.strikeCoords;
+  }, [status]);
 
   useEffect(() => {
     if (!status?.nearActivity) {
@@ -69,6 +86,63 @@ const StormOverlay = () => {
     return () => window.clearInterval(timer);
   }, [frames]);
 
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    if (typeof ResizeObserver === 'undefined') {
+      const update = () => {
+        setCanvasSize({ width: container.offsetWidth, height: container.offsetHeight });
+      };
+      update();
+      if (typeof window !== 'undefined') {
+        window.addEventListener('resize', update);
+        return () => {
+          window.removeEventListener('resize', update);
+        };
+      }
+      return undefined;
+    }
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const { width, height } = entry.contentRect;
+      setCanvasSize({ width, height });
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const { width, height } = canvasSize;
+    if (width <= 0 || height <= 0) {
+      canvas.width = 0;
+      canvas.height = 0;
+      return;
+    }
+    const dpr = typeof window !== 'undefined' && window.devicePixelRatio ? window.devicePixelRatio : 1;
+    const targetWidth = Math.round(width * dpr);
+    const targetHeight = Math.round(height * dpr);
+    if (canvas.width !== targetWidth || canvas.height !== targetHeight) {
+      canvas.width = targetWidth;
+      canvas.height = targetHeight;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+    }
+    const context = canvas.getContext('2d');
+    if (!context) {
+      return;
+    }
+    context.setTransform(1, 0, 0, 1, 0, 0);
+    context.clearRect(0, 0, canvas.width, canvas.height);
+    if (!strikeCoords.length) {
+      return;
+    }
+    context.scale(dpr, dpr);
+    drawLightningOverlay(context, width, height, strikeCoords);
+  }, [canvasSize, strikeCoords]);
+
   if (!status?.nearActivity) {
     return null;
   }
@@ -93,12 +167,15 @@ const StormOverlay = () => {
         </div>
       </div>
       {radarUrl ? (
-        <img
-          key={radarUrl}
-          src={radarUrl}
-          alt="Radar de precipitaciones"
-          className="mt-4 h-40 w-full rounded-2xl object-cover"
-        />
+        <div ref={containerRef} className="relative mt-4 h-40 w-full overflow-hidden rounded-2xl">
+          <img
+            key={radarUrl}
+            src={radarUrl}
+            alt="Radar de precipitaciones"
+            className="absolute inset-0 h-full w-full object-cover"
+          />
+          <canvas ref={canvasRef} className="pointer-events-none absolute inset-0" />
+        </div>
       ) : (
         <p className="mt-3 text-xs text-amber-100/70">{radarError ?? error ?? 'Sin radar disponible en este momento.'}</p>
       )}
@@ -125,6 +202,57 @@ async function preloadImage(url: string): Promise<void> {
     image.onerror = () => reject(new Error(`No se pudo precargar ${url}`));
     image.src = url;
   });
+}
+
+function drawLightningOverlay(
+  context: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  strikes: Array<[number, number]>,
+) {
+  context.save();
+  const radius = Math.max(4, Math.min(12, Math.min(width, height) * 0.02));
+  const cross = radius * 0.6;
+  context.lineWidth = Math.max(1, Math.min(2.5, width * 0.003));
+  context.strokeStyle = 'rgba(255, 255, 255, 0.9)';
+  context.fillStyle = 'rgba(255, 82, 82, 0.65)';
+  context.shadowColor = 'rgba(255, 51, 51, 0.5)';
+  context.shadowBlur = radius * 0.8;
+
+  for (const [lat, lon] of strikes) {
+    const point = projectToRadar(lat, lon, width, height);
+    if (!point) {
+      continue;
+    }
+    context.beginPath();
+    context.arc(point.x, point.y, radius, 0, Math.PI * 2);
+    context.fill();
+    context.beginPath();
+    context.moveTo(point.x - cross, point.y);
+    context.lineTo(point.x + cross, point.y);
+    context.moveTo(point.x, point.y - cross);
+    context.lineTo(point.x, point.y + cross);
+    context.stroke();
+  }
+
+  context.restore();
+}
+
+function projectToRadar(lat: number, lon: number, width: number, height: number) {
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return null;
+  }
+  const { minLat, maxLat, minLon, maxLon } = GEO_BOUNDS;
+  const latitude = clamp(lat, minLat, maxLat);
+  const longitude = clamp(lon, minLon, maxLon);
+  const x = ((longitude - minLon) / (maxLon - minLon)) * width;
+  const y = (1 - (latitude - minLat) / (maxLat - minLat)) * height;
+  // TODO(proj): ajustar los bounds al radar oficial utilizado por el panel.
+  return { x, y };
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
 }
 
 export default StormOverlay;

--- a/dash-ui/src/context/StormStatusContext.tsx
+++ b/dash-ui/src/context/StormStatusContext.tsx
@@ -8,7 +8,7 @@ interface StormStatusState {
 
 const StormStatusContext = createContext<StormStatusState | undefined>(undefined);
 
-const POLL_INTERVAL_MS = 5 * 60 * 1000;
+const POLL_INTERVAL_MS = 10_000;
 
 export function StormStatusProvider({ children }: { children: ReactNode }) {
   const [status, setStatus] = useState<StormStatus | null>(null);
@@ -17,7 +17,13 @@ export function StormStatusProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
     let timer: number | undefined;
 
+    let inFlight = false;
+
     const load = async () => {
+      if (inFlight) {
+        return;
+      }
+      inFlight = true;
       try {
         const data = await fetchStormStatus();
         if (!cancelled) {
@@ -28,6 +34,8 @@ export function StormStatusProvider({ children }: { children: ReactNode }) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Sin datos');
         }
+      } finally {
+        inFlight = false;
       }
     };
 

--- a/etc/pantalla-dash/config.json
+++ b/etc/pantalla-dash/config.json
@@ -2,6 +2,7 @@
   "backgroundMode": "daily",
   "retainDays": 30,
   "storm": {
+    "provider": "blitzortung",
     "enableExperimentalLightning": true,
     "threshold": 0.6,
     "nearKm": 15,
@@ -10,5 +11,9 @@
       "soundEnabled": false,
       "cooldownMinutes": 30
     }
+  },
+  "mqtt": {
+    "host": "127.0.0.1",
+    "port": 1883
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated Blitzortung strike store and MQTT client with FastAPI wiring so the backend exposes provider, counts, and coordinates via /api/storms/status
- extend the configuration schema and default config to support selecting the Blitzortung provider and a local MQTT broker endpoint
- render lightning strikes on the radar card with a canvas overlay and poll storm status every 10 seconds for fresh data

## Testing
- python -m compileall backend/services

------
https://chatgpt.com/codex/tasks/task_e_68fa60794910832689af681bb1c38bb3