### PR TITLE
Add kiosk recovery script and ensure Openbox launches Epiphany

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ sudo bash scripts/fix_permissions.sh [usuario] [grupo]
 Por defecto ajusta permisos para `dani:dani` y vuelve a asignar `/var/www/html` a
 `www-data`.
 
+## Reparación del entorno kiosk
+
+Si Firefox, Xorg u Openbox quedaron en un estado inconsistente (por ejemplo, un
+symlink roto en `/usr/local/bin/firefox` o permisos erróneos en
+`/run/user/1000`), ejecuta:
+
+```bash
+sudo KIOSK_USER=dani scripts/fix_kiosk_env.sh --with-firefox
+```
+
+El script reinstala el navegador desde Mozilla (opcional con
+`--with-firefox`), restablece `~/.mozilla/pantalla-kiosk`, `.Xauthority`,
+copias actualizadas de los servicios `pantalla-*.service` y reactiva
+automáticamente `pantalla-xorg`, `pantalla-openbox@dani`,
+`pantalla-dash-backend@dani` y `pantalla-kiosk@dani`.
+
 ## Desarrollo local
 
 - Backend: `cd backend && python3 -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt && uvicorn main:app --reload`

--- a/openbox/autostart
+++ b/openbox/autostart
@@ -10,6 +10,21 @@ xset s off || true
 xset s noblank || true
 xsetroot -solid '#111623' || true
 
+{
+  printf '===== %s launching kiosk-epiphany =====\n' "$(date -Is)"
+} >>"$LOG_FILE" 2>&1
+
+if command -v /usr/local/bin/kiosk-epiphany >/dev/null 2>&1; then
+  {
+    printf '===== %s kiosk-epiphany found, starting detached =====\n' "$(date -Is)"
+  } >>"$LOG_FILE" 2>&1
+  setsid -f /usr/local/bin/kiosk-epiphany >/dev/null 2>&1 || true
+else
+  {
+    printf '===== %s kiosk-epiphany missing in /usr/local/bin =====\n' "$(date -Is)"
+  } >>"$LOG_FILE" 2>&1
+fi
+
 XR_OUT="$(xrandr --query | awk '/ connected/{print $1; exit}')"
 if [ -n "$XR_OUT" ]; then
   xrandr --output "$XR_OUT" --rotate left --primary || true

