### PR TITLE
Ensure background fallback and kiosk warm-up

### DIFF
--- a/dash-ui/src/styles/globals.css
+++ b/dash-ui/src/styles/globals.css
@@ -6,12 +6,6 @@
   color-scheme: dark;
 }
 
-:root,
-body,
-#root {
-  --dash-text-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
-}
-
 html,
 body,
 #root {
@@ -27,12 +21,19 @@ body,
   background: transparent !important;
 }
 
+:root {
+  --dash-text-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+}
+
 body {
   @apply font-sans h-screen w-screen overflow-hidden antialiased;
   color: inherit;
 }
 
-.text-shadow-soft {
+.text-shadow-soft,
+.card *,
+.panel *,
+.widget * {
   text-shadow: var(--dash-text-shadow);
 }
 
@@ -40,9 +41,6 @@ body {
   text-shadow: 0 12px 32px rgba(0, 0, 0, 0.7);
 }
 
-.card *,
-.panel *,
-.widget *,
 .glass *,
 .glass-light *,
 .glass-panel * {
@@ -99,6 +97,7 @@ body.power-save {
   background: transparent !important;
 }
 
+/* 100% transparente, sin blur/velo */
 .glass,
 .glass-light {
   border-radius: 1.5rem;


### PR DESCRIPTION
## Summary
- harden the daily background generator to validate allowed sizes, emit a branded fallback asset and bootstrap latest.json metadata
- make glass-based UI cards fully transparent with shared text shadow styling for readability
- extend the installer to cache-bust the compiled CSS, restart kiosk services, pre-warm backend endpoints and print validation diagnostics

## Testing
- python3 -m compileall opt/dash/scripts/generate_bg_daily.py

------
https://chatgpt.com/codex/tasks/task_e_68fa699869a88326b69653d7ab7ff930