### PR TITLE
Fix backend unit installation and parameterize xorg dependency

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,8 +127,13 @@ log "Firefox operativo: $(/usr/local/bin/firefox --version)"
 # 4) Units de systemd
 # ---------------------------------------------------------------------------
 log "Instalando unidades systemd"
-install -D -m 0644 "$REPO_DIR/systemd/pantalla-xorg.service" /etc/systemd/system/pantalla-xorg.service
+xorg_unit_tmp="${TMP_ROOT}/pantalla-xorg.service"
+sed "s|__KIOSK_USER__|${KIOSK_USER}|g" "$REPO_DIR/systemd/pantalla-xorg.service" > "$xorg_unit_tmp"
+install -D -m 0644 "$xorg_unit_tmp" /etc/systemd/system/pantalla-xorg.service
 install -D -m 0644 "$REPO_DIR/systemd/pantalla-openbox@.service" /etc/systemd/system/pantalla-openbox@.service
+backend_unit_tmp="${TMP_ROOT}/pantalla-dash-backend@.service"
+sed "s|__REPO_DIR__|${REPO_DIR}|g" "$REPO_DIR/system/pantalla-dash-backend@.service" > "$backend_unit_tmp"
+install -D -m 0644 "$backend_unit_tmp" /etc/systemd/system/pantalla-dash-backend@.service
 systemctl daemon-reload
 systemctl enable pantalla-xorg.service "pantalla-openbox@${KIOSK_USER}.service"
 

--- a/systemd/pantalla-xorg.service
+++ b/systemd/pantalla-xorg.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Pantalla_reloj Xorg server (:0, vt7)
 After=systemd-user-sessions.service
-Wants=pantalla-openbox@dani.service
+Wants=pantalla-openbox@__KIOSK_USER__.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary
- render the pantalla-xorg unit with the selected kiosk user before installation
- install the pantalla-dash-backend template into systemd with the repository path resolved

## Testing
- bash -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68fc43f566c88326b1ce7f62d83ba3f5