### PR TITLE
fix: stabilize blitzortung websocket install

### DIFF
--- a/opt/blitzortung/ws_client/ws_client.py
+++ b/opt/blitzortung/ws_client/ws_client.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Blitzortung WebSocket → MQTT client."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import time
+from typing import Any, Dict, Optional
+
+import aiohttp
+import paho.mqtt.client as mqtt
+
+LOG_LEVEL = os.getenv("BLITZ_LOG_LEVEL", "INFO").upper()
+logging.basicConfig(level=LOG_LEVEL, format="%(asctime)s [%(levelname)s] %(message)s")
+
+
+class BlitzWSClient:
+    """Stream lightning strikes from Blitzortung proxy to MQTT."""
+
+    def __init__(self) -> None:
+        self.ws_url = os.getenv("BLITZ_WS_URL", "wss://blitzortung-proxy.fly.dev/ws")
+        self.heartbeat = int(os.getenv("BLITZ_HEARTBEAT", "20"))
+        self.mqtt_host = os.getenv("MQTT_HOST", "127.0.0.1")
+        self.mqtt_port = int(os.getenv("MQTT_PORT", "1883"))
+        self.mqtt_topic = os.getenv("MQTT_TOPIC", "blitzortung/1")
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._stop = asyncio.Event()
+        self._mqtt = self._create_mqtt_client()
+
+    def _create_mqtt_client(self) -> mqtt.Client:
+        client = mqtt.Client(client_id="pantalla-blitz-ws", protocol=mqtt.MQTTv311)
+        client.reconnect_delay_set(min_delay=1, max_delay=30)
+        client.on_connect = self._on_connect
+        client.on_disconnect = self._on_disconnect
+        return client
+
+    def _on_connect(self, client: mqtt.Client, userdata: Any, flags: Dict[str, Any], rc: int) -> None:
+        if rc == 0:
+            logging.info("MQTT conectado a %s:%s", self.mqtt_host, self.mqtt_port)
+        else:
+            logging.warning("MQTT conexión devuelta con rc=%s", rc)
+
+    def _on_disconnect(self, client: mqtt.Client, userdata: Any, rc: int) -> None:
+        if rc != 0:
+            logging.warning("MQTT desconectado inesperadamente (rc=%s) — reintentando", rc)
+
+    def _connect_mqtt(self) -> None:
+        try:
+            self._mqtt.connect(self.mqtt_host, self.mqtt_port, keepalive=self.heartbeat * 2)
+        except Exception as exc:  # noqa: BLE001
+            logging.error("No se pudo conectar a MQTT: %s", exc)
+            raise
+        self._mqtt.loop_start()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    async def run(self) -> None:
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            loop.add_signal_handler(sig, self.stop)
+
+        self._connect_mqtt()
+        timeout = aiohttp.ClientTimeout(total=None, sock_connect=30, sock_read=None)
+
+        while not self._stop.is_set():
+            try:
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    self._session = session
+                    logging.info("Conectando a %s", self.ws_url)
+                    async with session.ws_connect(self.ws_url, heartbeat=self.heartbeat) as ws:
+                        async for msg in ws:
+                            if msg.type == aiohttp.WSMsgType.TEXT:
+                                self._handle_message(msg.data)
+                            elif msg.type == aiohttp.WSMsgType.ERROR:
+                                logging.warning("Error de WebSocket: %s", ws.exception())
+                                break
+            except asyncio.CancelledError:  # pragma: no cover - handled by stop
+                break
+            except Exception as exc:  # noqa: BLE001
+                if not self._stop.is_set():
+                    logging.warning("Fallo en WS Blitzortung: %s", exc)
+            await asyncio.sleep(5)
+
+        self._mqtt.loop_stop()
+        self._mqtt.disconnect()
+
+    def _handle_message(self, payload: str) -> None:
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            return
+
+        if isinstance(data, dict) and {"lat", "lon"}.issubset(data):
+            strike_topic = f"{self.mqtt_topic}/{int(time.time())}"
+            self._mqtt.publish(strike_topic, json.dumps(data))
+            logging.info("⚡ %.4f, %.4f", data["lat"], data["lon"])
+
+
+async def main() -> None:
+    client = BlitzWSClient()
+    await client.run()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/scripts/install_post.sh
+++ b/scripts/install_post.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+loginctl enable-linger dani || true
+systemctl --user daemon-reload
+systemctl --user enable --now pantalla-dash-backend@dani pantalla-ui.service blitz_ws_client.service
+
+sudo systemctl restart nginx mosquitto
+
+curl -sf http://127.0.0.1:8081/api/health && echo "✅ Backend OK"
+mosquitto_pub -h 127.0.0.1 -t 'test/topic' -m 'ping' -r
+mosquitto_sub -h 127.0.0.1 -t 'test/topic' -C 1 -W 2 | grep ping

--- a/system/user/blitz_ws_client.service
+++ b/system/user/blitz_ws_client.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Blitzortung WebSocket Client
+After=network-online.target
+
+[Service]
+Type=simple
+Environment=PYTHONUNBUFFERED=1
+Environment=BLITZ_WS_URL=wss://blitzortung-proxy.fly.dev/ws
+Environment=BLITZ_HEARTBEAT=20
+Environment=MQTT_HOST=127.0.0.1
+Environment=MQTT_PORT=1883
+Environment=MQTT_TOPIC=blitzortung/1
+ExecStart=/opt/blitzortung/.venv/bin/python3 /opt/blitzortung/ws_client/ws_client.py
+WorkingDirectory=/opt/blitzortung/ws_client
+Restart=always
+RestartSec=5
+StandardOutput=append:/var/log/pantalla/blitz_ws_client.log
+StandardError=append:/var/log/pantalla/blitz_ws_client.err
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- simplify systemctl helpers in `install.sh`, provision the Blitzortung venv/client, and install a hardened Mosquitto loopback configuration
- add a dedicated Blitzortung WebSocket client script and user service
- introduce `install_post.sh` to finish enabling user services after the base installation

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68faf16f89f88326ae14e0e7296057a5