### PR TITLE
feat: redesign overlay as lateral configurable panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ operar offline si el backend no responde.
 
 - `GeoScopeCanvas` renderiza un degradado animado de referencia para la vista
   geoespacial mientras se preparan los datos reales.
-- `OverlayPanel` aplica un cristal translúcido configurable (opacidad, desenfoque,
-  radio) sobre el lienzo principal y posiciona la cabecera de reloj.
-- `Rotator` recorre las secciones informativas con transiciones *crossfade*
-  basadas en los parámetros `ui.overlay.{order,dwell_seconds,transition_ms}`.
+- `OverlayPanel` ancla un panel lateral translúcido configurable (posición, ancho,
+  opacidad y desenfoque) sobre el lienzo principal sin bloquear el mapa.
+- `Rotator` recorre las secciones informativas con transiciones *crossfade*,
+  controladas por `ui.overlay.{order,dwell_seconds,transition_ms}`.
 - Los iconos meteorológicos usan `lottie-web`; activa o desactiva la animación con
   `VITE_ENABLE_LOTTIE=1|0`.
 - `VITE_ENABLE_FPSMETER=1` muestra un contador de FPS para depurar rendimiento

--- a/backend/config/config.example.json
+++ b/backend/config/config.example.json
@@ -76,24 +76,10 @@
   "ui": {
     "mode": "geoscope_with_overlay",
     "overlay": {
-      "enabled": true,
-      "opacity": 0.28,
-      "blur_px": 6,
-      "corner_radius": 20,
-      "position": "bottom",
-      "margin_px": 24,
-      "dwell_seconds": 15,
-      "transition_ms": 450,
-      "order": [
-        "weather_now",
-        "weather_week",
-        "moon",
-        "season",
-        "ephemeris",
-        "news",
-        "saints",
-        "calendar"
-      ]
+      "position": "right",
+      "width_px": 420,
+      "opacity": 0.85,
+      "blur_px": 6
     },
     "sideInfo": {
       "enabled": true,

--- a/backend/config/config.json
+++ b/backend/config/config.json
@@ -62,24 +62,10 @@
   "ui": {
     "mode": "geoscope_with_overlay",
     "overlay": {
-      "enabled": true,
-      "opacity": 0.28,
-      "blur_px": 6,
-      "corner_radius": 20,
-      "position": "bottom",
-      "margin_px": 24,
-      "dwell_seconds": 15,
-      "transition_ms": 450,
-      "order": [
-        "weather_now",
-        "weather_week",
-        "moon",
-        "season",
-        "ephemeris",
-        "news",
-        "saints",
-        "calendar"
-      ]
+      "position": "right",
+      "width_px": 420,
+      "opacity": 0.85,
+      "blur_px": 6
     }
   },
   "geoscope": {

--- a/backend/config/schema.json
+++ b/backend/config/schema.json
@@ -90,12 +90,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "enabled": { "type": "boolean" },
-            "opacity": { "type": "number", "minimum": 0, "maximum": 1 },
-            "blur_px": { "type": "integer", "minimum": 0, "maximum": 128 },
-            "corner_radius": { "type": "integer", "minimum": 0, "maximum": 200 },
-            "position": { "type": "string", "enum": ["top", "bottom", "left", "right", "center"] },
-            "margin_px": { "type": "integer", "minimum": 0, "maximum": 200 },
+            "position": { "type": "string", "enum": ["left", "right"] },
+            "width_px": { "type": "integer", "minimum": 280, "maximum": 640 },
+            "opacity": { "type": "number", "minimum": 0.3, "maximum": 1 },
+            "blur_px": { "type": "integer", "minimum": 0, "maximum": 10 },
             "dwell_seconds": { "type": "integer", "minimum": 3, "maximum": 180 },
             "transition_ms": { "type": "integer", "minimum": 100, "maximum": 10000 },
             "order": {

--- a/backend/models/config.py
+++ b/backend/models/config.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, conint, validator
+from pydantic import BaseModel, ConfigDict, Field, confloat, conint, validator
 
 
 class Wifi(BaseModel):
@@ -16,15 +16,13 @@ class UiAppearance(BaseModel):
 class OverlayConfig(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    enabled: bool = True
-    opacity: float = Field(default=0.28, ge=0.0, le=1.0)
-    blur_px: conint(ge=0, le=128) = Field(6, alias="blur_px")  # type: ignore[call-arg]
-    corner_radius: conint(ge=0, le=200) = Field(20, alias="corner_radius")  # type: ignore[call-arg]
-    position: str = Field("bottom", alias="position")
-    margin_px: conint(ge=0, le=200) = Field(24, alias="margin_px")  # type: ignore[call-arg]
+    position: Literal["left", "right"] = Field("right", alias="position")
+    width_px: conint(ge=280, le=640) = Field(420, alias="width_px")  # type: ignore[call-arg]
+    opacity: confloat(ge=0.3, le=1.0) = Field(0.85, alias="opacity")  # type: ignore[call-arg]
+    blur_px: conint(ge=0, le=10) = Field(6, alias="blur_px")  # type: ignore[call-arg]
     dwell_seconds: conint(ge=3, le=180) = Field(15, alias="dwell_seconds")  # type: ignore[call-arg]
     transition_ms: conint(ge=100, le=10_000) = Field(450, alias="transition_ms")  # type: ignore[call-arg]
-    order: List[str] = Field(
+    order: list[str] = Field(
         default_factory=lambda: [
             "weather_now",
             "weather_week",
@@ -36,40 +34,6 @@ class OverlayConfig(BaseModel):
             "calendar",
         ]
     )
-
-    @validator("position")
-    def normalize_position(cls, value: str) -> str:  # type: ignore[override]
-        allowed = {"top", "bottom", "left", "right", "center"}
-        candidate = (value or "").strip().lower()
-        if candidate in allowed:
-            return candidate
-        return "bottom"
-
-    @validator("order", pre=True)
-    def sanitize_order(cls, value: Optional[List[str]]) -> List[str]:  # type: ignore[override]
-        default_order = [
-            "weather_now",
-            "weather_week",
-            "moon",
-            "season",
-            "ephemeris",
-            "news",
-            "saints",
-            "calendar",
-        ]
-        if not isinstance(value, list):
-            return default_order
-        allowed = set(default_order)
-        seen: set[str] = set()
-        normalized: List[str] = []
-        for item in value:
-            if not isinstance(item, str):
-                continue
-            key = item.strip()
-            if key in allowed and key not in seen:
-                normalized.append(key)
-                seen.add(key)
-        return normalized or default_order
 
 
 class UiConfig(BaseModel):

--- a/dash-ui/src/components/Rotator.tsx
+++ b/dash-ui/src/components/Rotator.tsx
@@ -5,6 +5,7 @@ interface RotatorProps {
   order?: OverlaySectionKey[];
   dwellSeconds?: number;
   transitionMs?: number;
+  className?: string;
 }
 
 interface PlaceholderItem {
@@ -49,7 +50,7 @@ const MAX_DWELL_MS = 120_000;
 const MIN_TRANSITION_MS = 150;
 const MAX_TRANSITION_MS = 10_000;
 
-export const Rotator = ({ order, dwellSeconds, transitionMs }: RotatorProps) => {
+export const Rotator = ({ order, dwellSeconds, transitionMs, className }: RotatorProps) => {
   const sanitizedOrder = useMemo(() => sanitizeOrder(order), [order]);
   const [index, setIndex] = useState(0);
   const [visible, setVisible] = useState(true);
@@ -101,14 +102,20 @@ export const Rotator = ({ order, dwellSeconds, transitionMs }: RotatorProps) => 
   const currentKey = sanitizedOrder[index % sanitizedOrder.length];
   const currentItem = PLACEHOLDERS.find((item) => item.key === currentKey) ?? PLACEHOLDERS[0];
 
+  const rootClassName = ['relative min-h-[180px] w-full overflow-hidden', className]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div className="relative min-h-[180px] w-full overflow-hidden">
+    <div className={rootClassName}>
       <div
         className="absolute inset-0 flex flex-col justify-center gap-3 transition-opacity duration-500 ease-in-out"
         style={{ opacity: visible ? 1 : 0, transitionDuration: `${fadeMs}ms` }}
       >
-        <div className="text-sm uppercase tracking-[0.35em] text-white/60">{currentItem.title}</div>
-        <div className="text-3xl font-semibold text-white drop-shadow-lg">{currentItem.subtitle}</div>
+        <div className="text-xs uppercase tracking-[0.35em] text-white/60">{currentItem.title}</div>
+        <div className="text-xl font-semibold leading-snug text-white drop-shadow-lg">
+          {currentItem.subtitle}
+        </div>
       </div>
     </div>
   );

--- a/dash-ui/src/pages/Display.tsx
+++ b/dash-ui/src/pages/Display.tsx
@@ -12,8 +12,9 @@ const Display = () => {
   return (
     <div className="relative h-screen w-screen overflow-hidden bg-black text-white">
       <GeoScopeCanvas />
-      <OverlayPanel>
+      <OverlayPanel settings={overlaySettings}>
         <Rotator
+          className="h-full"
           order={overlaySettings.order}
           dwellSeconds={overlaySettings.dwell_seconds}
           transitionMs={overlaySettings.transition_ms}

--- a/dash-ui/src/services/config.ts
+++ b/dash-ui/src/services/config.ts
@@ -55,12 +55,10 @@ export type OverlaySectionKey =
   | 'calendar';
 
 export interface OverlayConfig {
-  enabled?: boolean;
+  position?: 'left' | 'right';
+  width_px?: number;
   opacity?: number;
   blur_px?: number;
-  corner_radius?: number;
-  position?: 'top' | 'bottom' | 'left' | 'right' | 'center';
-  margin_px?: number;
   dwell_seconds?: number;
   transition_ms?: number;
   order?: OverlaySectionKey[];


### PR DESCRIPTION
## Summary
- anchor the display overlay as a fixed-width lateral panel with configurable position, opacity, blur and updated rotator layout
- expose overlay controls in the configuration UI and update backend schema/defaults for the new overlay properties
- refresh documentation and examples to reflect the new overlay behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fc57f2a6188326aa1d6b20b04ccc0e