### PR TITLE
Remove default server flag from nginx site

### DIFF
--- a/etc/nginx/sites-available/pantalla-reloj.conf
+++ b/etc/nginx/sites-available/pantalla-reloj.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 80;
     server_name _;
 
     root /var/www/html;


### PR DESCRIPTION
## Summary
- drop the `default_server` flag from the Pantalla Nginx site so it can coexist with other default sites without triggering duplicate default server errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc8612296c832688adc7eb94800e1b