### PR TITLE
Ensure Xorg cookie ownership and installer logging

### DIFF
--- a/usr/lib/pantalla-reloj/xorg-launch.sh
+++ b/usr/lib/pantalla-reloj/xorg-launch.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
 
 USER_NAME=${KIOSK_USER:-dani}
 STATE_DIR=${PANTALLA_STATE_DIR:-/var/lib/pantalla-reloj}
 AUTH_FILE="${STATE_DIR}/.Xauthority"
 LOCK_FILE="${STATE_DIR}/.Xauthority.lock"
+LOG_FILE=/tmp/xorg-launch.log
 
 log() {
   printf '[xorg-launch] %s\n' "$*"
@@ -37,6 +38,10 @@ xauth -f "$AUTH_FILE" add :0 . "$COOKIE"
 chown "$USER_NAME:$USER_NAME" "$AUTH_FILE"
 chmod 0600 "$AUTH_FILE"
 
+printf '[xorg-launch] cookie %s owner=%s perms=%s\n' \
+  "$AUTH_FILE" "$(stat -c '%U:%G' "$AUTH_FILE")" "$(stat -c '%a' "$AUTH_FILE")" \
+  >>"$LOG_FILE"
+
 if auth_stat=$(stat -c '%U:%G %a' "$AUTH_FILE" 2>/dev/null); then
   log "AUTH_FILE=$AUTH_FILE -> $auth_stat"
 else
@@ -47,11 +52,12 @@ HOME_AUTH="/home/${USER_NAME}/.Xauthority"
 HOME_AUTH_BACKUP="${HOME_AUTH}.bak"
 
 if [ -e "$HOME_AUTH" ] && [ ! -L "$HOME_AUTH" ]; then
-  if [ ! -e "$HOME_AUTH_BACKUP" ]; then
-    log "Creando backup de ${HOME_AUTH} en ${HOME_AUTH_BACKUP}"
-    cp -p "$HOME_AUTH" "$HOME_AUTH_BACKUP"
+  if [ -e "$HOME_AUTH_BACKUP" ] && [ ! -L "$HOME_AUTH_BACKUP" ]; then
+    log "Sobrescribiendo backup existente ${HOME_AUTH_BACKUP}"
+    rm -f "$HOME_AUTH_BACKUP"
   fi
-  rm -f "$HOME_AUTH"
+  log "Renombrando ${HOME_AUTH} a ${HOME_AUTH_BACKUP}"
+  mv -f "$HOME_AUTH" "$HOME_AUTH_BACKUP"
 fi
 
 ln -sfn "$AUTH_FILE" "$HOME_AUTH"


### PR DESCRIPTION
## Summary
- ensure the Xorg launch script enforces canonical .Xauthority ownership and permissions, logging the cookie metadata to /tmp/xorg-launch.log and creating a stable home symlink
- make the installer run with set -euxo, track the install log path, reload systemd units unconditionally, and record the cookie stat after restarting pantalla-xorg

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fceb9fb43883268eb32c8f24a152d7