### PR TITLE
Add Chromium kiosk user service and installer checks

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -119,6 +119,18 @@ if [[ -f "$USER_SYSTEMD_DIR/$UI_SERVICE_NAME" ]]; then
   fi
 fi
 
+echo "[INFO] Deshabilitando UI Chromium kiosk…"
+UI_KIOSK_USER="${APP_USER:-dani}"
+if [[ "$UI_KIOSK_USER" == "root" ]]; then
+  UI_KIOSK_USER="dani"
+fi
+UI_KIOSK_HOME="$(getent passwd "$UI_KIOSK_USER" | cut -d: -f6)"
+if [[ -n "$UI_KIOSK_HOME" ]]; then
+  sudo -u "$UI_KIOSK_USER" systemctl --user disable --now "pantalla-ui@${UI_KIOSK_USER}.service" 2>/dev/null || true
+  rm -f "$UI_KIOSK_HOME/.config/systemd/user/pantalla-ui@.service" 2>/dev/null || true
+  sudo -u "$UI_KIOSK_USER" systemctl --user daemon-reload 2>/dev/null || true
+fi
+
 # Kiosk service (legacy system service si existe)
 KIOSK_SERVICE="pantalla-kiosk.service"
 if [[ -f "$SYSTEMD_DIR/$KIOSK_SERVICE" ]]; then

--- a/services/pantalla-ui@.service
+++ b/services/pantalla-ui@.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Pantalla Dash UI Chromium Kiosk (%i)
+After=graphical.target openbox.service
+Wants=graphical.target
+
+[Service]
+Type=simple
+Environment=DISPLAY=:0
+ExecStart=/usr/bin/chromium-browser --kiosk http://127.0.0.1 \
+  --noerrdialogs --disable-session-crashed-bubble --incognito --start-fullscreen \
+  --disable-pinch --overscroll-history-navigation=0 --no-first-run --fast --fast-start \
+  --disable-translate --disable-infobars --disable-features=TranslateUI
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- add a pantalla-ui@.service user unit to launch Chromium in kiosk mode
- update install.sh to install Chromium, deploy the new unit for the UI user, add runtime checks, and fix config permissions
- extend uninstall.sh to clean up the Chromium kiosk user service

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fb9a274208832696da4e2e8156ee20