### PR TITLE
Refactor Blitzortung integration to use configurable MQTT proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,28 +288,28 @@ servicio (`sudo systemctl restart pantalla-xorg@dani`).
 
 MIT (o la licencia original del repositorio si se define).
 
-## Blitzortung WS Relay
+## Blitzortung (MQTT)
 
-El instalador despliega un relay WebSocket → MQTT real en `/opt/blitzortung/ws_relay/relay.py`
-utilizando un entorno virtual compartido en `/opt/blitzortung/.venv`. El servicio
-`blitz_relay.service` se instala como unidad de usuario (con `loginctl enable-linger`) y
-reenvía strikes desde LightningMaps/Blitzortung hacia Mosquitto (`blitzortung/1.1`).
+El backend consume los rayos de Blitzortung directamente mediante MQTT. Por defecto se conecta
+al proxy público configurado en el panel `/#!/config`, sin desplegar relays WebSocket ni un broker
+local adicional.
 
-### Logs y diagnóstico
+### Configuración rápida
 
-```bash
-journalctl --user -u blitz_relay -n 100 --no-pager
-sudo tail -f /var/log/pantalla/blitz_relay.log
-sudo tail -f /var/log/pantalla/blitz_relay.err
-```
+1. Accede a `/#/config` y abre la tarjeta «Blitzortung y apariencia».
+2. Activa la integración y selecciona el modo **Proxy público (recomendado)**.
+3. Ajusta `geohash` y el radio (km) para delimitar tu zona. Los cambios se aplican en caliente.
 
-### Configuración
+Puedes comprobar el estado actual vía `GET /api/storms/status` o desde la propia interfaz. Si ves
+`enabled=true` pero `connected=false`, revisa la conectividad con el proxy o las credenciales.
 
-El tópico MQTT se controla desde `config.json` (`storm.mqtt_topic`). No es necesario definir
-variables adicionales: el relay publica en `blitzortung/1.1` y el backend consume esa ruta.
+### Broker local opcional
 
-Para verificar actividad:
+Si prefieres publicar en un Mosquitto local, instala con la bandera `--enable-local-mqtt`:
 
 ```bash
-mosquitto_sub -h 127.0.0.1 -t 'blitzortung/#' -v | head -n 20
+sudo ./scripts/install.sh --enable-local-mqtt …
 ```
+
+y cambia el modo a **Broker personalizado (avanzado)** en `/#/config`, indicando host, puerto y
+credenciales.

--- a/backend/models/config.py
+++ b/backend/models/config.py
@@ -2,24 +2,89 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, NonNegativeInt, conint
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeInt,
+    conint,
+    root_validator,
+    validator,
+)
+from pydantic.functional_validators import model_validator
+
+
+_MQTT_MODE_PATTERN = r"^(public_proxy|custom_broker)$"
 
 
 class BlitzMQTT(BaseModel):
-    host: str = Field("", description="Broker del relay MQTT")
-    port: conint(ge=1, le=65535) = 8883  # type: ignore[call-arg]
-    ssl: bool = True
-    username: Optional[str] = None
-    password: Optional[str] = None
-    baseTopic: str = Field("", description="Prefijo del relay, p.ej. blitzortung/<region>")
+    mode: str = Field("public_proxy", pattern=_MQTT_MODE_PATTERN)
+    proxy_host: str = "mqtt.blitzortung.org"
+    proxy_port: conint(ge=1, le=65535) = 8883  # type: ignore[call-arg]
+    proxy_ssl: bool = True
+    proxy_baseTopic: str = "blitzortung"
     geohash: Optional[str] = None
     radius_km: NonNegativeInt = 100  # type: ignore[assignment]
 
+    host: Optional[str] = None
+    port: Optional[conint(ge=1, le=65535)] = 1883  # type: ignore[call-arg]
+    ssl: bool = False
+    username: Optional[str] = None
+    password: Optional[str] = None
 
