### PR TITLE
Improve kiosk install automation and health checks

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -51,3 +51,4 @@ if [[ $PURGE_USER_AUTOSTART -eq 1 ]]; then
 fi
 
 log "Desinstalación completada"
+echo "[SUCCESS] Kiosk uninstalled. You can remove /opt/firefox and /var/www/html if desired."

--- a/systemd/pantalla-xorg.service
+++ b/systemd/pantalla-xorg.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Pantalla_reloj Xorg server (:0, vt7)
 After=systemd-user-sessions.service
-Wants=pantalla-openbox@dani.service
+Wants=pantalla-openbox@__KIOSK_USER__.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary
- resolve the Mozilla tarball URL, extract .tar.xz builds, and log the deployed Firefox version with clearer failure handling
- install and configure backend, runtime directories, nginx site, and frontend assets idempotently during setup
- add comprehensive service health checks with journal dumps on failure and a concise success banner, plus clear uninstall messaging

## Testing
- bash -n scripts/install.sh
- bash -n scripts/uninstall.sh

------
https://chatgpt.com/codex/tasks/task_e_68fc49de9efc83268add4f652d431e2e