### PR TITLE
Implement Epiphany kiosk launcher via systemd

### DIFF
--- a/openbox/autostart
+++ b/openbox/autostart
@@ -1,30 +1,21 @@
 #!/bin/sh
-xset -dpms || true
-xset s off || true
-xset s noblank || true
-
-if command -v unclutter >/dev/null 2>&1; then
-  unclutter --fork --hide-on-touch || true
-fi
 
 LOG_FILE=/tmp/openbox-autostart.log
 {
-  printf '\n[%s] openbox-autostart start (pid=%s user=%s)\n' "$(date -Is)" "$$" "$(id -un 2>/dev/null || echo '?')"
-  printf 'DISPLAY=%s\n' "${DISPLAY:-}"
-  env | sort | sed 's/^/ENV: /'
+  printf '===== %s openbox-autostart start =====\n' "$(date -Is)"
 } >>"$LOG_FILE" 2>&1
+
+xset -dpms || true
+xset s off || true
+xset s noblank || true
+xsetroot -solid '#111623' || true
 
 XR_OUT="$(xrandr --query | awk '/ connected/{print $1; exit}')"
 if [ -n "$XR_OUT" ]; then
   xrandr --output "$XR_OUT" --rotate left --primary || true
 fi
 
-echo "[$(date -Is)] XR_OUT=${XR_OUT:-<none>}" >>"$LOG_FILE"
-
-sleep 1
-
-/usr/local/bin/kiosk-launch &
-KIOSK_PID=$!
-
-echo "[$(date -Is)] kiosk-launch pid=$KIOSK_PID" >>"$LOG_FILE"
-echo "[$(date -Is)] openbox-autostart end" >>"$LOG_FILE"
+echo "XR_OUT=${XR_OUT:-<none>}" >>"$LOG_FILE" 2>&1
+{
+  printf '===== %s openbox-autostart end =====\n' "$(date -Is)"
+} >>"$LOG_FILE" 2>&1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -260,8 +260,8 @@ if [[ -f "$AUTO_FILE" && ! -f "$AUTO_BACKUP" ]]; then
 fi
 install -o "$USER_NAME" -g "$USER_NAME" -m 0755 "$REPO_ROOT/openbox/autostart" "$AUTO_FILE"
 
-log_info "Instalando singleton kiosk-launch"
-install -m 0755 "$REPO_ROOT/scripts/kiosk-launch" /usr/local/bin/kiosk-launch
+log_info "Instalando lanzador kiosk-epiphany"
+install -m 0755 "$REPO_ROOT/usr/local/bin/kiosk-epiphany" /usr/local/bin/kiosk-epiphany
 
 log_info "Construyendo frontend"
 pushd "$REPO_ROOT/dash-ui" >/dev/null
@@ -295,9 +295,13 @@ log_info "Instalando unidades systemd"
 install -m 0644 "$REPO_ROOT/systemd/pantalla-xorg.service" "$SYSTEMD_DIR/pantalla-xorg.service"
 install -m 0644 "$REPO_ROOT/systemd/pantalla-openbox@.service" "$SYSTEMD_DIR/pantalla-openbox@.service"
 install -m 0644 "$REPO_ROOT/systemd/pantalla-dash-backend@.service" "$SYSTEMD_DIR/pantalla-dash-backend@.service"
+install -m 0644 "$REPO_ROOT/systemd/pantalla-kiosk@.service" "$SYSTEMD_DIR/pantalla-kiosk@.service"
 systemctl daemon-reload
 
