### PR TITLE
Ensure openbox session waits for X and enforce Xauthority ownership

### DIFF
--- a/opt/pantalla/bin/wait-x.sh
+++ b/opt/pantalla/bin/wait-x.sh
@@ -1,29 +1,12 @@
 #!/usr/bin/env bash
 set -euxo pipefail
-
-: "${DISPLAY:?DISPLAY must be set}"
-: "${XAUTHORITY:?XAUTHORITY must be set}"
-
-log() {
-  printf '%(%H:%M:%S)T wait-x: %s\n' -1 "$*"
-}
-
-attempts=30
-sleep_interval=0.5
-last_error=""
-
-for ((i=1; i<=attempts; i++)); do
-  if output=$(xdpyinfo 2>&1); then
-    log "DISPLAY ${DISPLAY} is ready (attempt ${i})"
+: "${DISPLAY:?}"; : "${XAUTHORITY:?}"
+for i in $(seq 1 30); do
+  if DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xset q >/dev/null 2>&1; then
     exit 0
   fi
-  last_error="$output"
-  log "Attempt ${i} failed; retrying after ${sleep_interval}s"
-  sleep "${sleep_interval}"
+  printf '[wait-x] %(%H:%M:%S)T intento %d/30\n' -1 "$i"
+  sleep 0.5
 done
-
-log "Failed to reach DISPLAY ${DISPLAY} after ${attempts} attempts"
-if [[ -n "${last_error}" ]]; then
-  printf '%s\n' "${last_error}" >&2
-fi
+echo "[wait-x] timeout esperando DISPLAY=$DISPLAY"
 exit 1

--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -12,9 +12,9 @@ Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
 Environment=XDG_RUNTIME_DIR=/run/user/1000
 WorkingDirectory=/home/%i
 ExecStartPre=/usr/bin/install -d -m 0700 -o %i -g %i /run/user/1000
-ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "pantalla-openbox@: missing XAUTHORITY at $XAUTHORITY" >&2; exit 1; }'
+ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "pantalla-openbox@: missing $XAUTHORITY" >&2; exit 1; }'
+ExecStartPre=/bin/test -x /opt/pantalla/openbox/autostart
 ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
-ExecStartPre=/usr/bin/install -m 0755 /opt/pantalla/openbox/autostart /opt/pantalla/openbox/autostart
 ExecStart=/usr/bin/openbox --startup /opt/pantalla/openbox/autostart
 Restart=always
 RestartSec=2

--- a/usr/lib/pantalla-reloj/xorg-launch.sh
+++ b/usr/lib/pantalla-reloj/xorg-launch.sh
@@ -26,9 +26,6 @@ else
   install -m 0600 -o "$USER_NAME" -g "$USER_NAME" /dev/null "$AUTH_FILE"
 fi
 
-chown "$USER_NAME:$USER_NAME" "$AUTH_FILE"
-chmod 0600 "$AUTH_FILE"
-
 COOKIE=$(mcookie)
 if [ -z "$COOKIE" ]; then
   log "No se pudo generar mcookie"
@@ -36,6 +33,15 @@ if [ -z "$COOKIE" ]; then
 fi
 
 xauth -f "$AUTH_FILE" add :0 . "$COOKIE"
+
+chown "$USER_NAME:$USER_NAME" "$AUTH_FILE"
+chmod 0600 "$AUTH_FILE"
+
+if auth_stat=$(stat -c '%U:%G %a' "$AUTH_FILE" 2>/dev/null); then
+  log "AUTH_FILE=$AUTH_FILE -> $auth_stat"
+else
+  log "No se pudo obtener stat de $AUTH_FILE"
+fi
 
 HOME_AUTH="/home/${USER_NAME}/.Xauthority"
 HOME_AUTH_BACKUP="${HOME_AUTH}.bak"


### PR DESCRIPTION
## Summary
- rewrite wait-x helper to poll X readiness via xset instead of xdpyinfo
- harden the Openbox unit by checking the autostart executable instead of reinstalling it
- ensure xorg-launch enforces dani ownership/0600 on the Xauthority file and logs its state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fce8f773a0832680a4d022c4e03262