### PR TITLE
Fix backend systemd service module path

### DIFF
--- a/systemd/pantalla-dash-backend@.service
+++ b/systemd/pantalla-dash-backend@.service
@@ -8,7 +8,8 @@ Type=simple
 User=%i
 WorkingDirectory=/opt/pantalla/backend
 Environment="PATH=/opt/pantalla/backend/.venv/bin"
-ExecStart=/opt/pantalla/backend/.venv/bin/uvicorn main:app --host 127.0.0.1 --port 8081 --proxy-headers
+Environment="PYTHONPATH=/opt/pantalla"
+ExecStart=/opt/pantalla/backend/.venv/bin/uvicorn backend.main:app --host 127.0.0.1 --port 8081 --proxy-headers
 Restart=always
 RestartSec=2
 StandardOutput=append:/var/log/pantalla/backend.log


### PR DESCRIPTION
## Summary
- ensure the backend systemd unit exposes /opt/pantalla on PYTHONPATH
- update the unit to start uvicorn with the backend.main module so relative imports succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc88008a00832692a23cac5ba1ec40