### PR TITLE
Add PermissionsStartOnly to pantalla-openbox unit

### DIFF
--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -5,6 +5,7 @@ Wants=pantalla-xorg.service
 
 [Service]
 User=%i
+PermissionsStartOnly=yes
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
 Environment=XDG_RUNTIME_DIR=/run/user/%U


### PR DESCRIPTION
## Summary
- ensure pantalla-openbox unit prepares runtime directories with elevated privileges by enabling PermissionsStartOnly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fdbd2d110c8326a32ffd393b1b0267