-class Blitzortung(BaseModel):
-    enabled: bool = False
-    mode: str = Field("mqtt", pattern=r"^(mqtt|ws)$")
-    mqtt: BlitzMQTT = Field(default_factory=BlitzMQTT)
+    @validator("mode")
+    def _validate_mode(cls, value: str) -> str:  # type: ignore[override]
+        normalized = (value or "public_proxy").strip()
+        if normalized not in {"public_proxy", "custom_broker"}:
+            raise ValueError("mode debe ser 'public_proxy' o 'custom_broker'")
+        return normalized
+
+    @validator("proxy_host")
+    def _normalize_proxy_host(cls, value: str) -> str:  # type: ignore[override]
+        normalized = (value or "").strip()
+        return normalized or "mqtt.blitzortung.org"
+
+    @validator("proxy_baseTopic")
+    def _normalize_proxy_base_topic(cls, value: str) -> str:  # type: ignore[override]
+        normalized = (value or "").strip().strip("/")
+        return normalized or "blitzortung"
+
+    @validator("geohash")
+    def _normalize_geohash(cls, value: Optional[str]) -> Optional[str]:  # type: ignore[override]
+        if value is None:
+            return None
+        normalized = value.strip().strip("/")
+        return normalized or None
+
+    @validator("host")
+    def _normalize_host(cls, value: Optional[str]) -> Optional[str]:  # type: ignore[override]
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    @validator("username")
+    def _normalize_username(cls, value: Optional[str]) -> Optional[str]:  # type: ignore[override]
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    @validator("password")
+    def _normalize_password(cls, value: Optional[str]) -> Optional[str]:  # type: ignore[override]
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @root_validator
+    def _validate_custom_broker(cls, values: dict) -> dict:  # type: ignore[override]
+        mode = values.get("mode")
+        host = values.get("host")
+        if mode == "custom_broker":
+            if not host:
+                raise ValueError("host es obligatorio en modo custom_broker")
+        return values
 
 
 class Wifi(BaseModel):
@@ -34,7 +99,54 @@ class UiConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     wifi: Wifi = Field(default_factory=Wifi)
-    blitzortung: Blitzortung = Field(default_factory=Blitzortung)
+    blitzortung: "Blitzortung" = Field(default_factory=lambda: Blitzortung())
     appearance: UiAppearance = Field(default_factory=UiAppearance)
+
+
+class Blitzortung(BaseModel):
+    model_config = ConfigDict(validate_assignment=True)
+
+    enabled: bool = False
+    mode: str = Field("public_proxy", pattern=_MQTT_MODE_PATTERN)
+    mqtt: BlitzMQTT = Field(default_factory=BlitzMQTT)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy(cls, value):
+        if isinstance(value, dict):
+            migrated = dict(value)
+            if "mqtt" not in migrated:
+                mqtt_keys = {
+                    "host",
+                    "port",
+                    "ssl",
+                    "username",
+                    "password",
+                    "baseTopic",
+                    "base_topic",
+                    "geohash",
+                    "radius_km",
+                }
+                if any(key in migrated for key in mqtt_keys):
+                    mqtt_payload = {
+                        "host": migrated.pop("host", None),
+                        "port": migrated.pop("port", None),
+                        "ssl": migrated.pop("ssl", None),
+                        "username": migrated.pop("username", None),
+                        "password": migrated.pop("password", None),
+                        "proxy_baseTopic": migrated.pop("baseTopic", None) or migrated.pop("base_topic", None),
+                        "geohash": migrated.pop("geohash", None),
+                        "radius_km": migrated.pop("radius_km", None),
+                    }
+                    migrated["mqtt"] = {k: v for k, v in mqtt_payload.items() if v is not None}
+            return migrated
+        return value
+
+    @model_validator(mode="after")
+    def _sync_mode(self):
+        mqtt_mode = self.mqtt.mode
+        if mqtt_mode != self.mode:
+            object.__setattr__(self, "mode", mqtt_mode)
+        return self
 
 

--- a/backend/services/blitz_consumer.py
+++ b/backend/services/blitz_consumer.py
@@ -1,16 +1,19 @@
-"""Background MQTT consumer for Blitzortung lightning relays."""
+"""Background MQTT consumer for Blitzortung lightning feeds."""
 
 from __future__ import annotations
 
 import json
 import logging
+import math
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .blitzortung_store import BlitzStore
 from .config import AppConfig, BlitzortungConfig, read_config
+from .location import get_location as get_location_override
 
 try:  # pragma: no cover - optional dependency
     import paho.mqtt.client as mqtt
@@ -21,11 +24,19 @@ except Exception:  # pragma: no cover - executed when dependency missing
 
 logger = logging.getLogger(__name__)
 
-_RELAY_TOPIC_BASE = "blitzortung/relay"
+
+@dataclass(frozen=True)
+class _ProxySettings:
+    host: str
+    port: int
+    ssl: bool
+    base_topic: str
+    geohash: Optional[str]
+    radius_km: int
 
 
 @dataclass(frozen=True)
-class _MQTTSettings:
+class _CustomBrokerSettings:
     host: str
     port: int
     ssl: bool
@@ -33,206 +44,240 @@ class _MQTTSettings:
     password: Optional[str]
     base_topic: str
     geohash: Optional[str]
-    radius_km: Optional[int]
+    radius_km: int
+
+
+SettingsType = Union[_ProxySettings, _CustomBrokerSettings]
 
 
 @dataclass(frozen=True)
 class _ConsumerConfig:
     enabled: bool
     mode: str
