### PR TITLE
fix: unmask display manager on uninstall

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -17,6 +17,7 @@ rm -f /etc/systemd/system/pantalla-dash-backend@.service
 rm -f /etc/systemd/system/pantalla-xorg.service
 systemctl daemon-reload
 systemctl reset-failed || true
+systemctl unmask display-manager.service 2>/dev/null || true
 
 rm -f /etc/nginx/sites-enabled/pantalla-reloj.conf
 rm -f /etc/nginx/sites-available/pantalla-reloj.conf


### PR DESCRIPTION
## Summary
- ensure the uninstaller restores the display-manager.service mask state by unmasking it before exit

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fca6811d248326938ae7cc9d342e93