### PR TITLE
Restore backend access to legacy state directories

### DIFF
--- a/scripts/fix_permissions.sh
+++ b/scripts/fix_permissions.sh
@@ -18,10 +18,10 @@ fi
 
 install -d -m 0700 -o "$USER" -g "$GROUP" "$STATE_ROOT"
 install -d -m 0755 -o "$USER" -g "$GROUP" "$STATE_RUNTIME"
-install -d -m 0755 -o root -g root "$CONFIG_ROOT" "$LOG_ROOT"
+install -d -m 0755 -o "$USER" -g "$GROUP" "$CONFIG_ROOT" "$LOG_ROOT"
 install -d -m 0755 -o "$USER" -g "$GROUP" "$APP_LOG_DIR" 2>/dev/null || true
 
-chown -R "$USER:$GROUP" "$PANTALLA_ROOT" "$STATE_ROOT" "$APP_LOG_DIR" 2>/dev/null || true
+chown -R "$USER:$GROUP" "$PANTALLA_ROOT" "$STATE_ROOT" "$CONFIG_ROOT" "$LOG_ROOT" "$APP_LOG_DIR" 2>/dev/null || true
 chown -R www-data:www-data "$WEB_ROOT" 2>/dev/null || true
 
 chmod 755 "$PANTALLA_ROOT" 2>/dev/null || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,8 +69,8 @@ install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$USER_HOME"
 install -d -m 0700 -o "$USER_NAME" -g "$USER_NAME" /run/user/1000
 install -d -m 0755 "$PANTALLA_PREFIX" "$SESSION_PREFIX"
 install -d -m 0755 "$SESSION_PREFIX/bin" "$SESSION_PREFIX/openbox"
-install -d -m 0755 -o root -g root /var/lib/pantalla
-install -d -m 0755 -o root -g root /var/log/pantalla
+install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" /var/lib/pantalla
+install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" /var/log/pantalla
 install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$LOG_DIR"
 install -d -m 0700 -o "$USER_NAME" -g "$USER_NAME" "$STATE_DIR"
 install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$STATE_RUNTIME"


### PR DESCRIPTION
## Summary
- adjust the installer and permission fixer to create the kiosk runtime directories with the required ownership and to add geometry/backend verification checks
- update the Xorg, Openbox, backend and kiosk systemd units to match the desired startup contract and reuse the backend launcher
- harden the Openbox autostart script and Xauthority preparation so the X session consistently exposes the expected geometry without DPMS blanking
- ensure legacy /var/lib/pantalla and /var/log/pantalla directories remain writable by the kiosk user so the backend can persist configuration

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68fda69e97208326b65de02fbaf2f963