-    mqtt: Optional[_MQTTSettings]
+    settings: Optional[SettingsType]
+    location: Optional[Tuple[float, float]]
 
 
-class _LocalPublisher:
-    """Lazy MQTT publisher towards the local Mosquitto instance."""
+def _haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    delta_phi = math.radians(lat2 - lat1)
+    delta_lambda = math.radians(lon2 - lon1)
+    a = (
+        math.sin(delta_phi / 2.0) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(delta_lambda / 2.0) ** 2
+    )
+    c = 2.0 * math.atan2(math.sqrt(a), math.sqrt(max(0.0, 1.0 - a)))
+    return 6371.0 * c
 
-    def __init__(self, host: str = "127.0.0.1", port: int = 1883, base_topic: str = _RELAY_TOPIC_BASE) -> None:
-        self._host = host
-        self._port = port
-        self._base_topic = base_topic.rstrip("/") or _RELAY_TOPIC_BASE
-        self._client: Optional["mqtt.Client"] = None
-        self._connected = False
-        self._lock = threading.Lock()
-        self._last_attempt = 0.0
 
-    def publish(self, topic_suffix: str, payload: bytes) -> None:
-        if mqtt is None:
-            return
-        topic = self._build_topic(topic_suffix)
-        now = time.time()
-        with self._lock:
-            if not self._connected and now - self._last_attempt < 5:
-                return
-            if self._client is None:
-                self._last_attempt = now
-                try:
-                    client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2) if CallbackAPIVersion else mqtt.Client()
-                    client.enable_logger(logger)
-                    client.connect(self._host, self._port, keepalive=30)
-                    client.loop_start()
-                    self._client = client
-                    self._connected = True
-                except Exception as exc:  # pragma: no cover - defensive
-                    logger.debug("No se pudo conectar a Mosquitto local: %s", exc)
-                    self._client = None
-                    self._connected = False
-                    return
-            try:
-                assert self._client is not None
-                self._client.publish(topic, payload, qos=0, retain=False)
-            except Exception as exc:  # pragma: no cover - defensive
-                logger.debug("Error publicando en Mosquitto local: %s", exc)
-                self._teardown_locked()
-
-    def stop(self) -> None:
-        with self._lock:
-            self._teardown_locked()
-
-    def _teardown_locked(self) -> None:
-        if self._client is not None:
-            try:
-                self._client.loop_stop()
-            except Exception:  # pragma: no cover - defensive
-                logger.debug("Error deteniendo loop del publicador", exc_info=True)
-            try:
-                self._client.disconnect()
-            except Exception:  # pragma: no cover - defensive
-                logger.debug("Error desconectando publicador local", exc_info=True)
-        self._client = None
-        self._connected = False
-        self._last_attempt = time.time()
-
-    def _build_topic(self, suffix: str) -> str:
-        normalized = suffix.lstrip("/")
-        if normalized:
-            return f"{self._base_topic}/{normalized}"
-        return self._base_topic
+def _bearing_deg(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    phi1 = math.radians(lat1)
+    phi2 = math.radians(lat2)
+    delta_lambda = math.radians(lon2 - lon1)
+    y = math.sin(delta_lambda) * math.cos(phi2)
+    x = math.cos(phi1) * math.sin(phi2) - math.sin(phi1) * math.cos(phi2) * math.cos(delta_lambda)
+    bearing = math.degrees(math.atan2(y, x))
+    return (bearing + 360.0) % 360.0
 
 
 class BlitzMQTTConsumer:
-    """Background MQTT consumer for Blitzortung relay feeds."""
+    """Manage a background MQTT client to consume Blitzortung events."""
 
     def __init__(self) -> None:
+        self._store = BlitzStore()
+        self._config: Optional[_ConsumerConfig] = None
+        self._client: Optional["mqtt.Client"] = None
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+        self._wake_event = threading.Event()
         self._lock = threading.Lock()
         self._status_lock = threading.Lock()
-        self._client: Optional["mqtt.Client"] = None
-        self._config: Optional[_ConsumerConfig] = None
-        self._store = BlitzStore()
         self._status: Dict[str, Any] = {
-            "mode": "disabled",
             "enabled": False,
+            "mode": "public_proxy",
             "connected": False,
-            "subscribed_topics": [],
-            "last_message_at": None,
+            "last_event_at": None,
+            "topic": None,
+            "counters": {
+                "received": 0,
+                "errors": 0,
+                "retries": 0,
+                "last_distance_km": None,
+                "last_azimuth_deg": None,
+            },
+            "retry_in": None,
             "last_error": None,
         }
-        self._local_publisher = _LocalPublisher()
-        self._base_topic = ""
+        self._last_retry_delay = 1
+        self._location: Optional[Tuple[float, float]] = None
+        self._current_topic: Optional[str] = None
 
-    # Public API -----------------------------------------------------
+    # ------------------------------------------------------------------
     def configure(self, config: Optional[_ConsumerConfig]) -> None:
-        if config == self._config:
-            return
-        if config is None or not config.enabled or config.mode != "mqtt" or config.mqtt is None:
-            self.stop()
-            self._update_status(
-                {
-                    "mode": config.mode if config else "disabled",
-                    "enabled": bool(config.enabled if config else False),
-                    "connected": False,
-                    "subscribed_topics": [],
-                    "last_error": None,
-                    "remote_base_topic": None,
-                    "geohash": None,
-                    "radius_km": None,
-                }
-            )
+        with self._lock:
             self._config = config
+            self._location = config.location if config else None
+            self._wake_event.set()
+            self._ensure_thread()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._wake_event.set()
+        thread = self._thread
+        if thread and thread.is_alive():
+            thread.join(timeout=5)
+        self._thread = None
+        self._disconnect_client()
+        self._store.clear()
+
+    def recent(self, limit: int = 500) -> List[Tuple[float, float]]:
+        coords = self._store.recent()
+        return coords[:limit] if limit >= 0 else coords
+
+    def status(self) -> Dict[str, Any]:
+        with self._status_lock:
+            return json.loads(json.dumps(self._status))
+
+    # ------------------------------------------------------------------
+    def _ensure_thread(self) -> None:
+        if self._thread and self._thread.is_alive():
             return
-        if mqtt is None:
-            self._update_status(
-                {
-                    "mode": config.mode,
-                    "enabled": True,
-                    "connected": False,
-                    "last_error": "paho-mqtt no disponible",
-                    "subscribed_topics": [],
-                    "remote_base_topic": None,
-                    "geohash": None,
-                    "radius_km": None,
-                }
-            )
-            self._config = config
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, name="BlitzMQTTConsumer", daemon=True)
+        self._thread.start()
+
+    def _run_loop(self) -> None:
+        backoff = 1
+        while not self._stop_event.is_set():
+            config = self._config
+            if not config or not config.enabled or not config.settings:
+                self._disconnect_client()
+                self._update_status(
+                    {
+                        "enabled": bool(config.enabled if config else False),
+                        "mode": config.mode if config else "public_proxy",
+                        "connected": False,
+                        "topic": None,
+                        "retry_in": None,
+                    }
+                )
+                self._wait_for_wakeup(timeout=1)
+                backoff = 1
+                continue
+
+            if mqtt is None:
+                self._update_status(
+                    {
+                        "enabled": True,
+                        "mode": config.mode,
+                        "connected": False,
+                        "last_error": "paho-mqtt no disponible",
+                    }
+                )
+                self._wait_for_wakeup(timeout=10)
+                continue
+
+            try:
+                self._connect(config)
+                backoff = 1
+                self._wait_for_wakeup()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Error Blitzortung MQTT (%s): %s", config.mode, exc)
+                self._update_status(
+                    {
+                        "connected": False,
+                        "last_error": str(exc),
+                        "retry_in": backoff,
+                    },
+                    increment_retry=True,
+                )
+                self._disconnect_client()
+                if self._stop_event.wait(timeout=backoff):
+                    break
+                backoff = min(backoff * 2, 60)
+                continue
+
+        self._disconnect_client()
+
+    def _wait_for_wakeup(self, timeout: Optional[float] = None) -> None:
+        if self._stop_event.is_set():
             return
