### PR TITLE
Improve kiosk boot reliability

### DIFF
--- a/openbox/autostart
+++ b/openbox/autostart
@@ -1,57 +1,30 @@
-#!/usr/bin/env bash
-# Autostart Pantalla_reloj — robusto (singleton + healthchecks)
-exec >>/tmp/openbox-autostart.log 2>&1
-set -euo pipefail
+#!/bin/sh
+xset -dpms || true
+xset s off || true
+xset s noblank || true
 
-# --- X env ---
-export DISPLAY=:0
-export XAUTHORITY=/home/dani/.Xauthority
+if command -v unclutter >/dev/null 2>&1; then
+  unclutter --fork --hide-on-touch || true
+fi
 
-# --- Rotación + no-blank ---
+LOG_FILE=/tmp/openbox-autostart.log
+{
+  printf '\n[%s] openbox-autostart start (pid=%s user=%s)\n' "$(date -Is)" "$$" "$(id -un 2>/dev/null || echo '?')"
+  printf 'DISPLAY=%s\n' "${DISPLAY:-}"
+  env | sort | sed 's/^/ENV: /'
+} >>"$LOG_FILE" 2>&1
+
 XR_OUT="$(xrandr --query | awk '/ connected/{print $1; exit}')"
-if [ -n "${XR_OUT:-}" ]; then
+if [ -n "$XR_OUT" ]; then
   xrandr --output "$XR_OUT" --rotate left --primary || true
 fi
-xset -dpms
-xset s off
-xset s noblank
 
-# --- Workarounds gráficos (evitar negro por DRM/EGL) ---
-export GDK_BACKEND=x11
-export GDK_GL=disable
-export LIBGL_ALWAYS_SOFTWARE=1
-export WEBKIT_DISABLE_DMABUF_RENDERER=1
-export GTK_USE_PORTAL=0
+echo "[$(date -Is)] XR_OUT=${XR_OUT:-<none>}" >>"$LOG_FILE"
 
-# --- Esperar a Nginx y Backend (máx 30s) ---
-for i in $(seq 1 30); do
-  CURL_OPTS="--silent --fail --max-time 0.7"
-  if curl $CURL_OPTS http://127.0.0.1/ >/dev/null 2>&1 && \
-     curl $CURL_OPTS http://127.0.0.1/api/health >/dev/null 2>&1; then
-    break
-  fi
-  sleep 1
-done
+sleep 1
 
-# --- Singleton con flock ---
-LOCK="/tmp/kiosk.lock"
-(
-  flock -n 9 || exit 0
+/usr/local/bin/kiosk-launch &
+KIOSK_PID=$!
 
-  # Cierra instancias previas
-  pkill -9 -f 'epiphany-browser' 2>/dev/null || true
-  pkill -9 -f 'firefox' 2>/dev/null || true
-  sleep 0.3
-
-  # Lanzar SOLO Epiphany (más ligero/fiable en este setup)
-  setsid -f epiphany-browser --new-window "http://127.0.0.1/?v=$(date +%s)" \
-    >/tmp/epi.out 2>/tmp/epi.err || true
-
-  # Si algún día se vuelve a Firefox, comentar Epiphany y descomentar:
-  # export MOZ_ENABLE_WAYLAND=0
-  # export MOZ_WEBRENDER=0
-  # export MOZ_DISABLE_GPU_SANDBOX=1
-  # setsid -f /usr/local/bin/firefox --no-remote --kiosk "http://127.0.0.1/?v=$(date +%s)" \
-  #   >/tmp/kiosk.out 2>/tmp/kiosk.err || true
-
-) 9>"$LOCK"
+echo "[$(date -Is)] kiosk-launch pid=$KIOSK_PID" >>"$LOG_FILE"
+echo "[$(date -Is)] openbox-autostart end" >>"$LOG_FILE"