-for svc in pantalla-xorg.service pantalla-dash-backend@${USER_NAME}.service pantalla-openbox@${USER_NAME}.service; do
+for svc in pantalla-xorg.service \
+           pantalla-dash-backend@${USER_NAME}.service \
+           pantalla-openbox@${USER_NAME}.service \
+           pantalla-kiosk@${USER_NAME}.service; do
   systemctl enable --now "$svc"
   systemctl restart "$svc"
 done

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 SERVICES=(
+  pantalla-kiosk@dani.service
   pantalla-openbox@dani.service
   pantalla-dash-backend@dani.service
   pantalla-xorg.service
@@ -17,7 +18,10 @@ done
 rm -f /etc/systemd/system/pantalla-openbox@.service
 rm -f /etc/systemd/system/pantalla-dash-backend@.service
 rm -f /etc/systemd/system/pantalla-xorg.service
-systemctl daemon-reload
+systemctl disable --now pantalla-kiosk@dani.service 2>/dev/null || true
+rm -f /usr/local/bin/kiosk-epiphany || true
+rm -f /etc/systemd/system/pantalla-kiosk@.service || true
+systemctl daemon-reload || true
 systemctl reset-failed || true
 
 PR_STATE_DIR=/var/lib/pantalla-reloj

--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Pantalla_reloj Kiosk (Epiphany) for user %i
+After=graphical.target pantallaxorg.target
+Wants=default.target
+
+[Service]
+Type=simple
+User=%i
+Environment=DISPLAY=:0
+ExecStart=/usr/local/bin/kiosk-epiphany
+Restart=on-failure
+RestartSec=3
+StartLimitIntervalSec=0
+
+[Install]
+WantedBy=default.target

--- a/usr/local/bin/kiosk-epiphany
+++ b/usr/local/bin/kiosk-epiphany
@@ -1,0 +1,68 @@
+#!/bin/sh
+set -eu
+
+LOG=/tmp/kiosk-launch.log
+exec 1>>"$LOG" 2>&1
+echo "===== $(date -Is) kiosk-epiphany start ====="
+
+# Entorno X
+export DISPLAY=:0
+export XAUTHORITY=/home/dani/.Xauthority
+export XDG_RUNTIME_DIR="/run/user/1000"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR" || true
+
+# Suavizar problemas GL/DRM en hardware raro
+export WEBKIT_DISABLE_DMABUF_RENDERER=1
+export LIBGL_ALWAYS_SOFTWARE=1
+export GDK_BACKEND=x11
+
+# Singleton por lock
+LOCK=/tmp/kiosk.lock
+exec 9>"$LOCK" || true
+if ! flock -n 9; then
+  echo "otro kiosk ya activo"
+  exit 0
+fi
+
+URL="http://127.0.0.1"
+
+# Espera best-effort hasta 35s a que estén front y back
+deadline=$(( $(date +%s) + 35 ))
+while :; do
+  ok_front=0
+  ok_api=0
+  curl -sf "$URL" >/dev/null 2>&1 && ok_front=1 || true
+  curl -sf "$URL:8081/api/health" >/dev/null 2>&1 && ok_api=1 || true
+  [ $ok_front -eq 1 ] && [ $ok_api -eq 1 ] && break
+  [ $(date +%s) -ge $deadline ] && break
+  sleep 1
+done
+
+# Evitar duplicados si quedó algo zombie
+pkill -9 -f epiphany-browser || true
+
+# Lanzar con bus propio y sin flags exóticos
+rm -f /tmp/epi.out /tmp/epi.err
+dbus-run-session sh -c \
+  "setsid -f epiphany-browser --new-window '$URL' >/tmp/epi.out 2>/tmp/epi.err"
+
+# Dar tiempo a crear la ventana y maximizar/fullscreen
+for i in 1 2 3 4 5; do
+  WIN="$(xdotool search --class Epiphany 2>/dev/null | head -n1 || true)"
+  [ -n "$WIN" ] && break
+  sleep 1
+done
+
+if [ -n "${WIN:-}" ]; then
+  # Forzar posición/tamaño del panel 1920x480 y fullscreen
+  wmctrl -ir "$WIN" -e 0,0,0,1920,480 || true
+  wmctrl -ir "$WIN" -b add,fullscreen || true
+  xdotool windowactivate "$WIN" 2>/dev/null || true
+  xdotool windowraise "$WIN" 2>/dev/null || true
+  echo "ventana $WIN lista"
+else
+  echo "no se encontró ventana Epiphany"
+fi
+
+echo "===== $(date -Is) kiosk-epiphany done ====="


### PR DESCRIPTION
## Summary
- stop launching the browser from Openbox autostart, set the fallback background color, and retain display rotation logging
- add the kiosk-epiphany launcher script plus a dedicated systemd user service for Epiphany
- wire installation and uninstall scripts to deploy the new launcher and service assets

## Testing
- sudo bash scripts/uninstall.sh || true
- sudo bash scripts/install.sh --non-interactive
- systemctl is-active pantalla-xorg.service pantalla-openbox@dani.service pantalla-dash-backend@dani.service pantalla-kiosk@dani.service
- sleep 5
- tail -n 80 /tmp/openbox-autostart.log || true
- tail -n 80 /tmp/kiosk-launch.log || true
- tail -n 40 /tmp/epi.err || true

------
https://chatgpt.com/codex/tasks/task_e_68fcc61db7f483268bec7131f670f56e