### PR TITLE
fix: keep run_sysctl skip path non-fatal

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,7 +83,8 @@ run_sysctl() {
     fi
   else
     echo "[SKIP] D-Bus de sistema no disponible. Omitido: systemctl ${cmd_desc}"
-    return 2
+    # Devuelve éxito para no abortar bajo `set -e` cuando simplemente se omite systemctl.
+    return 0
   fi
 }
 


### PR DESCRIPTION
## Summary
- ensure run_sysctl treats skipped systemctl calls as success to avoid aborting installs under set -e

## Testing
- bash -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68faef19f8cc83269cd3ef2df780080d