### PR TITLE
Switch kiosk launcher to Epiphany

### DIFF
--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pantalla_reloj Kiosk (Chromium) for user %i
+Description=Pantalla_reloj Kiosk (Epiphany) for user %i
 After=pantalla-openbox@%i.service
 Requires=pantalla-openbox@%i.service
 

--- a/usr/local/bin/pantalla-kiosk
+++ b/usr/local/bin/pantalla-kiosk
@@ -5,81 +5,87 @@ URL="${1:-http://127.0.0.1}"
 LOG=/tmp/kiosk-launch.log
 ERR=/tmp/browser.err
 
+touch "$LOG" "$ERR"
+exec >>"$LOG"
+exec 2>&1
+
 : "${DISPLAY:=:0}"
 : "${XAUTHORITY:?XAUTHORITY must be set}"
 : "${XDG_RUNTIME_DIR:=/run/user/1000}"
 
 STATE_DIR=/var/lib/pantalla-reloj/state
-PROFILE_DIR="$STATE_DIR/chromium-profile"
 LOCK="$STATE_DIR/kiosk.lock"
-
 OWNER="${KIOSK_USER:-${USER:-$(id -un)}}"
 
-install -d -m 0755 "$STATE_DIR" "$PROFILE_DIR"
-chown -R "$OWNER:$OWNER" "$STATE_DIR" "$PROFILE_DIR" || true
+install -d -m 0755 "$STATE_DIR"
+chown -R "$OWNER:$OWNER" "$STATE_DIR" || true
 
-{
-  echo "[kiosk] $(date -Is) start user=$(id -un) DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY URL=$URL"
-} >>"$LOG"
+echo "[kiosk] $(date -Is) start user=$(id -un) DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY URL=$URL"
 
-# única instancia
+# única instancia mediante lockfile
 exec 9>"$LOCK"
-flock -n 9 || { echo "[kiosk] already running" >>"$LOG"; exit 0; }
+if ! flock -n 9; then
+  echo "[kiosk] lock activo, no se lanza otra instancia"
+  exit 0
+fi
 
-# esperar X usable
-DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh >>"$LOG" 2>&1
+# evitar duplicar ventanas si ya corre epiphany en modo aplicación
+if pgrep -fa 'epiphany-browser.*--application-mode' >/dev/null 2>&1; then
+  echo "[kiosk] epiphany-browser ya en ejecución (modo aplicación)"
+  exit 0
+fi
 
-# esperar HTTP (front/api) sin bloquear el arranque si fallan
-wait_http() {
-  local name="$1" url="$2" max="$3"
-  for i in $(seq 1 "$max"); do
-    if curl -fsS -m 1 "$url" >/dev/null; then
-      echo "[kiosk] $name OK $url" >>"$LOG"
-      return 0
-    fi
-    echo "[kiosk] $name not ready $url ($i/$max)" >>"$LOG"
-    sleep 1
-  done
-  return 1
+echo "[kiosk] esperando X con /opt/pantalla/bin/wait-x.sh"
+DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh
+
+check_http() {
+  local name="$1" url="$2"
+  if curl -fsS -m 1 "$url" >/dev/null; then
+    echo "[kiosk] $name OK $url"
+  else
+    echo "[kiosk] $name fallo $url"
+  fi
 }
-wait_http FRONT http://127.0.0.1 10 || true
-wait_http API   http://127.0.0.1:8081/healthz 10 || true
 
-# detectar chromium
-CHROMIUM_BIN=""
-for c in chromium chromium-browser google-chrome-stable google-chrome; do
-  command -v "$c" >/dev/null 2>&1 && { CHROMIUM_BIN="$(command -v "$c")"; break; }
+check_http FRONT "$URL"
+(check_http API "http://127.0.0.1:8081/healthz") &
+
+# detectar navegadores disponibles
+EPIPHANY_BIN=""
+if command -v epiphany-browser >/dev/null 2>&1; then
+  EPIPHANY_BIN="$(command -v epiphany-browser)"
+fi
+
+chromium_snap_logged=0
+for candidate in chromium chromium-browser google-chrome-stable google-chrome; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    bin_path="$(command -v "$candidate")"
+    resolved="$(readlink -f "$bin_path" 2>/dev/null || printf '%s' "$bin_path")"
+    if [[ "$bin_path" == /snap/bin/* || "$resolved" == /snap/* ]]; then
+      if [[ "$chromium_snap_logged" -eq 0 ]]; then
+        echo "[kiosk] Chromium (snap) no soportado: confinamiento bloquea X11/XAUTHORITY"
+        chromium_snap_logged=1
+      fi
+    fi
+  fi
 done
-[ -n "$CHROMIUM_BIN" ] || { echo "[kiosk] chromium not found" >>"$LOG"; exit 1; }
 
-# evitar portals/diálogos
+if [[ -z "$EPIPHANY_BIN" ]]; then
+  echo "[kiosk] epiphany-browser no encontrado"
+  exit 1
+fi
+
+export GIO_USE_PORTALS=0
 export GTK_USE_PORTAL=0
-export XDG_DESKTOP_PORTAL_DIR=/nonexistent
 
-COMMON_FLAGS=(
-  --no-first-run
-  --no-default-browser-check
-  --kiosk
-  --app="$URL"
-  --new-window
-  --incognito
-  --disable-features=Translate,AutofillServerCommunication,Printing,MediaRouter,DownloadBubble,TabHoverCardImages
-  --disable-extensions
-  --disable-sync
-  --disable-session-crashed-bubble
-  --disable-infobars
-  --disable-logging
-  --enable-logging=stderr
-  --password-store=basic
-  --overscroll-history-navigation=0
-  --user-data-dir="$PROFILE_DIR"
-)
+echo "[kiosk] lanzando epiphany-browser: $EPIPHANY_BIN"
 
-# matar instancias viejas del mismo profile (suave)
-pkill -TERM -f "$CHROMIUM_BIN.*--user-data-dir=$PROFILE_DIR" || true
-sleep 0.2
-
-# lanzar
-exec env -i DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
-  GTK_USE_PORTAL="$GTK_USE_PORTAL" XDG_DESKTOP_PORTAL_DIR="$XDG_DESKTOP_PORTAL_DIR" \
-  "$CHROMIUM_BIN" "${COMMON_FLAGS[@]}" >>"$LOG" 2>>"$ERR"
+exec env -i \
+  DISPLAY="$DISPLAY" \
+  XAUTHORITY="$XAUTHORITY" \
+  XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+  HOME="${HOME:-/home/$OWNER}" \
+  PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  GIO_USE_PORTALS="$GIO_USE_PORTALS" \
+  GTK_USE_PORTAL="$GTK_USE_PORTAL" \
+  "$EPIPHANY_BIN" --application-mode --incognito --new-window "$URL" 2>>"$ERR"


### PR DESCRIPTION
## Summary
- update the kiosk launcher to run Epiphany with single-instance locking, portal-disabled environment variables, and clear logging including snap Chromium rejection
- adjust the installer to depend on Epiphany, record deployment checks, and write a summary to /tmp/install.log
- refresh the kiosk systemd unit description to reflect the Epiphany-based browser

## Testing
- bash -n usr/local/bin/pantalla-kiosk
- bash -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68fcfc8470c88326b6b196d0628bfc22