### PR TITLE
feat: launch chromium-based kiosk service

### DIFF
--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -2,6 +2,7 @@
 Description=Pantalla_reloj Kiosk (Chromium) for user %i
 After=pantalla-openbox@%i.service
 Requires=pantalla-openbox@%i.service
+PartOf=pantalla-openbox@%i.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
## Summary
- restore the PartOf relationship between the kiosk and Openbox template units so kiosk restarts follow Openbox restarts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fcfa733e048326970976770dbc3e02