-        self.stop()
-        self._config = config
-        settings = config.mqtt
-        assert settings is not None
-        try:
-            client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2) if CallbackAPIVersion else mqtt.Client()
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("No se pudo crear cliente MQTT: %s", exc)
-            self._update_status(
-                {
-                    "mode": config.mode,
-                    "enabled": True,
-                    "connected": False,
-                    "last_error": str(exc),
-                    "subscribed_topics": [],
-                    "remote_base_topic": settings.base_topic,
-                    "geohash": settings.geohash,
-                    "radius_km": settings.radius_km,
-                }
-            )
-            return
+        if timeout is None:
+            while not self._stop_event.is_set():
+                if self._wake_event.wait(timeout=1):
+                    self._wake_event.clear()
+                    break
+        else:
+            if self._wake_event.wait(timeout=timeout):
+                self._wake_event.clear()
+
+    def _connect(self, config: _ConsumerConfig) -> None:
+        self._disconnect_client()
+        settings = config.settings
+        if settings is None:
+            raise RuntimeError("Configuración MQTT incompleta")
+
+        client = (
+            mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2)
+            if CallbackAPIVersion
+            else mqtt.Client()
+        )
         client.enable_logger(logger)
         client.on_connect = self._on_connect  # type: ignore[assignment]
         client.on_disconnect = self._on_disconnect  # type: ignore[assignment]
         client.on_message = self._on_message  # type: ignore[assignment]
