### PR TITLE
feat: launch chromium-based kiosk service

### DIFF
--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euxo pipefail
-
 LOG_FILE=/tmp/openbox-autostart.log
 {
-  xrandr --output HDMI-1 --rotate left --primary || true
-  xset -dpms s off s noblank || true
+  echo "[openbox] $(date -Is) configuring display"
+  (sleep 0.3; DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --output HDMI-1 --rotate left --primary || true) &
+  (sleep 0.5; DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xset -dpms s off s noblank || true) &
+  wait
+  echo "[openbox] $(date -Is) configuration done"
 } >>"$LOG_FILE" 2>&1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,7 +82,7 @@ APT_PACKAGES=(
   rsync
   file
   xauth
-  epiphany-browser
+  chromium
   python3-venv
 )
 apt-get update -y
@@ -168,7 +168,7 @@ install -m 0755 "$REPO_ROOT/opt/pantalla/bin/xorg-openbox-env.sh" "$SESSION_PREF
 install -m 0755 "$REPO_ROOT/opt/pantalla/bin/wait-x.sh" "$SESSION_PREFIX/bin/wait-x.sh"
 install -m 0755 "$REPO_ROOT/opt/pantalla/openbox/autostart" "$SESSION_PREFIX/openbox/autostart"
 
-install -m 0755 "$KIOSK_BIN_SRC" "$KIOSK_BIN_DST"
+install -D -m 0755 "$KIOSK_BIN_SRC" "$KIOSK_BIN_DST"
 install -d -m 0755 /usr/lib/pantalla-reloj
 install -m 0755 "$REPO_ROOT/usr/lib/pantalla-reloj/xorg-launch.sh" /usr/lib/pantalla-reloj/xorg-launch.sh
 
@@ -347,7 +347,7 @@ units_changed=0
 deploy_unit() {
   local src="$1" dest="$2"
   if [[ ! -f "$dest" ]] || ! cmp -s "$src" "$dest"; then
-    install -m 0644 "$src" "$dest"
+    install -D -m 0644 "$src" "$dest"
     units_changed=1
   fi
 }
@@ -380,8 +380,8 @@ else
   printf '[install] stat failed for /var/lib/pantalla-reloj/.Xauthority\n' >> "$INSTALL_LOG"
 fi
 systemctl restart pantalla-openbox@${USER_NAME}.service
-systemctl restart pantalla-dash-backend@${USER_NAME}.service
 systemctl restart pantalla-kiosk@${USER_NAME}.service
+systemctl restart pantalla-dash-backend@${USER_NAME}.service
 
 log_info "Running quick health checks"
 if curl -sS -m 1 http://127.0.0.1:8081/healthz >/dev/null 2>&1; then
@@ -390,10 +390,10 @@ else
   log_warn "Backend healthz not responding yet"
 fi
 
-if pgrep -fa epiphany >/dev/null 2>&1; then
-  log_ok "Epiphany process detected"
+if pgrep -fa 'chromium|chromium-browser|google-chrome' >/dev/null 2>&1; then
+  log_ok "Chromium-based browser process detected"
 else
-  log_warn "Epiphany process not detected"
+  log_warn "Chromium-based browser process not detected"
 fi
 
 if WMCTRL_OUT=$(wmctrl -lG 2>&1); then

--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -1,26 +1,22 @@
 [Unit]
-Description=Pantalla_reloj Kiosk (Epiphany) for user %i
-After=pantalla-openbox@%i.service nginx.service pantalla-dash-backend@%i.service
+Description=Pantalla_reloj Kiosk (Chromium) for user %i
+After=pantalla-openbox@%i.service
 Requires=pantalla-openbox@%i.service
-Wants=nginx.service pantalla-dash-backend@%i.service
-PartOf=pantalla-openbox@%i.service
 
 [Service]
 Type=simple
 User=%i
+Group=%i
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
-Environment=XDG_RUNTIME_DIR=/run/user/%U
-Environment=WEBKIT_DISABLE_DMABUF_RENDERER=1
-Environment=WEBKIT_DISABLE_COMPOSITING_MODE=1
-Environment=GSK_RENDERER=cairo
-Environment=LIBGL_ALWAYS_SOFTWARE=1
-Environment=GTK_USE_PORTAL=0
-ExecStartPre=/usr/bin/test -r /var/lib/pantalla-reloj/.Xauthority
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+WorkingDirectory=/home/%i
+ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "kiosk@: missing $XAUTHORITY" >&2; exit 1; }'
+ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
 ExecStart=/usr/local/bin/pantalla-kiosk http://127.0.0.1
 Restart=always
-RestartSec=3
-StartLimitIntervalSec=0
+RestartSec=2
+TimeoutStartSec=30
 
 [Install]
 WantedBy=graphical.target

--- a/usr/local/bin/pantalla-kiosk
+++ b/usr/local/bin/pantalla-kiosk
@@ -1,51 +1,85 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-LOG_FILE=/var/log/pantalla-reloj/kiosk.log
-mkdir -p "$(dirname "$LOG_FILE")"
-exec >>"$LOG_FILE" 2>&1
-printf '\n[%s] pantalla-kiosk starting (pid=%s, url=%s)\n' "$(date -Is)" "$$" "${1:-http://127.0.0.1}"
+set -euxo pipefail
 
 URL="${1:-http://127.0.0.1}"
-PROFILE_DIR="${PANTALLA_KIOSK_PROFILE:-$HOME/.config/epiphany-pantalla}"
-mkdir -p "$PROFILE_DIR"
+LOG=/tmp/kiosk-launch.log
+ERR=/tmp/browser.err
 
