### PR TITLE
Ensure pantalla-openbox waits for DISPLAY before autostart check

### DIFF
--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -13,8 +13,8 @@ Environment=XDG_RUNTIME_DIR=/run/user/1000
 WorkingDirectory=/home/%i
 ExecStartPre=/usr/bin/install -d -m 0700 -o %i -g %i /run/user/1000
 ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "pantalla-openbox@: missing $XAUTHORITY" >&2; exit 1; }'
-ExecStartPre=/bin/test -x /opt/pantalla/openbox/autostart
 ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
+ExecStartPre=/bin/test -x /opt/pantalla/openbox/autostart
 ExecStart=/usr/bin/openbox --startup /opt/pantalla/openbox/autostart
 Restart=always
 RestartSec=2


### PR DESCRIPTION
## Summary
- reorder the pantalla-openbox unit's ExecStartPre directives so the display readiness check runs before verifying the autostart script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fcea62573c8326969969986174463c