### PR TITLE
Ensure kiosk services share canonical Xauthority cookie

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -62,6 +62,7 @@ USER_NAME="dani"
 PANTALLA_PREFIX=/opt/pantalla-reloj
 BACKEND_DEST="${PANTALLA_PREFIX}/backend"
 STATE_DIR=/var/lib/pantalla-reloj
+AUTH_FILE="${STATE_DIR}/.Xauthority"
 STATE_RUNTIME="${STATE_DIR}/state"
 LOG_DIR=/var/log/pantalla-reloj
 WEB_ROOT=/var/www/html
@@ -192,6 +193,20 @@ if [[ $PURGE_CONFIG -eq 1 ]]; then
 else
   # Keep state but remove runtime markers
   rm -rf "$STATE_RUNTIME"
+fi
+
+HOME_AUTH="/home/${USER_NAME}/.Xauthority"
+HOME_AUTH_BACKUP="${HOME_AUTH}.bak"
+
+if [[ -L "$HOME_AUTH" ]]; then
+  link_target="$(readlink "$HOME_AUTH")"
+  if [[ "$link_target" == "$AUTH_FILE" ]] || [[ "$(readlink -f "$HOME_AUTH" 2>/dev/null || true)" == "$AUTH_FILE" ]]; then
+    rm -f "$HOME_AUTH"
+  fi
+fi
+
+if [[ ! -e "$HOME_AUTH" && -f "$HOME_AUTH_BACKUP" ]]; then
+  mv -f "$HOME_AUTH_BACKUP" "$HOME_AUTH"
 fi
 
 AUTO_FILE="/home/${USER_NAME}/.config/openbox/autostart"

--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -10,11 +10,13 @@ Type=simple
 User=%i
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
+Environment=XDG_RUNTIME_DIR=/run/user/%U
 Environment=WEBKIT_DISABLE_DMABUF_RENDERER=1
 Environment=WEBKIT_DISABLE_COMPOSITING_MODE=1
 Environment=GSK_RENDERER=cairo
 Environment=LIBGL_ALWAYS_SOFTWARE=1
 Environment=GTK_USE_PORTAL=0
+ExecStartPre=/usr/bin/test -r /var/lib/pantalla-reloj/.Xauthority
 ExecStart=/usr/local/bin/pantalla-kiosk http://127.0.0.1
 Restart=always
 RestartSec=3

--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -8,11 +8,13 @@ Wants=pantalla-dash-backend@%i.service
 User=%i
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
+Environment=XDG_RUNTIME_DIR=/run/user/%U
 PAMName=login
 TTYPath=/dev/tty7
 TTYReset=yes
 TTYVHangup=yes
 TTYVTDisallocate=yes
+ExecStartPre=/usr/bin/test -r /var/lib/pantalla-reloj/.Xauthority
 ExecStart=/usr/bin/openbox --startup "/usr/lib/x86_64-linux-gnu/openbox-autostart OPENBOX"
 Restart=always
 RestartSec=2s


### PR DESCRIPTION
## Summary
- ensure xorg-launch provisions the canonical /var/lib/pantalla-reloj/.Xauthority and links it into the user home with backup handling
- export the shared Xauthority path and runtime directory to Openbox and kiosk services and verify the cookie before launching
- make the installer/uninstaller manage state directory ownership, conditionally reload systemd, and restart services in dependency order

## Testing
- bash -n usr/lib/pantalla-reloj/xorg-launch.sh
- bash -n scripts/install.sh
- bash -n scripts/uninstall.sh

------
https://chatgpt.com/codex/tasks/task_e_68fce0737e488326a7d8bed029fe6898