### PR TITLE
feat(config): allow managing google oauth secrets

### DIFF
--- a/dash-ui/src/services/config.ts
+++ b/dash-ui/src/services/config.ts
@@ -137,6 +137,11 @@ export interface ConfigEnvelope {
 
 export interface SecretsPatch {
   openai?: { apiKey?: string | null };
+  google?: {
+    client_id?: string | null;
+    client_secret?: string | null;
+    refresh_token?: string | null;
+  };
 }
 
 export async function apiRequest<T>(path: string, init?: RequestInit): Promise<T> {


### PR DESCRIPTION
## Summary
- add UI fields to edit Google Calendar OAuth client ID and secret from the config screen
- extend secrets patch support in the frontend to send Google credentials
- show updated guidance when Google credentials are missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa6b35ce0c8326b61dd539a7dfa51d