--- a/scripts/fix_kiosk_env.sh
+++ b/scripts/fix_kiosk_env.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+WITH_FIREFOX=0
+
+usage() {
+  cat <<'EOF'
+Repara el entorno kiosk para Pantalla_reloj.
+
+Uso: sudo KIOSK_USER=dani scripts/fix_kiosk_env.sh [--with-firefox]
+
+Opciones:
+  --with-firefox   Fuerza reinstalación de Firefox desde Mozilla.
+  -h, --help       Muestra este mensaje y sale.
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --with-firefox)
+      WITH_FIREFOX=1
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Argumento desconocido: $arg" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ $EUID -ne 0 ]]; then
+  echo "[ERROR] Este script debe ejecutarse como root" >&2
+  exit 1
+fi
+
+KIOSK_USER="${KIOSK_USER:-dani}"
+if ! id "$KIOSK_USER" >/dev/null 2>&1; then
+  echo "[ERROR] El usuario $KIOSK_USER no existe" >&2
+  exit 1
+fi
+
+KIOSK_UID="$(id -u "$KIOSK_USER")"
+KIOSK_HOME="$(eval echo "~${KIOSK_USER}")"
+
+log_info() {
+  printf '[INFO] %s\n' "$*"
+}
+
+log_ok() {
+  printf '[OK] %s\n' "$*"
+}
+
+log_warn() {
+  printf '[WARN] %s\n' "$*"
+}
+
+FIREFOX_URL="https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=es-ES"
+FIREFOX_DEST="/opt/firefox-mozilla"
+
+install_firefox() {
+  log_info "Descargando Firefox desde Mozilla"
+  tmp_tar="$(mktemp /tmp/firefox.XXXXXX.tar)"
+  if ! curl -fsSL "$FIREFOX_URL" -o "$tmp_tar"; then
+    rm -f "$tmp_tar"
+    echo "[ERROR] No se pudo descargar Firefox" >&2
+    exit 1
+  fi
+
+  mime_type="$(file -b --mime-type "$tmp_tar")"
+  case "$mime_type" in
+    application/x-bzip2) tar_flag=j ;;
+    application/x-xz) tar_flag=J ;;
+    application/gzip|application/x-gzip) tar_flag=z ;;
+    *)
+      rm -f "$tmp_tar"
+      echo "[ERROR] El archivo de Firefox no es un tar válido (tipo $mime_type)" >&2
+      exit 1
+      ;;
+  esac
+
+  tmp_dir="$(mktemp -d /tmp/firefox.XXXXXX)"
+  if ! tar -x"${tar_flag}"f "$tmp_tar" -C "$tmp_dir"; then
+    rm -rf "$tmp_dir" "$tmp_tar"
+    echo "[ERROR] No se pudo extraer Firefox" >&2
+    exit 1
+  fi
+
+  extracted="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | head -n1 || true)"
+  if [[ -z "$extracted" ]]; then
+    rm -rf "$tmp_dir" "$tmp_tar"
+    echo "[ERROR] No se encontró el directorio extraído de Firefox" >&2
+    exit 1
+  fi
+
+  rm -rf "$FIREFOX_DEST"
+  mkdir -p "$FIREFOX_DEST"
+  mv "$extracted" "$FIREFOX_DEST/firefox"
+  rm -rf "$tmp_dir" "$tmp_tar"
+
+  install -m 0755 "$REPO_ROOT/usr/local/bin/kiosk-epiphany" /usr/local/bin/kiosk-epiphany
+  ln -sfn "$FIREFOX_DEST/firefox/firefox" /usr/local/bin/firefox
+  chmod -R 755 "$FIREFOX_DEST"
+  log_ok "Firefox reinstalado en $FIREFOX_DEST"
+}
+
+ensure_firefox() {
+  if [[ $WITH_FIREFOX -eq 1 ]]; then
+    install_firefox
+    return
+  fi
+
+  if [[ ! -x /usr/local/bin/firefox ]]; then
+    log_warn "Firefox no encontrado. Usar --with-firefox para reinstalarlo (opcional)."
+    return
+  fi
+
+  if ! /usr/local/bin/firefox --version >/dev/null 2>&1; then
+    log_warn "El binario de Firefox existe pero no responde. Ejecute con --with-firefox para repararlo."
+  else
+    log_ok "Firefox operativo ($( /usr/local/bin/firefox --version | head -n1 ))"
+  fi
+}
+
+log_info "Asegurando estructura de directorios para $KIOSK_USER"
+install -d -o "$KIOSK_USER" -g "$KIOSK_USER" -m 0700 "$KIOSK_HOME/.mozilla/pantalla-kiosk"
+install -d -o "$KIOSK_USER" -g "$KIOSK_USER" -m 0755 "$KIOSK_HOME/.config/openbox"
+install -o "$KIOSK_USER" -g "$KIOSK_USER" -m 0755 "$REPO_ROOT/openbox/autostart" "$KIOSK_HOME/.config/openbox/autostart"
+touch "$KIOSK_HOME/.Xauthority"
+chown "$KIOSK_USER:$KIOSK_USER" "$KIOSK_HOME/.Xauthority"
+
+log_info "Validando runtime en /run/user/$KIOSK_UID"
+install -d -m 0700 -o "$KIOSK_USER" -g "$KIOSK_USER" "/run/user/$KIOSK_UID"
+
+log_info "Instalando scripts kiosk"
+install -m 0755 "$REPO_ROOT/usr/local/bin/kiosk-epiphany" /usr/local/bin/kiosk-epiphany
+
+ensure_firefox
+
+log_info "Recargando systemd units"
+install -m 0644 "$REPO_ROOT/systemd/pantalla-xorg.service" /etc/systemd/system/pantalla-xorg.service
+install -m 0644 "$REPO_ROOT/systemd/pantalla-openbox@.service" /etc/systemd/system/pantalla-openbox@.service
+install -m 0644 "$REPO_ROOT/systemd/pantalla-dash-backend@.service" /etc/systemd/system/pantalla-dash-backend@.service
+install -m 0644 "$REPO_ROOT/systemd/pantalla-kiosk@.service" /etc/systemd/system/pantalla-kiosk@.service
+systemctl daemon-reload
+
+SERVICES=(
+  pantalla-xorg.service
+  "pantalla-dash-backend@${KIOSK_USER}.service"
+  "pantalla-openbox@${KIOSK_USER}.service"
+  "pantalla-kiosk@${KIOSK_USER}.service"
+)
+
+for svc in "${SERVICES[@]}"; do
+  log_info "Habilitando $svc"
+  systemctl enable --now "$svc"
+done
+
+log_ok "Entorno kiosk reparado para $KIOSK_USER"

--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Pantalla_reloj Kiosk (Epiphany) for user %i
-After=graphical.target pantallaxorg.target
-Wants=default.target
+After=pantalla-xorg.service pantalla-openbox@%i.service
+Requires=pantalla-openbox@%i.service
+PartOf=pantalla-openbox@%i.service
 
 [Service]
 Type=simple
@@ -13,4 +14,4 @@ RestartSec=3
 StartLimitIntervalSec=0
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical.target


### PR DESCRIPTION
## Summary
- add a fix_kiosk_env.sh helper to rebuild the kiosk runtime, optionally reinstalling Firefox
- update the Openbox autostart sequence to launch the kiosk script directly with logging
- tighten the pantalla-kiosk systemd unit ordering and document the recovery path in the README

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68fccdbd022c8326a15e37e06a3d2081