### PR TITLE
Fix Openbox uninstall user targeting and wrap Openbox in dbus-launch

### DIFF
--- a/system/user/pantalla-openbox.service
+++ b/system/user/pantalla-openbox.service
@@ -8,8 +8,7 @@ Type=simple
 Environment=DISPLAY=:0
 Environment=XDG_RUNTIME_DIR=/run/user/%U
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus
-ExecStartPre=/usr/bin/dbus-launch --exit-with-session true
-ExecStart=/usr/bin/openbox-session
+ExecStart=/usr/bin/dbus-launch --exit-with-session /usr/bin/openbox-session
 Restart=always
 RestartSec=2
 


### PR DESCRIPTION
## Summary
- ensure the uninstall script disables the Openbox user service as the kiosk user with the appropriate runtime environment
- reload the kiosk user's systemd instance after removing the user unit
- start the Openbox session via dbus-launch so the service runs under the intended D-Bus session

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68fbab44b010832686b7696ae5b20ef9