### PR TITLE
Restore X readiness checks in stable kiosk drop-in

### DIFF
--- a/systemd/pantalla-kiosk@.service.d/90-stable.conf
+++ b/systemd/pantalla-kiosk@.service.d/90-stable.conf
@@ -6,8 +6,11 @@ Environment=WEBKIT_DISABLE_DMABUF_RENDERER=1
 Environment=GTK_USE_PORTAL=0
 Environment=GIO_USE_PORTALS=0
 
-# Elimina los ExecStartPre heredados que requieren el perfil WebApp
+# Elimina únicamente los ExecStartPre heredados que requieren el perfil WebApp
 ExecStartPre=
+# Conserva las comprobaciones de X heredadas del servicio base
+ExecStartPre=/bin/sh -lc 'test -r "$XAUTHORITY"'
+ExecStartPre=/bin/sh -lc 'DISPLAY=:0 XAUTHORITY="$XAUTHORITY" /opt/pantalla/bin/wait-x.sh'
 # Matar Epiphany preexistente (sin regex anclado que falla)
 ExecStartPre=/bin/sh -lc 'pkill -u %U -x epiphany-browser 2>/dev/null || true'
 ExecStartPre=/bin/sh -lc 'pkill -u %U -f "/usr/bin/epiphany-browser" 2>/dev/null || true'


### PR DESCRIPTION
## Summary
- keep the base service's XAUTHORITY and wait-x ExecStartPre steps in the stable kiosk override
- continue clearing only the WebApp profile ExecStartPre commands before applying kiosk-specific geometry and cleanup

## Testing
- not run (systemd is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68fdda99d0d48326a14c0b6981eb2eff