### PR TITLE
Fix kiosk log directory ownership in pantalla-xorg service

### DIFF
--- a/systemd/pantalla-xorg.service
+++ b/systemd/pantalla-xorg.service
@@ -5,8 +5,14 @@ After=systemd-user-sessions.service
 [Service]
 Type=simple
 User=root
-ExecStartPre=/usr/bin/install -d -m 0755 -o root -g root /var/log/pantalla
 ExecStartPre=/usr/lib/pantalla-reloj/xorg-launch.sh --prepare-only
+ExecStartPre=/bin/sh -c 'if [ -f /var/lib/pantalla-reloj/.Xauthority ]; then \\
+  owner=$(stat -c %u /var/lib/pantalla-reloj/.Xauthority) && \\
+  group=$(stat -c %g /var/lib/pantalla-reloj/.Xauthority) && \\
+  install -d -m 0755 -o "$owner" -g "$group" /var/log/pantalla; \\
+else \\
+  install -d -m 0755 /var/log/pantalla; \\
+fi'
 ExecStart=/usr/lib/xorg/Xorg :0 -verbose 3 -nolisten tcp -background none vt7 -auth /var/lib/pantalla-reloj/.Xauthority -logfile /var/log/pantalla/xorg.log
 Restart=on-failure
 


### PR DESCRIPTION
## Summary
- ensure the pantalla-xorg unit prepares the kiosk log directory using the Xauthority owner so the kiosk user retains write access
- keep a fallback that simply creates the directory if the kiosk state file is absent

## Testing
- Not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68fdb3ddc5f08326aaec8a89a3c93f4e