### PR TITLE
Propagate initial MQTT connection failures in ws client

### DIFF
--- a/opt/blitzortung/ws_client/ws_client.py
+++ b/opt/blitzortung/ws_client/ws_client.py
@@ -92,6 +92,7 @@ class MQTTBridge:
             self._client.connect(self._settings.mqtt_host, self._settings.mqtt_port, keepalive=60)
         except Exception as exc:  # pragma: no cover - dependencias externas
             logging.error("No se pudo conectar a MQTT: %s", exc)
+            raise
         self._client.loop_start()
 
     def stop(self) -> None:


### PR DESCRIPTION
## Summary
- raise the MQTT connection error so systemd retries the service when the broker is unreachable

## Testing
- python3 -m compileall opt/blitzortung/ws_client/ws_client.py

------
https://chatgpt.com/codex/tasks/task_e_68fa7618623c83269e7a562756b17e71