### PR TITLE
Ensure Epiphany kiosk launches with desktop portal backend

### DIFF
--- a/opt/pantalla/bin/pantalla-portal-launch.sh
+++ b/opt/pantalla/bin/pantalla-portal-launch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_DIR=/var/log/pantalla
+LOG_FILE="${LOG_DIR}/xdg-desktop-portal.log"
+STATE_FILE=/var/lib/pantalla-reloj/state/session.env
+DEFAULT_RUNTIME_DIR="/run/user/$(id -u)"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-$DEFAULT_RUNTIME_DIR}"
+PORTAL_BIN=${PORTAL_BIN:-/usr/libexec/xdg-desktop-portal}
+BACKEND_BIN=${BACKEND_BIN:-/usr/libexec/xdg-desktop-portal-gtk}
+DEFAULT_DISPLAY=":0"
+DEFAULT_XAUTH="/var/lib/pantalla-reloj/.Xauthority"
+
+log() {
+  local level="$1" message="$2"
+  local ts
+  ts="$(date -Is)"
+  install -d -m 0755 "$LOG_DIR" >/dev/null 2>&1 || true
+  printf '%s [%s] %s\n' "$ts" "$level" "$message" >>"$LOG_FILE"
+}
+
+load_session_state() {
+  if [[ -r "$STATE_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$STATE_FILE"
+    return 0
+  fi
+  return 1
+}
+
+wait_for_session_state() {
+  for _ in {1..20}; do
+    if load_session_state; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  log WARN "session.env not found after waiting"
+  return 1
+}
+
+ensure_runtime_dir() {
+  install -d -m 0700 "$RUNTIME_DIR" >/dev/null 2>&1 || true
+}
+
+ensure_dbus_bus() {
+  local bus_path="$RUNTIME_DIR/bus"
+  if [[ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
+    return 0
+  fi
+  if [[ -S "$bus_path" ]]; then
+    export DBUS_SESSION_BUS_ADDRESS="unix:path=${bus_path}"
+    return 0
+  fi
+  if command -v dbus-daemon >/dev/null 2>&1; then
+    if address=$(dbus-daemon --session --fork --print-address --address="unix:path=${bus_path}" 2>/dev/null); then
+      export DBUS_SESSION_BUS_ADDRESS="$address"
+      log INFO "dbus-daemon forked for portal"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+ensure_backend() {
+  if [[ ! -x "$BACKEND_BIN" ]]; then
+    log WARN "backend binary not executable: $BACKEND_BIN"
+    return
+  fi
+  if pgrep -u "$(id -u)" -f "xdg-desktop-portal-gtk" >/dev/null 2>&1; then
+    log INFO "backend already running"
+    return
+  fi
+  log INFO "starting backend: $BACKEND_BIN"
+  env -i \
+    XDG_RUNTIME_DIR="$RUNTIME_DIR" \
+    DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}" \
+    DISPLAY="${DISPLAY:-$DEFAULT_DISPLAY}" \
+    XAUTHORITY="${XAUTHORITY:-$DEFAULT_XAUTH}" \
+    GTK_USE_PORTAL=1 GIO_USE_PORTALS=1 \
+    "$BACKEND_BIN" >>"$LOG_FILE" 2>&1 &
+}
+
+main() {
+  wait_for_session_state || true
+
+  RUNTIME_DIR="${XDG_RUNTIME_DIR:-$RUNTIME_DIR}"
+  ensure_runtime_dir
+  log INFO "using runtime dir: $RUNTIME_DIR"
+
+  : "${DISPLAY:=$DEFAULT_DISPLAY}"
+  : "${XAUTHORITY:=$DEFAULT_XAUTH}"
+  : "${XDG_RUNTIME_DIR:=$RUNTIME_DIR}"
+
+  ensure_dbus_bus || log WARN "dbus-daemon unavailable"
+
+  if [[ ! -x "$PORTAL_BIN" ]]; then
+    log ERROR "portal binary missing: $PORTAL_BIN"
+    exit 1
+  fi
+
+  ensure_backend
+
+  log INFO "launching portal: $PORTAL_BIN"
+  exec env -i \
+    DISPLAY="$DISPLAY" \
+    XAUTHORITY="$XAUTHORITY" \
+    XDG_RUNTIME_DIR="$RUNTIME_DIR" \
+    DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-}" \
+    XDG_CURRENT_DESKTOP="${XDG_CURRENT_DESKTOP:-Openbox}" \
+    GTK_USE_PORTAL=1 GIO_USE_PORTALS=1 \
+    "$PORTAL_BIN" --watch >>"$LOG_FILE" 2>&1
+}
+
+main "$@"

--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -57,6 +57,7 @@ write_session_state() {
   {
     echo "DISPLAY=${DISPLAY}"
     echo "XAUTHORITY=${XAUTHORITY}"
+    echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}"
     if [[ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
       echo "DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS}"
     fi
@@ -68,7 +69,7 @@ write_session_state() {
 
 propagate_environment() {
   if command -v dbus-update-activation-environment >/dev/null 2>&1; then
-    if dbus-update-activation-environment --systemd DISPLAY XAUTHORITY DBUS_SESSION_BUS_ADDRESS >/dev/null 2>&1; then
+    if dbus-update-activation-environment --systemd DISPLAY XAUTHORITY XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS >/dev/null 2>&1; then
       log_session "dbus-update-activation=ok"
     else
       log_session "dbus-update-activation=failed"

--- a/scripts/fix_kiosk_env.sh
+++ b/scripts/fix_kiosk_env.sh
@@ -140,6 +140,8 @@ install -d -m 0700 -o "$KIOSK_USER" -g "$KIOSK_USER" "/run/user/$KIOSK_UID"
 
 log_info "Instalando scripts kiosk"
 install -m 0755 "$REPO_ROOT/usr/local/bin/kiosk-epiphany" /usr/local/bin/kiosk-epiphany
+install -d -m 0755 /opt/pantalla/bin
+install -m 0755 "$REPO_ROOT/opt/pantalla/bin/pantalla-portal-launch.sh" /opt/pantalla/bin/pantalla-portal-launch.sh
 
 ensure_firefox
 
@@ -148,12 +150,14 @@ install -m 0644 "$REPO_ROOT/systemd/pantalla-xorg.service" /etc/systemd/system/p
 install -m 0644 "$REPO_ROOT/systemd/pantalla-openbox@.service" /etc/systemd/system/pantalla-openbox@.service
 install -m 0644 "$REPO_ROOT/systemd/pantalla-dash-backend@.service" /etc/systemd/system/pantalla-dash-backend@.service
 install -m 0644 "$REPO_ROOT/systemd/pantalla-kiosk@.service" /etc/systemd/system/pantalla-kiosk@.service
+install -m 0644 "$REPO_ROOT/systemd/pantalla-portal@.service" /etc/systemd/system/pantalla-portal@.service
 systemctl daemon-reload
 
 SERVICES=(
   pantalla-xorg.service
   "pantalla-dash-backend@${KIOSK_USER}.service"
   "pantalla-openbox@${KIOSK_USER}.service"
+  "pantalla-portal@${KIOSK_USER}.service"
   "pantalla-kiosk@${KIOSK_USER}.service"
 )
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,7 +97,10 @@ APT_PACKAGES=(
   x11-xserver-utils
   wmctrl
   epiphany-browser
+  xdg-desktop-portal
+  xdg-desktop-portal-gtk
   xdotool
+  procps
   dbus-x11
   curl
   unzip
@@ -197,6 +200,7 @@ install -m 0755 "$REPO_ROOT/opt/pantalla/bin/wait-x.sh" "$SESSION_PREFIX/bin/wai
 install -m 0755 "$REPO_ROOT/opt/pantalla/bin/pantalla-geometry.sh" "$SESSION_PREFIX/bin/pantalla-geometry.sh"
 install -m 0755 "$REPO_ROOT/opt/pantalla/bin/pantalla-kiosk-sanitize.sh" "$SESSION_PREFIX/bin/pantalla-kiosk-sanitize.sh"
 install -m 0755 "$REPO_ROOT/opt/pantalla/bin/pantalla-kiosk-watchdog.sh" "$SESSION_PREFIX/bin/pantalla-kiosk-watchdog.sh"
+install -m 0755 "$REPO_ROOT/opt/pantalla/bin/pantalla-portal-launch.sh" "$SESSION_PREFIX/bin/pantalla-portal-launch.sh"
 install -m 0755 "$REPO_ROOT/opt/pantalla/openbox/autostart" "$SESSION_PREFIX/openbox/autostart"
 
 install -D -m 0755 "$KIOSK_BIN_SRC" "$KIOSK_BIN_DST"
@@ -413,6 +417,7 @@ deploy_unit "$REPO_ROOT/systemd/pantalla-xorg.service" /etc/systemd/system/panta
 deploy_unit "$REPO_ROOT/systemd/pantalla-openbox@.service" /etc/systemd/system/pantalla-openbox@.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-kiosk@.service" /etc/systemd/system/pantalla-kiosk@.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-dash-backend@.service" /etc/systemd/system/pantalla-dash-backend@.service
+deploy_unit "$REPO_ROOT/systemd/pantalla-portal@.service" /etc/systemd/system/pantalla-portal@.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-kiosk-watchdog@.service" /etc/systemd/system/pantalla-kiosk-watchdog@.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-kiosk-watchdog@.timer" /etc/systemd/system/pantalla-kiosk-watchdog@.timer
 
@@ -434,6 +439,7 @@ log_info "Enabling services"
 systemctl enable pantalla-xorg.service || true
 systemctl enable pantalla-dash-backend@${USER_NAME}.service || true
 systemctl enable pantalla-openbox@${USER_NAME}.service || true
+systemctl enable pantalla-portal@${USER_NAME}.service || true
 systemctl enable pantalla-kiosk@${USER_NAME}.service || true
 systemctl enable --now pantalla-kiosk-watchdog@${USER_NAME}.timer || true
 
@@ -445,6 +451,8 @@ else
   SUMMARY+=('[install] permisos XAUTHORITY: no disponible')
 fi
 systemctl restart pantalla-openbox@${USER_NAME}.service
+sleep 1
+systemctl restart pantalla-portal@${USER_NAME}.service
 sleep 1
 
 log_info "Running post-install checks"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -76,6 +76,7 @@ UDEV_RULE=/etc/udev/rules.d/70-pantalla-render.rules
 
 SYSTEMD_UNITS=(
   "pantalla-kiosk@${USER_NAME}.service"
+  "pantalla-portal@${USER_NAME}.service"
   "pantalla-openbox@${USER_NAME}.service"
   "pantalla-dash-backend@${USER_NAME}.service"
   "pantalla-xorg.service"
@@ -95,6 +96,7 @@ rm -f /etc/systemd/system/pantalla-kiosk@.service
 rm -f /etc/systemd/system/pantalla-openbox@.service
 rm -f /etc/systemd/system/pantalla-xorg.service
 rm -f /etc/systemd/system/pantalla-dash-backend@.service
+rm -f /etc/systemd/system/pantalla-portal@.service
 rm -rf /etc/systemd/system/pantalla-kiosk@.service.d /etc/systemd/system/pantalla-openbox@.service.d /etc/systemd/system/pantalla-dash-backend@.service.d
 
 systemctl daemon-reload
@@ -188,6 +190,7 @@ fi
 
 rm -f "$SESSION_PREFIX/bin/xorg-openbox-env.sh"
 rm -f "$SESSION_PREFIX/bin/wait-x.sh"
+rm -f "$SESSION_PREFIX/bin/pantalla-portal-launch.sh"
 rm -f "$SESSION_PREFIX/openbox/autostart"
 if [[ -d "$SESSION_PREFIX/bin" ]]; then
   rmdir --ignore-fail-on-non-empty "$SESSION_PREFIX/bin" || true

--- a/systemd/pantalla-portal@.service
+++ b/systemd/pantalla-portal@.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Pantalla_reloj XDG desktop portal for user %i
+After=pantalla-openbox@%i.service
+Requires=pantalla-openbox@%i.service
+PartOf=pantalla-openbox@%i.service
+
+[Service]
+User=%i
+Type=simple
+Environment=XDG_RUNTIME_DIR=/run/user/%U
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
+EnvironmentFile=-/var/lib/pantalla-reloj/state/session.env
+ExecStart=/opt/pantalla/bin/pantalla-portal-launch.sh
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- ensure the installer pulls in xdg-desktop-portal(-gtk) and procps and stage the portal launch helper alongside existing kiosk assets
- add a user-scoped portal launcher script and systemd unit so the kiosk session always starts xdg-desktop-portal with a GTK backend and exported runtime details
- propagate the changes through uninstall/fix scripts and the Openbox autostart so XDG_RUNTIME_DIR is recorded for the portal service

## Testing
- bash -n opt/pantalla/bin/pantalla-portal-launch.sh
- bash -n scripts/install.sh
- bash -n scripts/uninstall.sh
- bash -n scripts/fix_kiosk_env.sh

------
https://chatgpt.com/codex/tasks/task_e_68fdb4791914832682a1bba0790cb064