-        client.reconnect_delay_set(min_delay=1, max_delay=30)
-        if settings.ssl:
+        client.reconnect_delay_set(min_delay=1, max_delay=60)
+
+        if isinstance(settings, _ProxySettings):
+            host = settings.host
+            port = settings.port
+            use_ssl = settings.ssl
+        else:
+            host = settings.host
+            port = settings.port
+            use_ssl = settings.ssl
+            if settings.username:
+                password = settings.password or ""
+                if password == "*****":
+                    password = ""
+                client.username_pw_set(settings.username, password)
+
+        if use_ssl:
             try:
                 client.tls_set()
             except Exception as exc:  # pragma: no cover - defensive
-                logger.warning("No se pudo habilitar TLS para MQTT Blitzortung: %s", exc)
-        if settings.username:
-            client.username_pw_set(settings.username, settings.password)
-        self._base_topic = settings.base_topic.rstrip("/") or "blitzortung"
-        try:
-            client.connect(settings.host, settings.port, keepalive=30)
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.error("No se pudo conectar a %s:%s: %s", settings.host, settings.port, exc)
-            self._update_status(
-                {
-                    "mode": config.mode,
-                    "enabled": True,
-                    "connected": False,
-                    "last_error": str(exc),
-                    "subscribed_topics": [],
-                    "remote_base_topic": settings.base_topic,
-                    "geohash": settings.geohash,
-                    "radius_km": settings.radius_km,
-                }
-            )
-            return
+                logger.warning("No se pudo habilitar TLS para Blitzortung: %s", exc)
+
+        client.connect(host, port, keepalive=30)
+        topics = self._topics_for(settings)
+        self._current_topic = topics[0] if topics else None
         with self._lock:
             self._client = client
         client.loop_start()
-        topics = self._topics_from(settings)
+        for topic in topics:
+            try:
+                client.subscribe(topic, qos=0)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.debug("No se pudo suscribir a %s: %s", topic, exc)
         self._update_status(
             {
-                "mode": config.mode,
                 "enabled": True,
-                "connected": False,
+                "mode": config.mode,
+                "topic": self._current_topic,
                 "last_error": None,
-                "subscribed_topics": topics,
-                "remote_base_topic": self._base_topic,
-                "geohash": settings.geohash,
-                "radius_km": settings.radius_km,
+                "retry_in": None,
             }
         )
 
-    def stop(self) -> None:
+    def _topics_for(self, settings: SettingsType) -> List[str]:
+        base = settings.base_topic.rstrip("/") or "blitzortung"
+        geohash = settings.geohash.strip("/") if settings.geohash else "auto"
+        radius = settings.radius_km if settings.radius_km is not None else 100
+        topic = f"{base}/{geohash}/{radius}"
+        return [topic]
+
+    def _disconnect_client(self) -> None:
         with self._lock:
             client = self._client
             self._client = None
@@ -245,46 +290,20 @@ class BlitzMQTTConsumer:
                 client.disconnect()
             except Exception:  # pragma: no cover - defensive
                 logger.debug("Error desconectando MQTT Blitzortung", exc_info=True)
-        self._local_publisher.stop()
-        self._store.clear()
         self._update_status({"connected": False})
 
-    def recent(self, limit: int = 500) -> list[tuple[float, float]]:
-        coords = self._store.recent()
-        if limit >= 0:
-            return coords[:limit]
-        return coords
-
-    def status(self) -> Dict[str, Any]:
+    # ------------------------------------------------------------------
+    def _update_status(self, changes: Dict[str, Any], *, increment_retry: bool = False) -> None:
         with self._status_lock:
-            return dict(self._status)
-
-    # Internal helpers ------------------------------------------------
-    def _topics_from(self, settings: _MQTTSettings) -> List[str]:
-        base = settings.base_topic.rstrip("/")
-        if settings.geohash:
-            geohash = settings.geohash.strip("/")
-            return [f"{base}/{geohash}/#"]
-        return [f"{base}/#"]
-
-    def _update_status(self, changes: Dict[str, Any]) -> None:
-        with self._status_lock:
+            if increment_retry:
+                counters = self._status.get("counters")
+                if isinstance(counters, dict):
+                    counters["retries"] = counters.get("retries", 0) + 1
             self._status.update(changes)
 
