### PR TITLE
Follow-up: Avoid backend launcher directory provisioning as unprivileged user

### DIFF
--- a/usr/local/bin/pantalla-backend-launch
+++ b/usr/local/bin/pantalla-backend-launch
@@ -12,8 +12,21 @@ if [[ ! -x "$PY" ]]; then
   exit 1
 fi
 
-install -d -m 0755 /var/log/pantalla
-install -d -m 0755 /var/lib/pantalla
+require_dir() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    echo "[backend] missing required directory $dir" >&2
+    echo "[backend] please provision it via the installer or system setup" >&2
+    exit 4
+  fi
+  if [[ ! -w "$dir" ]]; then
+    echo "[backend] cannot write to $dir as $(id -un)" >&2
+    exit 5
+  fi
+}
+
+require_dir /var/log/pantalla
+require_dir /var/lib/pantalla
 
 cd "$APP_DIR"
 export PYTHONPATH="$APP_DIR"


### PR DESCRIPTION
## Summary
- prevent the backend launcher from attempting to create system directories when run as the service user
- add explicit checks that /var/log/pantalla and /var/lib/pantalla exist and are writable so failures surface with clear errors

## Testing
- bash -n usr/local/bin/pantalla-backend-launch

------
https://chatgpt.com/codex/tasks/task_e_68fd16c90cd88326bed7cb9a470a9b3d