-LOCK_FD=200
-LOCK_FILE=/tmp/pantalla-kiosk.lock
-exec {LOCK_FD}>"$LOCK_FILE"
-if ! flock -n "$LOCK_FD"; then
-  printf '[%s] waiting for kiosk lock %s\n' "$(date -Is)" "$LOCK_FILE"
-  flock "$LOCK_FD"
-fi
+: "${DISPLAY:=:0}"
+: "${XAUTHORITY:?XAUTHORITY must be set}"
+: "${XDG_RUNTIME_DIR:=/run/user/1000}"
 
-wait_for_url() {
-  local name="$1" url="$2" attempts="$3" delay="$4"
-  local i=1 status
-  while [ "$i" -le "$attempts" ]; do
-    status=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "$url" || printf '000')
-    if [ "$status" = "200" ]; then
-      printf '[%s] %s OK (%s) intento %s/%s\n' "$(date -Is)" "$name" "$url" "$i" "$attempts"
+STATE_DIR=/var/lib/pantalla-reloj/state
+PROFILE_DIR="$STATE_DIR/chromium-profile"
+LOCK="$STATE_DIR/kiosk.lock"
+
+OWNER="${KIOSK_USER:-${USER:-$(id -un)}}"
+
+install -d -m 0755 "$STATE_DIR" "$PROFILE_DIR"
+chown -R "$OWNER:$OWNER" "$STATE_DIR" "$PROFILE_DIR" || true
+
+{
+  echo "[kiosk] $(date -Is) start user=$(id -un) DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY URL=$URL"
+} >>"$LOG"
+
+# única instancia
+exec 9>"$LOCK"
+flock -n 9 || { echo "[kiosk] already running" >>"$LOG"; exit 0; }
+
+# esperar X usable
+DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh >>"$LOG" 2>&1
+
+# esperar HTTP (front/api) sin bloquear el arranque si fallan
+wait_http() {
+  local name="$1" url="$2" max="$3"
+  for i in $(seq 1 "$max"); do
+    if curl -fsS -m 1 "$url" >/dev/null; then
+      echo "[kiosk] $name OK $url" >>"$LOG"
       return 0
     fi
-    printf '[%s] %s KO (%s -> %s) intento %s/%s\n' "$(date -Is)" "$name" "$url" "$status" "$i" "$attempts"
-    sleep "$delay"
-    i=$((i + 1))
+    echo "[kiosk] $name not ready $url ($i/$max)" >>"$LOG"
+    sleep 1
   done
   return 1
 }
+wait_http FRONT http://127.0.0.1 10 || true
+wait_http API   http://127.0.0.1:8081/healthz 10 || true
 
-if ! wait_for_url "backend" "http://127.0.0.1:8081/healthz" 60 1; then
-  printf '[%s] backend no respondió, continuando para permitir reconexión automática\n' "$(date -Is)"
-fi
+# detectar chromium
+CHROMIUM_BIN=""
+for c in chromium chromium-browser google-chrome-stable google-chrome; do
+  command -v "$c" >/dev/null 2>&1 && { CHROMIUM_BIN="$(command -v "$c")"; break; }
+done
+[ -n "$CHROMIUM_BIN" ] || { echo "[kiosk] chromium not found" >>"$LOG"; exit 1; }
 
-if ! wait_for_url "frontend" "$URL" 60 1; then
-  printf '[%s] frontend no respondió, lanzando navegador igualmente\n' "$(date -Is)"
-fi
+# evitar portals/diálogos
+export GTK_USE_PORTAL=0
+export XDG_DESKTOP_PORTAL_DIR=/nonexistent
 
-if pgrep -x epiphany >/dev/null 2>&1; then
-  printf '[%s] cerrando instancias anteriores de epiphany\n' "$(date -Is)"
-  pkill -TERM -x epiphany || true
-  sleep 2
-fi
+COMMON_FLAGS=(
+  --no-first-run
+  --no-default-browser-check
+  --kiosk
+  --app="$URL"
+  --new-window
+  --incognito
+  --disable-features=Translate,AutofillServerCommunication,Printing,MediaRouter,DownloadBubble,TabHoverCardImages
+  --disable-extensions
+  --disable-sync
+  --disable-session-crashed-bubble
+  --disable-infobars
+  --disable-logging
+  --enable-logging=stderr
+  --password-store=basic
+  --overscroll-history-navigation=0
+  --user-data-dir="$PROFILE_DIR"
+)
 
-exec /usr/bin/epiphany --new-window --application-mode --profile="${PROFILE_DIR}" "$URL"
+# matar instancias viejas del mismo profile (suave)
+pkill -TERM -f "$CHROMIUM_BIN.*--user-data-dir=$PROFILE_DIR" || true
+sleep 0.2
+
+# lanzar
+exec env -i DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+  GTK_USE_PORTAL="$GTK_USE_PORTAL" XDG_DESKTOP_PORTAL_DIR="$XDG_DESKTOP_PORTAL_DIR" \
+  "$CHROMIUM_BIN" "${COMMON_FLAGS[@]}" >>"$LOG" 2>>"$ERR"


### PR DESCRIPTION
## Summary
- replace the kiosk launcher with a Chromium-based implementation that waits for X/HTTP readiness and logs to /tmp
- update the kiosk systemd unit and Openbox autostart script to respect the Chromium environment and disable DPMS
- extend the installer to deploy the new launcher/unit and ensure Chromium is installed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcf8ac17b4832682923f2a89c212f0