-    # MQTT callbacks --------------------------------------------------
     def _on_connect(self, client, userdata, flags, reason_code, properties=None):  # noqa: D401
-        del userdata, flags, reason_code, properties
-        config = self._config
-        settings = config.mqtt if config else None
-        if not settings:
-            return
-        topics = self._topics_from(settings)
-        for topic in topics:
-            try:
-                client.subscribe(topic, qos=0)
-            except Exception:  # pragma: no cover - defensive
-                logger.debug("No se pudo suscribir a %s", topic, exc_info=True)
-        self._update_status({"connected": True, "subscribed_topics": topics, "last_error": None})
+        del client, userdata, flags, reason_code, properties
+        self._update_status({"connected": True, "last_error": None})
 
     def _on_disconnect(self, client, userdata, reason_code, properties=None):  # noqa: D401
         del client, userdata, reason_code, properties
@@ -293,32 +312,59 @@ class BlitzMQTTConsumer:
     def _on_message(self, client, userdata, message):  # noqa: D401
         del client, userdata
         payload = bytes(message.payload)
-        suffix = self._extract_suffix(message.topic)
-        self._local_publisher.publish(suffix, payload)
         try:
             data = json.loads(payload.decode("utf-8"))
         except Exception:  # pragma: no cover - defensivo
             data = None
+            self._increment_error()
+        self._handle_event(data)
+
+    def _increment_error(self) -> None:
+        with self._status_lock:
+            counters = self._status.get("counters")
+            if isinstance(counters, dict):
+                counters["errors"] = counters.get("errors", 0) + 1
+
+    def _handle_event(self, data: Any) -> None:
+        timestamp = time.time()
+        lat = None
+        lon = None
         if isinstance(data, dict):
             lat = self._extract_float(data, ["lat", "latitude", "latitud"])
             lon = self._extract_float(data, ["lon", "longitude", "longitud"])
             if lat is None or lon is None:
-                position = data.get("position")
+                position = data.get("position") if isinstance(data.get("position"), dict) else None
                 if isinstance(position, dict):
                     lat = self._extract_float(position, ["lat", "latitude"])
                     lon = self._extract_float(position, ["lon", "longitude"])
-            if lat is not None and lon is not None:
-                ts = self._extract_float(data, ["time", "timestamp", "ts", "datetime"])
-                if ts and ts > 1e12:
-                    ts /= 1000.0
-                self._store.add(lat, lon, ts)
-        self._update_status({"last_message_at": time.time()})
+            ts_value = self._extract_float(
+                data,
+                ["timestamp", "time", "ts", "datetime", "epoch"],
+            )
+            if ts_value:
+                if ts_value > 1e12:
+                    ts_value /= 1000.0
+                timestamp = ts_value
 
-    def _extract_suffix(self, topic: str) -> str:
-        base = self._base_topic
-        if base and topic.startswith(base.rstrip("/") + "/"):
-            return topic[len(base.rstrip("/")) + 1 :]
-        return topic
+        if lat is not None and lon is not None:
+            self._store.add(lat, lon, timestamp)
+
+        iso_time = datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()
+        distance_km = None
+        azimuth_deg = None
+        if lat is not None and lon is not None and self._location:
+            try:
+                distance_km = _haversine_km(self._location[0], self._location[1], lat, lon)
+                azimuth_deg = _bearing_deg(self._location[0], self._location[1], lat, lon)
+            except Exception:  # pragma: no cover - defensivo
+                logger.debug("No se pudo calcular distancia/azimut", exc_info=True)
+        with self._status_lock:
+            counters = self._status.get("counters")
+            if isinstance(counters, dict):
+                counters["received"] = counters.get("received", 0) + 1
+                counters["last_distance_km"] = distance_km
+                counters["last_azimuth_deg"] = azimuth_deg
+        self._update_status({"last_event_at": iso_time})
 
     @staticmethod
     def _extract_float(data: Dict[str, Any], keys: List[str]) -> Optional[float]:
@@ -336,30 +382,60 @@ class BlitzMQTTConsumer:
 _CONSUMER = BlitzMQTTConsumer()
 
 
+def _resolve_location(app_config: Optional[AppConfig]) -> Optional[Tuple[float, float]]:
+    override = get_location_override()
+    if override:
+        return override
+    return None
+
+
 def _to_consumer_config(app_config: Optional[AppConfig]) -> Optional[_ConsumerConfig]:
     if app_config is None:
         return None
     blitz_cfg: Optional[BlitzortungConfig] = getattr(app_config, "blitzortung", None)
     if blitz_cfg is None:
         return None