--- a/scripts/kiosk-launch
+++ b/scripts/kiosk-launch
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -eu
+
+LOG_FILE=/tmp/kiosk-launch.log
+{
+  printf '\n[%s] kiosk-launch invoked (pid=%s)\n' "$(date -Is)" "$$"
+} >>"$LOG_FILE"
+exec >>"$LOG_FILE" 2>&1
+
+export DISPLAY=:0
+export XAUTHORITY=/home/dani/.Xauthority
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export LIBGL_ALWAYS_SOFTWARE=1
+printf '[%s] Environment prepared: DISPLAY=%s XAUTHORITY=%s\n' "$(date -Is)" "$DISPLAY" "$XAUTHORITY"
+
+LOCK_FILE=/tmp/kiosk.lock
+PID_FILE=/tmp/kiosk.pid
+
+(
+  if ! command -v flock >/dev/null 2>&1; then
+    echo "flock command not available" >&2
+    exit 1
+  fi
+
+  flock -n 9 || {
+    printf '[%s] Another kiosk-launch instance is running\n' "$(date -Is)"
+    exit 0
+  }
+
+  if command -v wmctrl >/dev/null 2>&1; then
+    if wmctrl -l 2>/dev/null | grep -qi 'Epiphany'; then
+      printf '[%s] Epiphany window already present, exiting\n' "$(date -Is)"
+      exit 0
+    fi
+  fi
+
+  FRONT_OK=0
+  API_OK=0
+  for attempt in $(seq 1 30); do
+    if [ $FRONT_OK -eq 0 ]; then
+      if curl -sf --max-time 1 http://127.0.0.1/ >/dev/null 2>&1; then
+        FRONT_OK=1
+        printf '[%s] Frontend reachable on attempt %s\n' "$(date -Is)" "$attempt"
+      fi
+    fi
+    if [ $API_OK -eq 0 ]; then
+      if curl -sf --max-time 1 http://127.0.0.1:8081/api/health >/dev/null 2>&1; then
+        API_OK=1
+        printf '[%s] Backend reachable on attempt %s\n' "$(date -Is)" "$attempt"
+      fi
+    fi
+    if [ $FRONT_OK -eq 1 ] && [ $API_OK -eq 1 ]; then
+      break
+    fi
+    sleep 1
+  done
+  printf '[%s] Launching Epiphany (FRONT_OK=%s API_OK=%s)\n' "$(date -Is)" "$FRONT_OK" "$API_OK"
+
+  if ! dbus-run-session sh -c 'setsid -f epiphany-browser --new-window http://127.0.0.1 > /tmp/epi.out 2>/tmp/epi.err'; then
+    printf '[%s] Epiphany launch command failed\n' "$(date -Is)"
+  fi
+
+  sleep 3
+
+  WINDOW_ID=""
+  if command -v xdotool >/dev/null 2>&1; then
+    WINDOW_ID="$(xdotool search --class Epiphany 2>/dev/null | head -n1 || true)"
+  fi
+  if [ -n "$WINDOW_ID" ]; then
+    printf '[%s] Adjusting window %s\n' "$(date -Is)" "$WINDOW_ID"
+    wmctrl -ir "$WINDOW_ID" -b remove,maximized_vert -b remove,maximized_horz 2>/dev/null || true
+    wmctrl -ir "$WINDOW_ID" -b add,fullscreen 2>/dev/null || true
+    wmctrl -ir "$WINDOW_ID" -e 0,0,0,1920,480 2>/dev/null || true
+    xdotool windowsize "$WINDOW_ID" 1920 480 2>/dev/null || true
+    xdotool windowmove "$WINDOW_ID" 0 0 2>/dev/null || true
+    xdotool windowactivate "$WINDOW_ID" 2>/dev/null || true
+  else
+    printf '[%s] Could not locate Epiphany window\n' "$(date -Is)"
+  fi
+
+  EPIPHANY_PID="$(pgrep -n -f 'epiphany-browser --new-window http://127.0.0.1' || true)"
+  if [ -z "$EPIPHANY_PID" ]; then
+    EPIPHANY_PID="$(pgrep -n epiphany-browser || true)"
+  fi
+  if [ -n "$EPIPHANY_PID" ]; then
+    printf '%s\n' "$EPIPHANY_PID" >"$PID_FILE"
+    printf '[%s] Recorded Epiphany PID %s\n' "$(date -Is)" "$EPIPHANY_PID"
+  else
+    printf '[%s] Unable to determine Epiphany PID\n' "$(date -Is)"
+  fi
+
+  printf '[%s] kiosk-launch done\n' "$(date -Is)"
+) 9>"$LOCK_FILE"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -24,8 +24,9 @@ PR_STATE_DIR=/var/lib/pantalla-reloj
 PR_STATE_STATE_DIR="$PR_STATE_DIR/state"
 DISPLAY_MANAGER_MARK="$PR_STATE_STATE_DIR/display-manager.masked"
 
+systemctl unmask display-manager.service 2>/dev/null || true
+
 if [[ -f "$DISPLAY_MANAGER_MARK" ]]; then
-  systemctl unmask display-manager.service 2>/dev/null || true
   rm -f "$DISPLAY_MANAGER_MARK"
 fi
 
