### PR TITLE
Fix TypeScript build failures for dash UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 .env
+dash-ui/dist/
+dash-ui/tsconfig*.tsbuildinfo
+dash-ui/vite.config.js
+dash-ui/vite.config.d.ts

--- a/dash-ui/src/modules/AstronomyModule.tsx
+++ b/dash-ui/src/modules/AstronomyModule.tsx
@@ -1,13 +1,14 @@
 import React from "react";
+import { coerceToDisplayString } from "../utils/text";
 
 type Props = {
   data: Record<string, unknown>;
 };
 
 export const AstronomyModule: React.FC<Props> = ({ data }) => {
-  const moonPhase = data.moon_phase ?? data.moonPhase ?? "--";
-  const sunrise = data.sunrise ?? "--";
-  const sunset = data.sunset ?? "--";
+  const moonPhase = coerceToDisplayString(data.moon_phase ?? data.moonPhase);
+  const sunrise = coerceToDisplayString(data.sunrise);
+  const sunset = coerceToDisplayString(data.sunset);
 
   return (
     <div className="module-wrapper">

--- a/dash-ui/src/modules/WeatherModule.tsx
+++ b/dash-ui/src/modules/WeatherModule.tsx
@@ -1,25 +1,31 @@
 import React from "react";
+import { coerceToDisplayString } from "../utils/text";
 
 type Props = {
   data: Record<string, unknown>;
 };
 
 export const WeatherModule: React.FC<Props> = ({ data }) => {
-  const temperature = data.temperature ?? "--";
-  const unit = data.unit ?? "°C";
-  const condition = data.condition ?? "Desconocido";
-  const location = data.location ?? "--";
-  const updatedAt = data.updated_at ?? data.updatedAt ?? "";
+  const temperatureValue = coerceToDisplayString(data.temperature);
+  const unit = coerceToDisplayString(data.unit, "°C");
+  const condition = coerceToDisplayString(data.condition, "Desconocido");
+  const location = coerceToDisplayString(data.location);
+  const updatedAtRaw = data.updated_at ?? data.updatedAt;
+  const updatedAt = updatedAtRaw ? coerceToDisplayString(updatedAtRaw, "") : "";
 
   return (
     <div className="module-wrapper">
       <div>
         <h2>Condiciones actuales</h2>
         <div className="module-content">
-          <div style={{ fontSize: "4.5rem", fontWeight: 600 }}>{`${temperature}${unit}`}</div>
+          <div style={{ fontSize: "4.5rem", fontWeight: 600 }}>{`${temperatureValue}${unit}`}</div>
           <div style={{ fontSize: "1.6rem", color: "rgba(231,240,255,0.78)" }}>{condition}</div>
           <div style={{ fontSize: "1.2rem", color: "rgba(173,203,239,0.7)" }}>{location}</div>
-          {updatedAt && <div style={{ fontSize: "0.9rem", color: "rgba(173,203,239,0.5)" }}>Actualizado: {String(updatedAt)}</div>}
+          {updatedAt && (
+            <div style={{ fontSize: "0.9rem", color: "rgba(173,203,239,0.5)" }}>
+              Actualizado: {updatedAt}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/dash-ui/src/utils/text.ts
+++ b/dash-ui/src/utils/text.ts
@@ -1,0 +1,22 @@
+export const coerceToDisplayString = (
+  value: unknown,
+  fallback = "--"
+): string => {
+  if (value == null) {
+    return fallback;
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return fallback;
+};

--- a/dash-ui/tsconfig.node.json
+++ b/dash-ui/tsconfig.node.json
@@ -1,9 +1,13 @@
 {
   "compilerOptions": {
     "composite": true,
+    "skipLibCheck": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "typeRoots": ["./types", "./node_modules/@types"]
   },
   "include": ["vite.config.ts"]
 }

--- a/dash-ui/types/node-shims/index.d.ts
+++ b/dash-ui/types/node-shims/index.d.ts
@@ -1,0 +1,82 @@
+// Minimal Node.js type shims to satisfy the TypeScript compiler when the real
+// `@types/node` package is unavailable in the deployment environment.
+declare const Buffer: {
+  from: (...args: unknown[]) => unknown;
+  isBuffer: (value: unknown) => boolean;
+  byteLength: (...args: unknown[]) => number;
+};
+
+type Buffer = unknown;
+
+declare namespace NodeJS {
+  interface EventEmitter {}
+  interface Timeout {}
+}
+
+declare module "node:events" {
+  export class EventEmitter implements NodeJS.EventEmitter {
+    on: (...args: unknown[]) => this;
+    off: (...args: unknown[]) => this;
+    once: (...args: unknown[]) => this;
+    emit: (...args: unknown[]) => boolean;
+  }
+}
+
+declare module "node:http" {
+  export type OutgoingHttpHeaders = Record<string, string>;
+  export type ClientRequestArgs = Record<string, unknown>;
+  export type IncomingMessage = unknown;
+  export type ClientRequest = unknown;
+  export type Agent = unknown;
+  export type Server = unknown;
+  export type ServerResponse = unknown;
+  const http: unknown;
+  export = http;
+}
+
+declare module "node:http2" {
+  export type Http2SecureServer = unknown;
+}
+
+declare module "node:https" {
+  export type ServerOptions = Record<string, unknown>;
+  export type Server = unknown;
+}
+
+declare module "node:fs" {
+  const fs: unknown;
+  export = fs;
+}
+
+declare module "node:net" {
+  const net: unknown;
+  export = net;
+}
+
+declare module "node:url" {
+  export class URL {}
+  const url: unknown;
+  export = url;
+}
+
+declare module "node:stream" {
+  export type Duplex = unknown;
+  export type DuplexOptions = Record<string, unknown>;
+}
+
+declare module "node:tls" {
+  export type SecureContextOptions = Record<string, unknown>;
+}
+
+declare module "node:zlib" {
+  export type ZlibOptions = Record<string, unknown>;
+}
+
+declare module "node:buffer" {
+  export const Buffer: typeof globalThis extends { Buffer: infer T } ? T : never;
+}
+
+declare module "rollup/parseAst" {
+  export const parseAst: (...args: unknown[]) => unknown;
+  export const parseAstAsync: (...args: unknown[]) => Promise<unknown>;
+}


### PR DESCRIPTION
## Summary
- add minimal Node.js type shims and update the Node TypeScript config to consume them
- coerce incoming module data to display-safe strings through a shared helper
- ignore generated build artifacts in the repository

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fc8459fe088326aa73e770c03b09fe