### PR TITLE
Add stable kiosk drop-in configuration

### DIFF
--- a/systemd/pantalla-kiosk@.service.d/90-stable.conf
+++ b/systemd/pantalla-kiosk@.service.d/90-stable.conf
@@ -1,0 +1,24 @@
+[Service]
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
+Environment=GDK_BACKEND=x11
+Environment=WEBKIT_DISABLE_DMABUF_RENDERER=1
+Environment=GTK_USE_PORTAL=0
+Environment=GIO_USE_PORTALS=0
+
+# Matar Epiphany preexistente (sin regex anclado que falla)
+ExecStartPre=/bin/sh -lc 'pkill -u %U -x epiphany-browser 2>/dev/null || true'
+ExecStartPre=/bin/sh -lc 'pkill -u %U -f "/usr/bin/epiphany-browser" 2>/dev/null || true'
+
+# Geometría robusta con reintento (480x1920 rotado a la izquierda)
+ExecStartPre=/bin/sh -lc 'xrandr --fb 1920x1920 || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --rotate normal || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xset -dpms; xset s off; xset s noblank || true'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --mode 480x1920 --primary --pos 0x0 || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --rotate left || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --fb 480x1920 || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --mode 480x1920 --rotate left --primary --pos 0x0 || true'
+
+# Sustituye el ExecStart: NO usar --application-mode (evita dependencia de portals)
+ExecStart=
+ExecStart=/usr/bin/epiphany-browser --new-window --start-fullscreen http://127.0.0.1


### PR DESCRIPTION
## Summary
- add a 90-stable drop-in for `pantalla-kiosk@` that configures the display environment
- ensure the override resets Epiphany before launch and applies the required geometry commands
- run Epiphany with the fullscreen flag without portal dependencies

## Testing
- not run (systemd is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fdd547645883269ea04ea8bedaaa01