@@ -67,8 +68,17 @@ HTML
 fi
 chown -R www-data:www-data /var/www/html 2>/dev/null || true
 
+rm -f /usr/local/bin/kiosk-launch
+
+rm -f /etc/udev/rules.d/70-pantalla-render.rules
+udevadm control --reload 2>/dev/null || true
+udevadm trigger 2>/dev/null || true
+
 AUTO_FILE="/home/dani/.config/openbox/autostart"
-if [[ -f "$AUTO_FILE" ]] && grep -q "Pantalla_reloj" "$AUTO_FILE"; then
+AUTO_BACKUP="${AUTO_FILE}.pantalla-reloj.bak"
+if [[ -f "$AUTO_BACKUP" ]]; then
+  mv -f "$AUTO_BACKUP" "$AUTO_FILE"
+elif [[ -f "$AUTO_FILE" ]]; then
   rm -f "$AUTO_FILE"
 fi
 

--- a/systemd/pantalla-dash-backend@.service
+++ b/systemd/pantalla-dash-backend@.service
@@ -9,9 +9,9 @@ User=%i
 WorkingDirectory=/opt/pantalla/backend
 Environment="PATH=/opt/pantalla/backend/.venv/bin"
 Environment="PYTHONPATH=/opt/pantalla"
-ExecStart=/opt/pantalla/backend/.venv/bin/uvicorn backend.main:app --host 127.0.0.1 --port 8081 --proxy-headers
+ExecStart=/opt/pantalla/backend/.venv/bin/python -m uvicorn backend.main:app --host 127.0.0.1 --port 8081 --proxy-headers --timeout-keep-alive 30
 Restart=always
-RestartSec=2
+RestartSec=1s
 StandardOutput=append:/var/log/pantalla/backend.log
 StandardError=append:/var/log/pantalla/backend.log
 

--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Pantalla_reloj Openbox session for %i (DISPLAY=:0)
-After=systemd-user-sessions.service getty@tty7.service
-After=pantalla-xorg.service pantalla-dash-backend@%i.service nginx.service
+After=systemd-user-sessions.service getty@tty7.service pantalla-xorg.service pantalla-dash-backend@%i.service nginx.service
+Requires=pantalla-xorg.service
 Wants=pantalla-dash-backend@%i.service nginx.service
 
 [Service]
@@ -15,7 +15,7 @@ TTYVHangup=yes
 TTYVTDisallocate=yes
 ExecStart=/usr/bin/openbox --startup "/usr/lib/x86_64-linux-gnu/openbox-autostart OPENBOX"
 Restart=always
-RestartSec=2
+RestartSec=2s
 
 [Install]
 WantedBy=graphical.target

--- a/systemd/pantalla-xorg.service
+++ b/systemd/pantalla-xorg.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Pantalla_reloj Xorg server (:0, vt7)
-After=systemd-user-sessions.service
+After=systemd-user-sessions.service systemd-logind.service
 Conflicts=display-manager.service
-Wants=graphical.target
+Wants=graphical.target systemd-logind.service
 
 [Service]
 ExecStart=/usr/lib/xorg/Xorg :0 -verbose 3 -nolisten tcp -background none vt7
 Restart=always
-RestartSec=2
+RestartSec=2s
 
 [Install]
 WantedBy=graphical.target


### PR DESCRIPTION
## Summary
- add a flock-protected /usr/local/bin/kiosk-launch helper that waits for the frontend/backend and enforces a single Epiphany window
- simplify the Openbox autostart to log session details, rotate the panel once, and invoke the new launcher while disabling DPMS/blanking
- harden install/uninstall scripts, udev permissions, and systemd units so the kiosk stack restarts cleanly and keeps the GPU accessible

## Testing
- not run (not feasible in container)

## Post-change test script
```sh
# 1) Instalación
cd ~/Pantalla_reloj
sudo bash scripts/uninstall.sh || true
sudo bash scripts/install.sh --non-interactive

# 2) Verificaciones rápidas
systemctl is-active pantalla-xorg.service pantalla-openbox@dani.service pantalla-dash-backend@dani.service
sleep 3
curl -sf http://127.0.0.1/ >/dev/null && echo FRONT_OK
curl -sf http://127.0.0.1:8081/api/health && echo API_OK

# 3) Reboot y sanity
sudo reboot
# (tras arrancar)
tail -n 200 /tmp/openbox-autostart.log /tmp/kiosk-launch.log /tmp/epi.err || true
```


------
https://chatgpt.com/codex/tasks/task_e_68fcc2f01f1483268806e9461cd1e723