### PR TITLE
Wait for X before launching Openbox

### DIFF
--- a/opt/pantalla/bin/wait-x.sh
+++ b/opt/pantalla/bin/wait-x.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+: "${DISPLAY:?DISPLAY must be set}"
+: "${XAUTHORITY:?XAUTHORITY must be set}"
+
+log() {
+  printf '%(%H:%M:%S)T wait-x: %s\n' -1 "$*"
+}
+
+attempts=30
+sleep_interval=0.5
+last_error=""
+
+for ((i=1; i<=attempts; i++)); do
+  if output=$(xdpyinfo 2>&1); then
+    log "DISPLAY ${DISPLAY} is ready (attempt ${i})"
+    exit 0
+  fi
+  last_error="$output"
+  log "Attempt ${i} failed; retrying after ${sleep_interval}s"
+  sleep "${sleep_interval}"
+done
+
+log "Failed to reach DISPLAY ${DISPLAY} after ${attempts} attempts"
+if [[ -n "${last_error}" ]]; then
+  printf '%s\n' "${last_error}" >&2
+fi
+exit 1

--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -3,13 +3,6 @@ set -euxo pipefail
 
 LOG_FILE=/tmp/openbox-autostart.log
 {
-  printf '%s Starting Openbox autostart\n' "$(date -Is)"
-
-  printf '%s Disabling DPMS and screen blanking\n' "$(date -Is)"
-  xset -dpms s off s noblank || true
-
-  printf '%s Setting HDMI-1 as primary rotated left\n' "$(date -Is)"
   xrandr --output HDMI-1 --rotate left --primary || true
-
-  printf '%s Autostart sequence completed\n' "$(date -Is)"
+  xset -dpms s off s noblank || true
 } >>"$LOG_FILE" 2>&1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,6 +164,7 @@ fi
 install -o "$USER_NAME" -g "$USER_NAME" -m 0755 "$REPO_ROOT/openbox/autostart" "$AUTO_FILE"
 
 install -m 0755 "$REPO_ROOT/opt/pantalla/bin/xorg-openbox-env.sh" "$SESSION_PREFIX/bin/xorg-openbox-env.sh"
+install -m 0755 "$REPO_ROOT/opt/pantalla/bin/wait-x.sh" "$SESSION_PREFIX/bin/wait-x.sh"
 install -m 0755 "$REPO_ROOT/opt/pantalla/openbox/autostart" "$SESSION_PREFIX/openbox/autostart"
 
 install -m 0755 "$KIOSK_BIN_SRC" "$KIOSK_BIN_DST"
@@ -370,7 +371,6 @@ systemctl enable pantalla-kiosk@${USER_NAME}.service
 
 log_info "Restarting Pantalla services"
 systemctl restart pantalla-xorg.service
-systemctl enable --now pantalla-openbox@${USER_NAME}.service
 systemctl restart pantalla-openbox@${USER_NAME}.service
 systemctl restart pantalla-dash-backend@${USER_NAME}.service
 systemctl restart pantalla-kiosk@${USER_NAME}.service

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -187,6 +187,7 @@ if [[ $PURGE_ASSETS -eq 1 ]]; then
 fi
 
 rm -f "$SESSION_PREFIX/bin/xorg-openbox-env.sh"
+rm -f "$SESSION_PREFIX/bin/wait-x.sh"
 rm -f "$SESSION_PREFIX/openbox/autostart"
 if [[ -d "$SESSION_PREFIX/bin" ]]; then
   rmdir --ignore-fail-on-non-empty "$SESSION_PREFIX/bin" || true

--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -11,9 +11,10 @@ Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
 Environment=XDG_RUNTIME_DIR=/run/user/%U
 WorkingDirectory=/home/%i
-ExecStartPre=/bin/sh -c 'install -d -m 0700 -o %i -g %i "$XDG_RUNTIME_DIR"'
-ExecStartPre=/bin/sh -c 'if [ ! -r "$XAUTHORITY" ]; then echo "pantalla-openbox@: missing XAUTHORITY at $XAUTHORITY" >&2; exit 1; fi'
-ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" xset q >/dev/null 2>&1 || true'
+ExecStartPre=/usr/bin/install -d -m 0700 -o %i -g %i "$XDG_RUNTIME_DIR"
+ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "pantalla-openbox@: missing XAUTHORITY at $XAUTHORITY" >&2; exit 1; }'
+ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
+ExecStartPre=/usr/bin/install -m 0755 /opt/pantalla/openbox/autostart /opt/pantalla/openbox/autostart
 ExecStart=/usr/bin/openbox --startup /opt/pantalla/openbox/autostart
 Restart=always
 RestartSec=2


### PR DESCRIPTION
## Summary
- add a wait-x helper that polls DISPLAY=:0 with the configured Xauthority cookie
- update the pantalla-openbox@.service unit to run the preflight checks and enforce autostart permissions
- simplify the Openbox autostart script and ensure install/uninstall handle the new helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fce4ef9e888326bc112a331f05b685