### PR TITLE
fix: ensure dbus-user-session installed for blitz relay user service

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -123,7 +123,7 @@ fi
 log "Instalando paquetes base…"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y python3 python3-venv python3-pip nginx curl jq unzip ca-certificates espeak-ng network-manager rsync
+apt-get install -y python3 python3-venv python3-pip nginx curl jq unzip ca-certificates espeak-ng network-manager rsync dbus-user-session
 
 log "Asegurando NetworkManager activo…"
 systemctl_safe enable --now NetworkManager || true


### PR DESCRIPTION
## Summary
- include dbus-user-session in the base package install list so user systemd services can start

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68fae8354a9083269ff0c670e47febbd