### PR TITLE
Fix kiosk service dependency dependency typo

### DIFF
--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Pantalla_reloj Kiosk (Epiphany) for user %i
-After=graphical.target pantallaxorg.target
+After=graphical.target pantalla-xorg.service
 Wants=default.target
 
 [Service]


### PR DESCRIPTION
## Summary
- correct the kiosk service's After= directive to wait for pantalla-xorg.service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcc7e21cc0832698da5cb33f7172c1