-    enabled = bool(getattr(blitz_cfg, "enabled", True))
-    mode = str(getattr(blitz_cfg, "mode", "mqtt") or "mqtt").lower()
+    enabled = bool(getattr(blitz_cfg, "enabled", False))
     mqtt_cfg = getattr(blitz_cfg, "mqtt", None)
     if mqtt_cfg is None:
-        mqtt_settings = None
+        return _ConsumerConfig(enabled=False, mode="public_proxy", settings=None, location=None)
+
+    mode = getattr(mqtt_cfg, "mode", getattr(blitz_cfg, "mode", "public_proxy")) or "public_proxy"
+    mode = str(mode).strip().lower()
+    base_topic = getattr(mqtt_cfg, "proxy_baseTopic", None) or "blitzortung"
+    geohash = getattr(mqtt_cfg, "geohash", None)
+    radius = getattr(mqtt_cfg, "radius_km", None)
+    radius_int = int(radius) if isinstance(radius, (int, float)) else 100
+
+    settings: Optional[SettingsType]
+    if mode == "custom_broker":
+        host = getattr(mqtt_cfg, "host", None)
+        if not host:
+            settings = None
+        else:
+            settings = _CustomBrokerSettings(
+                host=str(host),
+                port=int(getattr(mqtt_cfg, "port", 1883) or 1883),
+                ssl=bool(getattr(mqtt_cfg, "ssl", False)),
+                username=getattr(mqtt_cfg, "username", None),
+                password=getattr(mqtt_cfg, "password", None),
+                base_topic=str(base_topic),
+                geohash=str(geohash) if geohash else None,
+                radius_km=radius_int,
+            )
     else:
