### PR TITLE
Finalize Chromium .deb kiosk environment

### DIFF
--- a/system/user/pantalla-openbox.service
+++ b/system/user/pantalla-openbox.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pantalla Dash Openbox Session (with D-Bus)
+Description=Pantalla Dash Openbox Session (Final)
 After=graphical.target
 Wants=graphical.target
 
@@ -7,8 +7,7 @@ Wants=graphical.target
 Type=simple
 Environment=DISPLAY=:0
 Environment=XDG_RUNTIME_DIR=/run/user/%U
-Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus
-ExecStartPre=/usr/bin/dbus-launch --exit-with-session true
+ExecStartPre=/usr/bin/xsetroot -solid black
 ExecStart=/usr/bin/openbox-session
 Restart=always
 RestartSec=2


### PR DESCRIPTION
## Summary
- replace the snap-based Chromium setup with a reproducible Debian .deb installation and clean legacy PPAs
- update the Openbox kiosk autostart and verification flow to launch the classic Chromium build
- refresh uninstall and service assets to purge Chromium configuration and ensure a black background at startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fbb72b97b883268189ebfaa55025a8