### PR TITLE
Add XAUTHORITY env to pantalla UI service

### DIFF
--- a/services/pantalla-ui@.service
+++ b/services/pantalla-ui@.service
@@ -6,6 +6,7 @@ Wants=graphical.target
 [Service]
 Type=simple
 Environment=DISPLAY=:0
+Environment=XAUTHORITY=/home/dani/.Xauthority
 ExecStart=/usr/bin/chromium-browser --kiosk http://127.0.0.1 \
   --noerrdialogs --disable-session-crashed-bubble --incognito --start-fullscreen \
   --disable-pinch --overscroll-history-navigation=0 --no-first-run --fast --fast-start \


### PR DESCRIPTION
## Summary
- ensure the pantalla UI chromium service exports XAUTHORITY so it can authenticate with the X server

## Testing
- systemctl --user daemon-reload *(fails: Failed to connect to bus: No medium found)*
- systemctl --user restart pantalla-ui@dani *(fails: Failed to connect to bus: No medium found)*
- sleep 2
- pgrep -a chromium

------
https://chatgpt.com/codex/tasks/task_e_68fb9d9113a48326b83ad5301e4d52bb