### PR TITLE
Address review feedback for Fix Openbox runtime directory setup

### DIFF
--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -9,9 +9,10 @@ User=%i
 Group=%i
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
-Environment=XDG_RUNTIME_DIR=/run/user/1000
+Environment=XDG_RUNTIME_DIR=/run/user/%U
+PermissionsStartOnly=true
 WorkingDirectory=/home/%i
-ExecStartPre=/usr/bin/install -d -m 0700 -o %i -g %i /run/user/1000
+ExecStartPre=/usr/bin/install -d -m 0700 -o %i -g %i "$XDG_RUNTIME_DIR"
 ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "pantalla-openbox@: missing XAUTHORITY at $XAUTHORITY" >&2; exit 1; }'
 ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
 ExecStartPre=/usr/bin/install -m 0755 /opt/pantalla/openbox/autostart /opt/pantalla/openbox/autostart


### PR DESCRIPTION
## Summary
- restore the pantalla-openbox runtime directory path to use the service user's UID
- ensure the runtime directory creation runs with root permissions before dropping privileges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fce899058c8326ab7feef82770c51c