### PR TITLE
Fix Openbox runtime directory setup

### DIFF
--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -9,9 +9,9 @@ User=%i
 Group=%i
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
-Environment=XDG_RUNTIME_DIR=/run/user/%U
+Environment=XDG_RUNTIME_DIR=/run/user/1000
 WorkingDirectory=/home/%i
-ExecStartPre=/usr/bin/install -d -m 0700 -o %i -g %i "$XDG_RUNTIME_DIR"
+ExecStartPre=/usr/bin/install -d -m 0700 -o %i -g %i /run/user/1000
 ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "pantalla-openbox@: missing XAUTHORITY at $XAUTHORITY" >&2; exit 1; }'
 ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
 ExecStartPre=/usr/bin/install -m 0755 /opt/pantalla/openbox/autostart /opt/pantalla/openbox/autostart


### PR DESCRIPTION
## Summary
- force pantalla-openbox sessions to use the /run/user/1000 runtime directory
- ensure the runtime directory exists with the correct ownership before launching Openbox

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fce77d795c8326a16d6eb577620408