### PR TITLE
Align kiosk and backend launchers with deployment guidelines

### DIFF
--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -3,11 +3,9 @@ set -euxo pipefail
 LOG_FILE=/tmp/openbox-autostart.log
 {
   echo "[openbox] $(date -Is) configuring display"
-  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --output HDMI-1 --panning 0x0 || true
-  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --output HDMI-1 --mode 480x1920 --rotate left || true
-  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --fb 1920x480 || true
-  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xrandr --output HDMI-1 --pos 0x0 || true
+  DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority \
+    xrandr --output HDMI-1 --rotate left --mode 480x1920 || true
   (sleep 0.5; DISPLAY=:0 XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority xset -dpms s off s noblank || true) &
-  wait
+  wait || true
   echo "[openbox] $(date -Is) configuration done"
 } >>"$LOG_FILE" 2>&1

--- a/systemd/pantalla-dash-backend@.service
+++ b/systemd/pantalla-dash-backend@.service
@@ -8,7 +8,7 @@ Group=%i
 ExecStart=/usr/local/bin/pantalla-backend-launch
 WorkingDirectory=/opt/pantalla-reloj
 Restart=always
-RestartSec=2
+RestartSec=1
 Environment=PYTHONUNBUFFERED=1
 
 [Install]

--- a/usr/local/bin/pantalla-backend-launch
+++ b/usr/local/bin/pantalla-backend-launch
@@ -7,13 +7,15 @@ echo "[backend] $(date -Is) start"
 APP_DIR="/opt/pantalla-reloj/backend"
 PY="$APP_DIR/.venv/bin/python"
 
-if [[ ! -x "$PY" ]]; then
-  echo "[backend] python no encontrado en $PY" >&2
-  exit 1
+if [[ ! -d "$APP_DIR" ]]; then
+  echo "[backend] ERROR: APP_DIR no existe: $APP_DIR" >&2
+  exit 2
 fi
 
-install -d -m 0755 /var/log/pantalla
-install -d -m 0755 /var/lib/pantalla
+if [[ ! -x "$PY" ]]; then
+  echo "[backend] ERROR: venv no existe: $PY" >&2
+  exit 2
+fi
 
 cd "$APP_DIR"
 export PYTHONPATH="$APP_DIR"

--- a/usr/local/bin/pantalla-kiosk
+++ b/usr/local/bin/pantalla-kiosk
@@ -9,32 +9,37 @@ LOG=/tmp/kiosk-launch.log
 exec >>"$LOG" 2>&1
 echo "[kiosk] $(date -Is) start user=$(id -un) DISPLAY=$DISPLAY URL=$URL"
 
-/opt/pantalla/bin/wait-x.sh
+STATE_DIR=/var/lib/pantalla-reloj/state
+PROFILE_DIR="$STATE_DIR/org.gnome.Epiphany.WebApp_PantallaReloj"
+LOCK="$STATE_DIR/kiosk.lock"
+OWNER="${KIOSK_USER:-${USER:-$(id -un)}}"
 
-skip_snap() {
-  local b="$1"; local r
-  r="$(readlink -f "$b" 2>/dev/null || echo "$b")"
-  [[ "$b" == /snap/bin/* || "$r" == /snap/* ]]
-}
+if ! install -d -m 0755 "$STATE_DIR" "$PROFILE_DIR" 2>/dev/null; then
+  if [[ ! -d "$PROFILE_DIR" ]]; then
+    echo "[kiosk] no se pudo preparar el perfil: $PROFILE_DIR" >&2
+    exit 1
+  fi
+fi
+chown -R "$OWNER:$OWNER" "$STATE_DIR" || true
+
+exec 9>"$LOCK"
+if ! flock -n 9; then
+  echo "[kiosk] otro proceso en ejecución; saliendo"
+  exit 0
+fi
+
+DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh
 
 EPIPHANY_BIN="$(command -v epiphany-browser || true)"
 if [[ -z "$EPIPHANY_BIN" ]]; then
   echo "[kiosk] epiphany-browser no encontrado" >&2
   exit 1
 fi
-if skip_snap "$EPIPHANY_BIN"; then
-  echo "[kiosk] epiphany-browser proviene de snap y no se puede usar" >&2
-  exit 1
-fi
 
-curl -fsS -m 1 "$URL" >/dev/null && echo "[kiosk] FRONT OK $URL" || echo "[kiosk] FRONT FAIL $URL"
-(check_http(){ curl -fsS -m 1 "$1" >/dev/null && echo "[kiosk] API OK $1" || echo "[kiosk] API FAIL $1"; }; check_http http://127.0.0.1:8081/healthz) &
+export GIO_USE_PORTALS=0
+export GTK_USE_PORTAL=0
 
-PROFILE_DIR=/var/lib/pantalla-reloj/state/org.gnome.Epiphany.WebApp_PantallaReloj
-install -d -m 0755 "$PROFILE_DIR"
-
-export GIO_USE_PORTALS=0 GTK_USE_PORTAL=0
 exec env -i DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
-  HOME="/home/$(id -un)" PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+  HOME="/home/$OWNER" PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
   GIO_USE_PORTALS=0 GTK_USE_PORTAL=0 \
   "$EPIPHANY_BIN" --application-mode --profile="$PROFILE_DIR" --new-window "$URL"


### PR DESCRIPTION
## Summary
- ensure the installer prepares Pantalla directories with the expected ownership and adds the required post-install checks for X, backend, and kiosk health
- update the backend launcher and systemd unit to validate the application directory/venv before starting uvicorn
- adjust the kiosk launcher and Openbox autostart so Epiphany uses the persistent profile with locking and rotation avoids xrandr fb/panning flags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd1bc63eb08326953abb37fa29f951