### PR TITLE
Hardening kiosk launch and backend service

### DIFF
--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -3,7 +3,10 @@ set -euxo pipefail
 LOG_FILE=/tmp/openbox-autostart.log
 {
   echo "[openbox] $(date -Is) configuring display"
-  (sleep 0.3; DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --output HDMI-1 --rotate left --primary || true) &
+  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --output HDMI-1 --panning 0x0 || true
+  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --output HDMI-1 --mode 480x1920 --rotate left || true
+  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --fb 1920x480 || true
+  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --output HDMI-1 --pos 0x0 || true
   (sleep 0.5; DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xset -dpms s off s noblank || true) &
   wait
   echo "[openbox] $(date -Is) configuration done"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,6 +65,7 @@ BACKEND_LAUNCHER_SRC="${REPO_ROOT}/usr/local/bin/pantalla-backend-launch"
 BACKEND_LAUNCHER_DST=/usr/local/bin/pantalla-backend-launch
 UDEV_RULE=/etc/udev/rules.d/70-pantalla-render.rules
 
+install -d -m 0755 /var/log/pantalla /var/lib/pantalla
 install -d -m 0755 "$PANTALLA_PREFIX" "$LOG_DIR" "$SESSION_PREFIX"
 install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$STATE_DIR"
 install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$STATE_RUNTIME"
@@ -169,6 +170,9 @@ if [[ -f "$AUTO_FILE" && ! -f "$AUTO_BACKUP" ]]; then
   cp -p "$AUTO_FILE" "$AUTO_BACKUP"
 fi
 install -o "$USER_NAME" -g "$USER_NAME" -m 0755 "$REPO_ROOT/openbox/autostart" "$AUTO_FILE"
+
+ln -sfn /var/lib/pantalla-reloj/.Xauthority "$USER_HOME/.Xauthority"
+chown -h "$USER_NAME:$USER_NAME" "$USER_HOME/.Xauthority"
 
 install -m 0755 "$REPO_ROOT/opt/pantalla/bin/xorg-openbox-env.sh" "$SESSION_PREFIX/bin/xorg-openbox-env.sh"
 install -m 0755 "$REPO_ROOT/opt/pantalla/bin/wait-x.sh" "$SESSION_PREFIX/bin/wait-x.sh"

--- a/systemd/pantalla-dash-backend@.service
+++ b/systemd/pantalla-dash-backend@.service
@@ -1,21 +1,15 @@
 [Unit]
 Description=Pantalla reloj FastAPI backend (%i)
-After=network-online.target
-Wants=network-online.target
+After=network.target
 
 [Service]
-Type=simple
 User=%i
-WorkingDirectory=/opt/pantalla-reloj/backend
-Environment="PANTALLA_STATE_DIR=/var/lib/pantalla-reloj"
-Environment="PANTALLA_CONFIG_FILE=/var/lib/pantalla-reloj/config.json"
-Environment="PANTALLA_DEFAULT_CONFIG_FILE=/opt/pantalla-reloj/backend/default_config.json"
-ExecStartPre=/bin/test -x /usr/local/bin/pantalla-backend-launch
+Group=%i
 ExecStart=/usr/local/bin/pantalla-backend-launch
+WorkingDirectory=/opt/pantalla-reloj
 Restart=always
-RestartSec=1s
-StandardOutput=append:/var/log/pantalla-reloj/backend.log
-StandardError=append:/var/log/pantalla-reloj/backend.log
+RestartSec=2
+Environment=PYTHONUNBUFFERED=1
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Pantalla_reloj Kiosk (Epiphany) for user %i
-After=pantalla-openbox@%i.service
+After=pantalla-openbox@%i.service pantalla-dash-backend@%i.service
 Requires=pantalla-openbox@%i.service
 
 [Service]
@@ -11,7 +11,7 @@ Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
 Environment=XDG_RUNTIME_DIR=/run/user/1000
 WorkingDirectory=/home/%i
-ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY" || { echo "kiosk@: missing $XAUTHORITY" >&2; exit 1; }'
+ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY"'
 ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
 ExecStart=/usr/local/bin/pantalla-kiosk http://127.0.0.1
 Restart=always

--- a/usr/local/bin/pantalla-backend-launch
+++ b/usr/local/bin/pantalla-backend-launch
@@ -1,18 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
+LOG=/tmp/backend-launch.log
+exec >>"$LOG" 2>&1
+echo "[backend] $(date -Is) start"
 
-BACKEND_DIR=/opt/pantalla-reloj/backend
-PYTHON_BIN="$BACKEND_DIR/.venv/bin/python"
+APP_DIR="/opt/pantalla-reloj/backend"
+PY="$APP_DIR/.venv/bin/python"
 
-if [[ ! -x "$PYTHON_BIN" ]]; then
-  echo "[backend-launch] python executable not found: $PYTHON_BIN" >&2
+if [[ ! -x "$PY" ]]; then
+  echo "[backend] python no encontrado en $PY" >&2
   exit 1
 fi
 
-cd "$BACKEND_DIR"
-export PYTHONPATH="$BACKEND_DIR"
-exec "$PYTHON_BIN" -m uvicorn backend.main:app \
-  --host 127.0.0.1 \
-  --port 8081 \
-  --proxy-headers \
-  --timeout-keep-alive 30
+install -d -m 0755 /var/log/pantalla
+install -d -m 0755 /var/lib/pantalla
+
+cd "$APP_DIR"
+export PYTHONPATH="$APP_DIR"
+
+"$PY" - <<'PYCODE'
+import importlib, sys
+try:
+    m = importlib.import_module("backend.main")
+    print("[backend] import OK:", m.__name__)
+except Exception as e:
+    print("[backend] import FAIL:", repr(e))
+    sys.exit(3)
+PYCODE
+
+exec "$PY" -m uvicorn backend.main:app \
+  --host 127.0.0.1 --port 8081 \
+  --proxy-headers --timeout-keep-alive 30

--- a/usr/local/bin/pantalla-kiosk
+++ b/usr/local/bin/pantalla-kiosk
@@ -1,95 +1,40 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
+set -euxo pipefail
 URL="${1:-http://127.0.0.1}"
-LOG=/tmp/kiosk-launch.log
-exec >>"$LOG"
-exec 2>&1
-
-echo "[kiosk] $(date -Is) start user=$(id -un) DISPLAY=${DISPLAY:-} XAUTHORITY=${XAUTHORITY:-} URL=$URL"
-
 : "${DISPLAY:=:0}"
 : "${XAUTHORITY:?XAUTHORITY must be set}"
 : "${XDG_RUNTIME_DIR:=/run/user/1000}"
 
-STATE_DIR=/var/lib/pantalla-reloj/state
-PROFILE_DIR="$STATE_DIR/org.gnome.Epiphany.WebApp_PantallaReloj"
-LOCK="$STATE_DIR/kiosk.lock"
-OWNER="${KIOSK_USER:-${USER:-$(id -un)}}"
+LOG=/tmp/kiosk-launch.log
+exec >>"$LOG" 2>&1
+echo "[kiosk] $(date -Is) start user=$(id -un) DISPLAY=$DISPLAY URL=$URL"
 
-install -d -m 0755 "$STATE_DIR"
-install -d -m 0755 "$PROFILE_DIR"
-chown -R "$OWNER:$OWNER" "$STATE_DIR" || true
+/opt/pantalla/bin/wait-x.sh
 
-exec 9>"$LOCK"
-if ! flock -n 9; then
-  echo "[kiosk] lock activo, no se lanza otra instancia"
-  exit 0
-fi
-
-if pgrep -fa 'epiphany-browser.*--application-mode' >/dev/null 2>&1; then
-  echo "[kiosk] epiphany-browser ya en ejecución (modo aplicación)"
-  exit 0
-fi
-
-echo "[kiosk] esperando X con /opt/pantalla/bin/wait-x.sh"
-DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh
-
-check_http() {
-  local name="$1" url="$2"
-  if curl -fsS -m 1 "$url" >/dev/null; then
-    echo "[kiosk] $name OK $url"
-  else
-    echo "[kiosk] $name fallo $url"
-  fi
+skip_snap() {
+  local b="$1"; local r
+  r="$(readlink -f "$b" 2>/dev/null || echo "$b")"
+  [[ "$b" == /snap/bin/* || "$r" == /snap/* ]]
 }
 
-check_http FRONT "$URL"
-(check_http API "http://127.0.0.1:8081/healthz") &
-
-# detectar navegadores disponibles
-chromium_snap_logged=0
-chromium_bin=""
-for candidate in chromium-browser chromium google-chrome-stable google-chrome; do
-  if command -v "$candidate" >/dev/null 2>&1; then
-    bin_path="$(command -v "$candidate")"
-    resolved="$(readlink -f "$bin_path" 2>/dev/null || printf '%s' "$bin_path")"
-    if [[ "$bin_path" == /snap/bin/* || "$resolved" == /snap/* ]]; then
-      if [[ "$chromium_snap_logged" -eq 0 ]]; then
-        echo "[kiosk] Chromium (snap) no soportado: confinamiento bloquea X11/XAUTHORITY"
-        chromium_snap_logged=1
-      fi
-      continue
-    fi
-    chromium_bin="$bin_path"
-    break
-  fi
-done
-
-if command -v epiphany-browser >/dev/null 2>&1; then
-  browser="epiphany-browser"
-  browser_cmd=("$(command -v epiphany-browser)" --application-mode "--profile=$PROFILE_DIR" --new-window "$URL")
-  browser_desc="epiphany-browser"
-elif [[ -n "$chromium_bin" ]]; then
-  browser="$chromium_bin"
-  browser_cmd=("$chromium_bin" --kiosk --no-first-run --no-default-browser-check "$URL")
-  browser_desc="$(basename "$chromium_bin")"
-else
-  echo "[kiosk] no se encontró un navegador compatible"
+EPIPHANY_BIN="$(command -v epiphany-browser || true)"
+if [[ -z "$EPIPHANY_BIN" ]]; then
+  echo "[kiosk] epiphany-browser no encontrado" >&2
+  exit 1
+fi
+if skip_snap "$EPIPHANY_BIN"; then
+  echo "[kiosk] epiphany-browser proviene de snap y no se puede usar" >&2
   exit 1
 fi
 
-export GIO_USE_PORTALS=0
-export GTK_USE_PORTAL=0
+curl -fsS -m 1 "$URL" >/dev/null && echo "[kiosk] FRONT OK $URL" || echo "[kiosk] FRONT FAIL $URL"
+(check_http(){ curl -fsS -m 1 "$1" >/dev/null && echo "[kiosk] API OK $1" || echo "[kiosk] API FAIL $1"; }; check_http http://127.0.0.1:8081/healthz) &
 
-echo "[kiosk] lanzando $browser_desc: ${browser_cmd[*]}"
+PROFILE_DIR=/var/lib/pantalla-reloj/state/org.gnome.Epiphany.WebApp_PantallaReloj
+install -d -m 0755 "$PROFILE_DIR"
 
-exec env -i \
-  DISPLAY="$DISPLAY" \
-  XAUTHORITY="$XAUTHORITY" \
-  XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
-  HOME="${HOME:-/home/$OWNER}" \
-  PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-  GIO_USE_PORTALS="$GIO_USE_PORTALS" \
-  GTK_USE_PORTAL="$GTK_USE_PORTAL" \
-  "${browser_cmd[@]}"
+export GIO_USE_PORTALS=0 GTK_USE_PORTAL=0
+exec env -i DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+  HOME="/home/$(id -un)" PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  GIO_USE_PORTALS=0 GTK_USE_PORTAL=0 \
+  "$EPIPHANY_BIN" --application-mode --profile="$PROFILE_DIR" --new-window "$URL"


### PR DESCRIPTION
## Summary
- harden the backend launcher to provision required directories, validate imports, and log to /tmp/backend-launch.log
- rebuild the Epiphany kiosk wrapper to reject snap binaries, validate health endpoints, and use the required WebApp profile
- update Openbox geometry, systemd units, installer provisioning, and README with the black-screen runbook

## Testing
- bash -n usr/local/bin/pantalla-backend-launch
- bash -n usr/local/bin/pantalla-kiosk
- bash -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68fd133a72c48326a9be9a2f62b1fbb5