### PR TITLE
Add UI-driven config API and Blitzortung settings

### DIFF
--- a/backend/models/config.py
+++ b/backend/models/config.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, conint
+
+
+class BlitzMQTT(BaseModel):
+    host: str = Field("", description="Broker del relay MQTT")
+    port: conint(ge=1, le=65535) = 8883  # type: ignore[call-arg]
+    ssl: bool = True
+    username: Optional[str] = None
+    password: Optional[str] = None
+    baseTopic: str = Field("", description="Prefijo del relay, p.ej. blitzortung/<region>")
+    geohash: Optional[str] = None
+    radius_km: NonNegativeInt = 100  # type: ignore[assignment]
+
+
+class Blitzortung(BaseModel):
+    enabled: bool = False
+    mode: str = Field("mqtt", pattern=r"^(mqtt|ws)$")
+    mqtt: BlitzMQTT = Field(default_factory=BlitzMQTT)
+
+
+class Wifi(BaseModel):
+    preferredInterface: str = "wlp2s0"
+
+
+class UiAppearance(BaseModel):
+    transparentCards: bool = False
+
+
+class UiConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    wifi: Wifi = Field(default_factory=Wifi)
+    blitzortung: Blitzortung = Field(default_factory=Blitzortung)
+    appearance: UiAppearance = Field(default_factory=UiAppearance)
+
+

--- a/backend/services/wifi.py
+++ b/backend/services/wifi.py
@@ -128,6 +128,15 @@ def _extract_wifi_devices(lines: Sequence[str]) -> Dict[str, Dict[str, Optional[
     return devices
 
 
+def list_wifi_interfaces() -> List[str]:
+    result = _run_nmcli(["-t", "-f", "DEVICE,TYPE,STATE,CONNECTION", "device"])
+    if result.returncode != 0:
+        message = result.stderr.strip() or "No se pudo enumerar interfaces Wi-Fi"
+        raise WifiError(message, stderr=result.stderr, code=result.returncode)
+    devices = _extract_wifi_devices(result.stdout.splitlines())
+    return list(devices.keys())
+
+
 def _validate_wifi_interface(interface: str) -> None:
     result = _run_nmcli(["-t", "-f", "TYPE", "device", "show", interface])
     if result.returncode != 0:

--- a/dash-ui/src/components/GlassPanel.tsx
+++ b/dash-ui/src/components/GlassPanel.tsx
@@ -6,7 +6,7 @@ interface GlassPanelProps extends PropsWithChildren {
 
 const GlassPanel = ({ children, className }: GlassPanelProps) => (
   <div
-    className={`glass-panel flex h-full w-full flex-col gap-6 rounded-[28px] border border-white/15 bg-transparent p-6 text-white md:p-8 ${className ?? ''}`}
+    className={`glass-panel flex h-full w-full flex-col gap-6 rounded-2xl border border-white/15 bg-transparent px-6 py-6 text-white backdrop-blur-lg md:px-8 md:py-8 ${className ?? ''}`}
   >
     {children}
   </div>

--- a/dash-ui/src/context/DashboardConfigContext.tsx
+++ b/dash-ui/src/context/DashboardConfigContext.tsx
@@ -68,6 +68,12 @@ export const DashboardConfigProvider = ({ children }: Props) => {
     }
   }, []);
 
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const transparent = config?.ui?.appearance?.transparentCards ?? false;
+    document.body.classList.toggle('transparent-cards', Boolean(transparent));
+  }, [config?.ui?.appearance?.transparentCards]);
+
   const value = useMemo(
     () => ({ config, loading, error, refresh, update }),
     [config, loading, error, refresh, update]

--- a/dash-ui/src/styles/globals.css
+++ b/dash-ui/src/styles/globals.css
@@ -97,16 +97,36 @@ body.power-save {
   background: transparent !important;
 }
 
-/* 100% transparente, sin blur/velo */
+
 .glass,
 .glass-light {
   border-radius: 1.5rem;
   transition: background 0.6s ease, border-color 0.6s ease, box-shadow 0.6s ease;
-  background: transparent !important;
-  border: 1px solid rgba(255, 255, 255, 0.16);
   box-shadow: none !important;
-  backdrop-filter: none !important;
-  -webkit-backdrop-filter: none !important;
+}
+
+.glass {
+  background: rgba(255, 255, 255, 0.06) !important;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.glass-light {
+  background: rgba(255, 255, 255, 0.75) !important;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  color: #0f172a;
+}
+
+.transparent-cards .glass,
+.transparent-cards .glass-light,
+.transparent-cards .glass-panel {
+  background: transparent !important;
+  border-color: rgba(255, 255, 255, 0.14) !important;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 .glass-surface {


### PR DESCRIPTION
## Summary
- add UI configuration models covering Blitzortung MQTT, Wi-Fi preferences, and appearance defaults with legacy migration
- expose updated config API endpoints with secret redaction, Blitzortung test hook, Wi-Fi interface discovery, and runtime reloads
- overhaul the config UI to edit the new settings, validate Blitzortung MQTT credentials, and refresh glass panel styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fafb514134832689c2934718569bbf