### PR TITLE
Address Codex review issues for wait-x helper

### DIFF
--- a/opt/pantalla/bin/wait-x.sh
+++ b/opt/pantalla/bin/wait-x.sh
@@ -13,7 +13,7 @@ sleep_interval=0.5
 last_error=""
 
 for ((i=1; i<=attempts; i++)); do
-  if output=$(xdpyinfo 2>&1); then
+  if output=$(xset q 2>&1); then
     log "DISPLAY ${DISPLAY} is ready (attempt ${i})"
     exit 0
   fi

--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -14,7 +14,6 @@ WorkingDirectory=/home/%i
 ExecStartPre=/usr/bin/install -d -m 0700 -o %i -g %i "$XDG_RUNTIME_DIR"
 ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "pantalla-openbox@: missing XAUTHORITY at $XAUTHORITY" >&2; exit 1; }'
 ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
-ExecStartPre=/usr/bin/install -m 0755 /opt/pantalla/openbox/autostart /opt/pantalla/openbox/autostart
 ExecStart=/usr/bin/openbox --startup /opt/pantalla/openbox/autostart
 Restart=always
 RestartSec=2


### PR DESCRIPTION
## Summary
- remove the failing ExecStartPre stanza from pantalla-openbox@.service
- switch wait-x.sh to probe DISPLAY readiness with xset q instead of xdpyinfo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fce6c29bbc8326b32498d1ac8f69f6