-        base_topic = str(getattr(mqtt_cfg, "baseTopic", "blitzortung/1.1") or "blitzortung/1.1")
-        mqtt_settings = _MQTTSettings(
-            host=str(getattr(mqtt_cfg, "host", "127.0.0.1") or "127.0.0.1"),
-            port=int(getattr(mqtt_cfg, "port", 1883) or 1883),
-            ssl=bool(getattr(mqtt_cfg, "ssl", False)),
-            username=getattr(mqtt_cfg, "username", None),
-            password=getattr(mqtt_cfg, "password", None),
-            base_topic=base_topic,
-            geohash=getattr(mqtt_cfg, "geohash", None),
-            radius_km=getattr(mqtt_cfg, "radius_km", None),
+        mode = "public_proxy"
+        settings = _ProxySettings(
+            host=str(getattr(mqtt_cfg, "proxy_host", getattr(mqtt_cfg, "host", "mqtt.blitzortung.org"))),
+            port=int(getattr(mqtt_cfg, "proxy_port", getattr(mqtt_cfg, "port", 8883)) or 8883),
+            ssl=bool(getattr(mqtt_cfg, "proxy_ssl", True)),
+            base_topic=str(base_topic),
+            geohash=str(geohash) if geohash else None,
+            radius_km=radius_int,
         )
-    return _ConsumerConfig(enabled=enabled, mode=mode, mqtt=mqtt_settings)
+
+    location = _resolve_location(app_config)
+    return _ConsumerConfig(enabled=enabled and settings is not None, mode=mode, settings=settings, location=location)
 
 
 def configure_from_app_config(app_config: Optional[AppConfig]) -> None:
@@ -371,8 +447,7 @@ def configure_from_disk() -> None:
         app_config = read_config()
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("No se pudo cargar configuración Blitzortung: %s", exc)
-        configure_from_app_config(None)
-        return
+        app_config = None
     configure_from_app_config(app_config)
 
 
@@ -380,17 +455,16 @@ def shutdown() -> None:
     _CONSUMER.stop()
 
 
-def recent_strikes(limit: int = 500) -> list[tuple[float, float]]:
+def recent_strikes(limit: int = 500) -> List[Tuple[float, float]]:
     return _CONSUMER.recent(limit)
 
 
 def consumer_status() -> Dict[str, Any]:
     status = _CONSUMER.status()
-    status.setdefault("relay_topic", _RELAY_TOPIC_BASE)
     return status
 
 
-def main() -> None:
+def main() -> None:  # pragma: no cover - manual execution
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s :: %(message)s")
     configure_from_disk()
     try:
@@ -398,9 +472,5 @@ def main() -> None:
             time.sleep(30)
     except KeyboardInterrupt:
         logger.info("Blitzortung consumer detenido por usuario")
-    finally:
         shutdown()
 
-
-if __name__ == "__main__":
-    main()

--- a/dash-ui/src/services/config.ts
+++ b/dash-ui/src/services/config.ts
@@ -45,19 +45,22 @@ export interface UiAppearanceConfig {
 }
 
 export interface BlitzMqttConfig {
-  host: string;
-  port: number;
-  ssl: boolean;
+  mode: 'public_proxy' | 'custom_broker';
+  proxy_host: string;
+  proxy_port: number;
+  proxy_ssl: boolean;
+  proxy_baseTopic: string;
+  geohash?: string | null;
+  radius_km?: number | null;
+  host?: string | null;
+  port?: number | null;
+  ssl?: boolean;
   username?: string | null;
   password?: string | null;
-  baseTopic: string;
-  geohash?: string | null;
-  radius_km?: number;
 }
 
 export interface BlitzortungUiConfig {
   enabled: boolean;
-  mode: 'mqtt' | 'ws';
   mqtt: BlitzMqttConfig;
 }
 
@@ -228,10 +231,9 @@ export interface BlitzTestResult {
 }
 
 export async function testBlitzConnection(payload: BlitzortungUiConfig): Promise<BlitzTestResult> {
-  const { mode, mqtt } = payload;
   return await apiRequest<BlitzTestResult>('/storms/blitz/test', {
     method: 'POST',
-    body: JSON.stringify({ mode, mqtt }),
+    body: JSON.stringify(payload),
   });
 }
 

--- a/dash-ui/src/services/storms.ts
+++ b/dash-ui/src/services/storms.ts
@@ -13,6 +13,14 @@ export interface StormStatus {
   strikesCount?: number;
   strikesWindowMinutes?: number;
   strikesCountKey?: string | null;
+  blitzEnabled?: boolean;
+  blitzConnected?: boolean;
+  blitzMode?: 'public_proxy' | 'custom_broker' | string;
+  blitzTopic?: string | null;
+  blitzLastEventAt?: string | null;
+  blitzCounters?: Record<string, unknown> | null;
+  blitzRetryIn?: number | null;
+  blitzLastError?: string | null;
 }
 
 export interface RadarFrame {
@@ -101,6 +109,20 @@ export async function fetchStormStatus(): Promise<StormStatus> {
       ? null
       : undefined;
 
+  const blitzEnabled = typeof data.enabled === 'boolean' ? data.enabled : undefined;
+  const blitzConnected = typeof data.connected === 'boolean' ? data.connected : undefined;
+  const blitzMode = typeof data.mode === 'string' ? (data.mode as StormStatus['blitzMode']) : undefined;
+  const blitzTopic = typeof data.topic === 'string' ? data.topic : undefined;
+  const blitzLastEventAt =
+    typeof data.last_event_at === 'string'
+      ? data.last_event_at
+      : data.last_event_at === null
+      ? null
+      : undefined;
+  const blitzCounters = typeof data.counters === 'object' && data.counters !== null ? (data.counters as Record<string, unknown>) : null;
+  const blitzRetryIn = typeof data.retry_in === 'number' ? data.retry_in : null;
+  const blitzLastError = typeof data.last_error === 'string' ? data.last_error : null;
+
   return {
     stormProb: data.storm_prob,
     nearActivity: data.near_activity,
@@ -114,6 +136,14 @@ export async function fetchStormStatus(): Promise<StormStatus> {
     strikesCount,
     strikesWindowMinutes,
     strikesCountKey: strikesCountKey ?? undefined,
+    blitzEnabled,
+    blitzConnected,
+    blitzMode,
+    blitzTopic: blitzTopic ?? null,
+    blitzLastEventAt: blitzLastEventAt ?? null,
+    blitzCounters,
+    blitzRetryIn,
+    blitzLastError,
   };
 }
 

--- a/docs/DEPLOY_BACKEND.md
+++ b/docs/DEPLOY_BACKEND.md
@@ -134,6 +134,15 @@ curl -s http://127.0.0.1:8081/api/network/status
 curl -s http://127.0.0.1:8081/api/storms/status
 ```
 
+### Blitzortung
+
+El backend se conecta por defecto al proxy MQTT público de Blitzortung; no es necesario desplegar
+Mosquitto ni relays adicionales. Configura la integración desde `/#/config` → «Blitzortung y
+apariencia».
+
+Si prefieres un broker local, instala el proyecto con `--enable-local-mqtt` y cambia el modo a
+«Broker personalizado» en la UI especificando host, puerto y credenciales.
+
 Desde un cliente conectado al AP visita `http://10.42.0.1:8081/setup` para usar
 la mini-web de configuración (escaneo Wi-Fi y conexión con password).
 


### PR DESCRIPTION
## Summary
- add configurable Blitzortung MQTT models that support proxy and custom brokers and migrate legacy fields
- replace the relay client with a paho-mqtt consumer, expose status/test endpoints, and update the React config UI accordingly
- skip Mosquitto by default in install.sh, add health retries, and document the new configuration flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb0216c618832686c18d0460dc12a9