### PR TITLE
Update Firefox tarball handling

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,11 +65,11 @@ resolved_url=$(curl -fsI -o /dev/null -w '%{url_effective}' -L "$FIREFOX_URL" ||
 resolved_version=""
 if [[ -n "$resolved_url" ]]; then
   resolved_file=${resolved_url##*/}
-  resolved_file=${resolved_file%.tar.bz2}
+  resolved_file=${resolved_file%.tar.xz}
   resolved_version=${resolved_file#firefox-}
 fi
 
-firefox_tar="${TMP_ROOT}/firefox.tar.bz2"
+firefox_tar="${TMP_ROOT}/firefox.tar.xz"
 need_download=1
 if [[ -x /opt/firefox/firefox && -n "$installed_firefox_version" && -n "$resolved_version" && "$installed_firefox_version" == "$resolved_version" ]]; then
   need_download=0
@@ -86,7 +86,7 @@ if (( need_download )); then
   fi
 
   log "Extrayendo Firefox en entorno temporal"
-  tar -xjf "$firefox_tar" -C "$TMP_ROOT"
+  tar -xJf "$firefox_tar" -C "$TMP_ROOT"
   if [[ ! -d "${TMP_ROOT}/firefox" ]]; then
     err "No se encontró directorio firefox tras la extracción"
     exit 1


### PR DESCRIPTION
## Summary
- adjust install script to expect Mozilla Firefox .tar.xz archives
- use the appropriate tar extraction flag for xz-compressed downloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc4506fee0832691169f2c525b8f13