### PR TITLE
Reset ExecStartPre in stable kiosk drop-in

### DIFF
--- a/systemd/pantalla-kiosk@.service.d/90-stable.conf
+++ b/systemd/pantalla-kiosk@.service.d/90-stable.conf
@@ -6,6 +6,8 @@ Environment=WEBKIT_DISABLE_DMABUF_RENDERER=1
 Environment=GTK_USE_PORTAL=0
 Environment=GIO_USE_PORTALS=0
 
+# Elimina los ExecStartPre heredados que requieren el perfil WebApp
+ExecStartPre=
 # Matar Epiphany preexistente (sin regex anclado que falla)
 ExecStartPre=/bin/sh -lc 'pkill -u %U -x epiphany-browser 2>/dev/null || true'
 ExecStartPre=/bin/sh -lc 'pkill -u %U -f "/usr/bin/epiphany-browser" 2>/dev/null || true'


### PR DESCRIPTION
## Summary
- clear inherited ExecStartPre commands in the stable kiosk drop-in so the WebApp profile check is removed

## Testing
- not run (systemd is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68fdd9bda7cc8326b17efc933bb8f1c9