### PR TITLE
Hardening Epiphany kiosk startup environment

### DIFF
--- a/opt/pantalla/bin/pantalla-kiosk-sanitize.sh
+++ b/opt/pantalla/bin/pantalla-kiosk-sanitize.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+DELAY=4
+WM_CLASS="org.gnome.Epiphany.WebApp_PantallaReloj"
+LOG_FILE="/var/log/pantalla/kiosk-sanitize.log"
+
+log() {
+  local ts
+  ts="$(date -Is)"
+  printf '%s %s\n' "$ts" "$*" >>"$LOG_FILE"
+}
+
+usage() {
+  cat <<USAGE
+Usage: pantalla-kiosk-sanitize.sh [--delay SECONDS] [--wm-class WMCLASS] [--log FILE]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --delay)
+      DELAY="$2"
+      shift 2
+      ;;
+    --wm-class)
+      WM_CLASS="$2"
+      shift 2
+      ;;
+    --log)
+      LOG_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$LOG_FILE" ]]; then
+  echo "Log file path required" >&2
+  exit 1
+fi
+
+install -d -m 0755 "$(dirname "$LOG_FILE")"
+touch "$LOG_FILE"
+
+sleep "$DELAY" 2>/dev/null || sleep 4
+
+wmctrl -lx >/dev/null 2>&1 || {
+  log "wmctrl no disponible"
+  exit 0
+}
+
+mapfile -t windows < <(wmctrl -lx | awk -v cls="$WM_CLASS" '$3 == cls {print $1":"$0}')
+count=${#windows[@]}
+
+if (( count == 0 )); then
+  log "sin-ventanas wmclass=$WM_CLASS"
+  exit 0
+fi
+
+primary="${windows[0]%%:*}"
+
+if (( count > 1 )); then
+  for ((i = 1; i < count; i++)); do
+    wid="${windows[i]%%:*}"
+    if wmctrl -i -c "$wid" >/dev/null 2>&1; then
+      log "cerrada-duplicada id=$wid"
+    else
+      log "error-cerrar id=$wid"
+    fi
+  done
+fi
+
+if wmctrl -i -r "$primary" -b add,fullscreen >/dev/null 2>&1; then
+  log "fullscreen id=$primary"
+else
+  log "error-fullscreen id=$primary"
+fi
+
+if wmctrl -i -a "$primary" >/dev/null 2>&1; then
+  log "focus id=$primary"
+else
+  log "error-focus id=$primary"
+fi
+
+exit 0

--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -4,6 +4,25 @@ set -euo pipefail
 export DISPLAY=:0
 export XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
 
+# Prepare session environment for systemd services
+STATE_DIR=/var/lib/pantalla-reloj/state
+SESSION_ENV="${STATE_DIR}/session.env"
+umask 077
+install -d -m 0700 "$STATE_DIR"
+{
+  echo "DISPLAY=${DISPLAY}"
+  echo "XAUTHORITY=${XAUTHORITY}"
+  if [[ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
+    echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS}"
+  fi
+} >"${SESSION_ENV}.tmp"
+chmod 0640 "${SESSION_ENV}.tmp"
+mv "${SESSION_ENV}.tmp" "$SESSION_ENV"
+
+if command -v dbus-update-activation-environment >/dev/null 2>&1; then
+  dbus-update-activation-environment --systemd DISPLAY XAUTHORITY DBUS_SESSION_BUS_ADDRESS || true
+fi
+
 # Disable DPMS and screen blanking to avoid black screen with pointer
 xset -dpms
 xset s off

--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -9,13 +9,16 @@ Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
 Environment=GIO_USE_PORTALS=0
 Environment=GTK_USE_PORTAL=0
+Environment=GDK_BACKEND=x11
+Environment=WEBKIT_DISABLE_DMABUF_RENDERER=1
 Environment=EPHY_PROFILE=/var/lib/pantalla-reloj/state/org.gnome.Epiphany.WebApp_PantallaReloj
+EnvironmentFile=-/var/lib/pantalla-reloj/state/session.env
 ExecStartPre=/bin/sh -c 'test -r "$XAUTHORITY"'
 ExecStartPre=/bin/sh -c 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
-ExecStart=/usr/bin/epiphany-browser --application-mode --profile=${EPHY_PROFILE} \
-          --new-window http://127.0.0.1
+ExecStart=/usr/local/bin/pantalla-kiosk http://127.0.0.1
 Restart=on-failure
 RestartSec=2
+RestartPreventExitStatus=3
 
 [Install]
 WantedBy=multi-user.target

--- a/usr/local/bin/pantalla-kiosk
+++ b/usr/local/bin/pantalla-kiosk
@@ -1,45 +1,172 @@
 #!/usr/bin/env bash
-set -euxo pipefail
-URL="${1:-http://127.0.0.1}"
+set -euo pipefail
+
+APP_ID="org.gnome.Epiphany.WebApp_PantallaReloj"
+APP_WM_CLASS="$APP_ID"
+DEFAULT_URL="http://127.0.0.1"
+URL="${1:-$DEFAULT_URL}"
+
 : "${DISPLAY:=:0}"
 : "${XAUTHORITY:?XAUTHORITY must be set}"
-: "${XDG_RUNTIME_DIR:=/run/user/1000}"
+: "${XDG_RUNTIME_DIR:=/run/user/$(id -u)}"
 
-LOG=/tmp/kiosk-launch.log
-exec >>"$LOG" 2>&1
-echo "[kiosk] $(date -Is) start user=$(id -un) DISPLAY=$DISPLAY URL=$URL"
+EXIT_MISSING=3
+STATE_BASE="/var/lib/pantalla-reloj/state"
+PROFILE_DIR="${EPHY_PROFILE:-${STATE_BASE}/${APP_ID}}"
+DESKTOP_FILE="/usr/local/share/applications/${APP_ID}.desktop"
+LOG_DIR="/var/log/pantalla"
+PROFILE_LOG="${LOG_DIR}/kiosk-profile.log"
+SANITIZE_LOG="${LOG_DIR}/kiosk-sanitize.log"
+WAIT_X="/opt/pantalla/bin/wait-x.sh"
+SANITIZER="/opt/pantalla/bin/pantalla-kiosk-sanitize.sh"
 
-STATE_DIR=/var/lib/pantalla-reloj/state
-PROFILE_DIR="$STATE_DIR/org.gnome.Epiphany.WebApp_PantallaReloj"
-LOCK="$STATE_DIR/kiosk.lock"
 OWNER="${KIOSK_USER:-${USER:-$(id -un)}}"
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
-if ! install -d -m 0755 "$STATE_DIR" "$PROFILE_DIR" 2>/dev/null; then
-  if [[ ! -d "$PROFILE_DIR" ]]; then
-    echo "[kiosk] no se pudo preparar el perfil: $PROFILE_DIR" >&2
+log_err() { printf '[kiosk] %s\n' "$*" >&2; }
+log_info() { printf '[kiosk] %s\n' "$*"; }
+
+fail_missing() {
+  log_err "$1"
+  exit "$EXIT_MISSING"
+}
+
+ensure_profile_dir() {
+  install -d -m 0700 "$PROFILE_DIR"
+  local owner group mode
+  owner="$(stat -c '%U' "$PROFILE_DIR")"
+  group="$(stat -c '%G' "$PROFILE_DIR")"
+  mode="$(stat -c '%a' "$PROFILE_DIR")"
+  if [[ "$owner" != "$OWNER" || "$group" != "$OWNER" ]]; then
+    log_err "Propietario inesperado en $PROFILE_DIR: ${owner}:${group}"
+    fail_missing "El perfil debe pertenecer a ${OWNER}:${OWNER}"
+  fi
+  if [[ "$mode" != "700" ]]; then
+    if ! chmod 0700 "$PROFILE_DIR" 2>/dev/null; then
+      fail_missing "No se pudo ajustar permisos 0700 en ${PROFILE_DIR}"
+    fi
+  fi
+}
+
+check_desktop_file() {
+  if [[ ! -r "$DESKTOP_FILE" ]]; then
+    fail_missing "Desktop file requerido no disponible: ${DESKTOP_FILE}"
+  fi
+}
+
+kill_existing_instances() {
+  if command -v pkill >/dev/null 2>&1; then
+    local uid pattern
+    uid="$(id -u "$OWNER")"
+    pattern="$PROFILE_DIR"
+    pkill -u "$uid" -f "$pattern" 2>/dev/null || true
+  fi
+}
+
+prepare_logs() {
+  if ! install -d -m 0755 "$LOG_DIR" 2>/dev/null; then
+    if [[ ! -d "$LOG_DIR" ]]; then
+      log_err "No se pudo preparar ${LOG_DIR}"
+      fail_missing "No se pudo preparar el directorio de logs"
+    fi
+  fi
+  touch "$PROFILE_LOG" "$SANITIZE_LOG"
+}
+
+apply_profile_preferences() {
+  local ts summary status schema key desired reason current
+  ts="$(date -Is)"
+  summary=()
+  status=0
+
+  export GSETTINGS_BACKEND=dconf
+  export XDG_CONFIG_HOME="${PROFILE_DIR}/config"
+  export XDG_DATA_HOME="${PROFILE_DIR}/share"
+  export XDG_CACHE_HOME="${PROFILE_DIR}/cache"
+  install -d -m 0700 "${XDG_CONFIG_HOME}" "${XDG_DATA_HOME}" "${XDG_CACHE_HOME}"
+
+  if ! command -v gsettings >/dev/null 2>&1; then
+    summary+=("gsettings=missing")
+    status=1
+  else
+    if gsettings list-schemas 2>/dev/null | grep -qx "org.gnome.Epiphany"; then
+      schema="org.gnome.Epiphany"
+      key="restore-session-policy"
+      desired="'never'"
+      reason="disable-session-restore"
+      current="$(gsettings get "$schema" "$key" 2>/dev/null || echo '__error__')"
+      if [[ "$current" != "$desired" ]]; then
+        if gsettings set "$schema" "$key" "$desired" 2>/dev/null; then
+          summary+=("${schema}/${key}=${desired}:${reason}")
+        else
+          summary+=("${schema}/${key}=error")
+          status=1
+        fi
+      else
+        summary+=("${schema}/${key}=already:${desired}")
+      fi
+
+      key="process-model"
+      desired="'single-web-process'"
+      reason="reduce-unresponsive-dialogs"
+      current="$(gsettings get "$schema" "$key" 2>/dev/null || echo '__error__')"
+      if [[ "$current" != "$desired" ]]; then
+        if gsettings set "$schema" "$key" "$desired" 2>/dev/null; then
+          summary+=("${schema}/${key}=${desired}:${reason}")
+        else
+          summary+=("${schema}/${key}=error")
+          status=1
+        fi
+      else
+        summary+=("${schema}/${key}=already:${desired}")
+      fi
+    else
+      summary+=("schema-missing=org.gnome.Epiphany")
+      status=1
+    fi
+  fi
+
+  {
+    printf '%s status=%s' "$ts" "$status"
+    for entry in "${summary[@]}"; do
+      printf ' %s' "$entry"
+    done
+    printf '\n'
+  } >>"$PROFILE_LOG"
+}
+
+launch_sanitizer() {
+  if [[ -x "$SANITIZER" ]]; then
+    "$SANITIZER" --delay 4 --wm-class "$APP_WM_CLASS" --log "$SANITIZE_LOG" &
+  else
+    log_err "No se encontró sanitizador en $SANITIZER"
+  fi
+}
+
+main() {
+  ensure_profile_dir
+  check_desktop_file
+  prepare_logs
+  apply_profile_preferences
+
+  if [[ -x "$WAIT_X" ]]; then
+    DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" "$WAIT_X"
+  fi
+
+  kill_existing_instances
+  launch_sanitizer
+
+  local epiphany
+  epiphany="$(command -v epiphany-browser || true)"
+  if [[ -z "$epiphany" ]]; then
+    log_err "epiphany-browser no encontrado"
     exit 1
   fi
-fi
-chown -R "$OWNER:$OWNER" "$STATE_DIR" || true
 
-exec 9>"$LOCK"
-if ! flock -n 9; then
-  echo "[kiosk] otro proceso en ejecución; saliendo"
-  exit 0
-fi
+  exec env -i DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
+    HOME="/home/$OWNER" PATH="$PATH" GIO_USE_PORTALS=0 GTK_USE_PORTAL=0 \
+    GDK_BACKEND="${GDK_BACKEND:-x11}" WEBKIT_DISABLE_DMABUF_RENDERER="${WEBKIT_DISABLE_DMABUF_RENDERER:-1}" \
+    "$epiphany" --application-mode --profile="$PROFILE_DIR" --new-window "$URL"
+}
 
-DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh
-
-EPIPHANY_BIN="$(command -v epiphany-browser || true)"
-if [[ -z "$EPIPHANY_BIN" ]]; then
-  echo "[kiosk] epiphany-browser no encontrado" >&2
-  exit 1
-fi
-
-export GIO_USE_PORTALS=0
-export GTK_USE_PORTAL=0
-
-exec env -i DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" XDG_RUNTIME_DIR="$XDG_RUNTIME_DIR" \
-  HOME="/home/$OWNER" PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-  GIO_USE_PORTALS=0 GTK_USE_PORTAL=0 \
-  "$EPIPHANY_BIN" --application-mode --profile="$PROFILE_DIR" --new-window "$URL"
+main "$@"

--- a/usr/local/bin/pantalla-kiosk-verify
+++ b/usr/local/bin/pantalla-kiosk-verify
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="/var/log/pantalla/kiosk-verify.log"
+DISPLAY_VALUE="${DISPLAY:-:0}"
+XAUTHORITY_VALUE="${XAUTHORITY:-/var/lib/pantalla-reloj/.Xauthority}"
+
+run_cmd() {
+  local desc cmd status
+  desc="$1"
+  shift
+  cmd=("$@")
+  {
+    printf '--- %s ---\n' "$desc"
+    printf 'CMD: %s\n' "${cmd[*]}"
+    if "${cmd[@]}"; then
+      status=0
+    else
+      status=$?
+      printf 'exit-status=%s\n' "$status"
+    fi
+    printf '\n'
+  }
+}
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+{
+  echo "=== $(date -Is) pantalla-kiosk-verify ==="
+  echo "DISPLAY=${DISPLAY_VALUE}"
+  echo "XAUTHORITY=${XAUTHORITY_VALUE}"
+  echo
+
+  run_cmd "xrandr --query" env DISPLAY="$DISPLAY_VALUE" XAUTHORITY="$XAUTHORITY_VALUE" xrandr --query
+  run_cmd "xset q" env DISPLAY="$DISPLAY_VALUE" XAUTHORITY="$XAUTHORITY_VALUE" xset q
+  run_cmd "wmctrl -lx" env DISPLAY="$DISPLAY_VALUE" XAUTHORITY="$XAUTHORITY_VALUE" wmctrl -lx
+  run_cmd "_NET_ACTIVE_WINDOW" env DISPLAY="$DISPLAY_VALUE" XAUTHORITY="$XAUTHORITY_VALUE" xprop -root _NET_ACTIVE_WINDOW
+  run_cmd "_NET_CLIENT_LIST" env DISPLAY="$DISPLAY_VALUE" XAUTHORITY="$XAUTHORITY_VALUE" xprop -root _NET_CLIENT_LIST
+  run_cmd "backend health" curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8081/api/health
+
+  echo "--- tail kiosk-sanitize.log ---"
+  if [[ -f /var/log/pantalla/kiosk-sanitize.log ]]; then
+    tail -n 60 /var/log/pantalla/kiosk-sanitize.log
+  else
+    echo "no-sanitize-log"
+  fi
+  echo
+
+  echo "--- tail kiosk-profile.log ---"
+  if [[ -f /var/log/pantalla/kiosk-profile.log ]]; then
+    tail -n 60 /var/log/pantalla/kiosk-profile.log
+  else
+    echo "no-profile-log"
+  fi
+} >"${LOG_FILE}.tmp" 2>&1
+
+mv "${LOG_FILE}.tmp" "$LOG_FILE"
+
+printf 'Resultados guardados en %s\n' "$LOG_FILE"

--- a/usr/local/share/applications/org.gnome.Epiphany.WebApp_PantallaReloj.desktop
+++ b/usr/local/share/applications/org.gnome.Epiphany.WebApp_PantallaReloj.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Pantalla Reloj
+Type=Application
+NoDisplay=true
+Terminal=false
+StartupWMClass=org.gnome.Epiphany.WebApp_PantallaReloj
+Exec=/usr/bin/epiphany-browser --application-mode --profile=/var/lib/pantalla-reloj/state/org.gnome.Epiphany.WebApp_PantallaReloj --new-window http://127.0.0.1


### PR DESCRIPTION
## Summary
- ensure the kiosk launcher enforces profile ownership, applies per-profile Epiphany settings, spawns a post-launch window sanitizer, and exits cleanly when prerequisites are missing
- add Openbox session environment export, install the Epiphany WebApp desktop file, and update the systemd unit to rely on the new launcher and required environment variables
- provision the WebApp profile directory, sanitizer helper, verification script, and refresh the desktop database during install

## Testing
- bash -n usr/local/bin/pantalla-kiosk opt/pantalla/bin/pantalla-kiosk-sanitize.sh usr/local/bin/pantalla-kiosk-verify opt/pantalla/openbox/autostart

------
https://chatgpt.com/codex/tasks/task_e_68fda8bf14008326b46d9f402dbdf3c8