### PR TITLE
Add Chromium kiosk service and setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Pantalla_reloj/
   vía `pantalla-backend-launch`, que valida imports y crea las rutas necesarias.
 - `pantalla-kiosk@dani.service`: depende de Openbox y del backend para abrir Epiphany
   en modo WebApp con el perfil correcto y sin navegadores confinados por snap.
+- `pantalla-kiosk-chromium@dani.service`: alternativa basada en Chromium con
+  geometría 480×1920 rotada a la izquierda y sin portals.
 
 ## Arranque estable (boot hardening)
 
@@ -106,7 +108,8 @@ en un estado consistente. Durante la instalación:
 - Se validan e instalan las dependencias APT requeridas.
 - Se habilita Corepack con `npm` actualizado sin usar `apt install npm`.
 - Se instala Epiphany como navegador kiosk por defecto (Firefox se descarga solo
-  si se ejecuta con `--with-firefox`).
+  si se ejecuta con `--with-firefox`). Para migrar a Chromium en modo kiosk, usa
+  `scripts/setup_chromium_kiosk.sh` tras la instalación.
 - Se prepara el backend (venv + `requirements.txt`) sirviendo en
   `http://127.0.0.1:8081` y se crea `/var/lib/pantalla/config.json` con el layout
   `full`, panel derecho y overlay oculto.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,6 +62,8 @@ WEB_ROOT=/var/www/html
 WEBROOT_MANIFEST="${STATE_RUNTIME}/webroot-manifest"
 KIOSK_BIN_SRC="${REPO_ROOT}/usr/local/bin/pantalla-kiosk"
 KIOSK_BIN_DST=/usr/local/bin/pantalla-kiosk
+CHROMIUM_KIOSK_BIN_SRC="${REPO_ROOT}/usr/local/bin/pantalla-kiosk-chromium"
+CHROMIUM_KIOSK_BIN_DST=/usr/local/bin/pantalla-kiosk-chromium
 BACKEND_LAUNCHER_SRC="${REPO_ROOT}/usr/local/bin/pantalla-backend-launch"
 BACKEND_LAUNCHER_DST=/usr/local/bin/pantalla-backend-launch
 UDEV_RULE=/etc/udev/rules.d/70-pantalla-render.rules
@@ -204,7 +206,9 @@ install -m 0755 "$REPO_ROOT/opt/pantalla/bin/pantalla-portal-launch.sh" "$SESSIO
 install -m 0755 "$REPO_ROOT/opt/pantalla/openbox/autostart" "$SESSION_PREFIX/openbox/autostart"
 
 install -D -m 0755 "$KIOSK_BIN_SRC" "$KIOSK_BIN_DST"
+install -D -m 0755 "$CHROMIUM_KIOSK_BIN_SRC" "$CHROMIUM_KIOSK_BIN_DST"
 SUMMARY+=("[install] launcher de kiosk instalado en ${KIOSK_BIN_DST}")
+SUMMARY+=("[install] launcher Chromium kiosk disponible en ${CHROMIUM_KIOSK_BIN_DST}")
 install -D -m 0755 "$BACKEND_LAUNCHER_SRC" "$BACKEND_LAUNCHER_DST"
 SUMMARY+=("[install] launcher de backend instalado en ${BACKEND_LAUNCHER_DST}")
 install -D -m 0644 "$REPO_ROOT/usr/local/share/applications/${APP_ID}.desktop" \
@@ -420,6 +424,7 @@ deploy_unit() {
 deploy_unit "$REPO_ROOT/systemd/pantalla-xorg.service" /etc/systemd/system/pantalla-xorg.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-openbox@.service" /etc/systemd/system/pantalla-openbox@.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-kiosk@.service" /etc/systemd/system/pantalla-kiosk@.service
+deploy_unit "$REPO_ROOT/systemd/pantalla-kiosk-chromium@.service" /etc/systemd/system/pantalla-kiosk-chromium@.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-dash-backend@.service" /etc/systemd/system/pantalla-dash-backend@.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-portal@.service" /etc/systemd/system/pantalla-portal@.service
 deploy_unit "$REPO_ROOT/systemd/pantalla-kiosk-watchdog@.service" /etc/systemd/system/pantalla-kiosk-watchdog@.service

--- a/scripts/setup_chromium_kiosk.sh
+++ b/scripts/setup_chromium_kiosk.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+USER_NAME="dani"
+DISPLAY_NUM=":0"
+XAUTH="/var/lib/pantalla-reloj/.Xauthority"
+STATE_DIR="/var/lib/pantalla-reloj/state"
+CACHE_DIR="/var/lib/pantalla-reloj/cache"
+CHROMIUM_STATE="${STATE_DIR}/chromium"
+CHROMIUM_CACHE="${CACHE_DIR}/chromium"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SERVICE_SRC="${REPO_ROOT}/systemd/pantalla-kiosk-chromium@.service"
+LAUNCHER_SRC="${REPO_ROOT}/usr/local/bin/pantalla-kiosk-chromium"
+
+log() { printf '[chromium-setup] %s\n' "$*"; }
+log_err() { printf '[chromium-setup][ERROR] %s\n' "$*" >&2; }
+
+ensure_packages() {
+  log "Asegurando paquetes (Chromium, utilidades X11)…"
+  sudo apt-get update -y
+  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y x11-xserver-utils wmctrl
+  if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y chromium-browser; then
+    log "chromium-browser no disponible; intentando con paquete chromium"
+    if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y chromium; then
+      log_err "No fue posible instalar chromium-browser ni chromium"
+      exit 1
+    fi
+  fi
+}
+
+find_chromium_bin() {
+  local candidate
+  for candidate in chromium-browser chromium /snap/bin/chromium; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+prepare_dirs() {
+  log "Preparando directorios de estado/caché…"
+  sudo install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$STATE_DIR" "$CACHE_DIR"
+  sudo install -d -m 0700 -o "$USER_NAME" -g "$USER_NAME" "$CHROMIUM_STATE"
+  sudo install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$CHROMIUM_CACHE"
+}
+
+disable_epiphany() {
+  log "Deshabilitando Epiphany/portal anteriores (si existen)…"
+  sudo systemctl disable --now "pantalla-kiosk@${USER_NAME}.service" 2>/dev/null || true
+  sudo systemctl disable --now "pantalla-kiosk-watchdog@${USER_NAME}.timer" 2>/dev/null || true
+  sudo systemctl stop "pantalla-portal@${USER_NAME}.service" 2>/dev/null || true
+  pkill -u "$USER_NAME" -x epiphany-browser 2>/dev/null || true
+  pkill -u "$USER_NAME" -f "/usr/bin/epiphany-browser" 2>/dev/null || true
+}
+
+install_artifacts() {
+  local chromium_bin
+  if [[ ! -f "$SERVICE_SRC" ]]; then
+    log_err "No se encontró la unidad systemd en ${SERVICE_SRC}"
+    exit 1
+  fi
+  if [[ ! -f "$LAUNCHER_SRC" ]]; then
+    log_err "No se encontró el lanzador Chromium en ${LAUNCHER_SRC}"
+    exit 1
+  fi
+
+  if ! chromium_bin="$(find_chromium_bin)"; then
+    log_err "No se encontró el binario de Chromium tras la instalación"
+    exit 1
+  fi
+  log "Usando Chromium en: ${chromium_bin}"
+
+  log "Instalando unidad systemd y lanzador…"
+  sudo install -D -m 0644 "$SERVICE_SRC" /etc/systemd/system/pantalla-kiosk-chromium@.service
+  sudo install -D -m 0755 "$LAUNCHER_SRC" /usr/local/bin/pantalla-kiosk-chromium
+
+  sudo systemctl daemon-reload
+}
+
+enable_services() {
+  log "Habilitando servicios base…"
+  sudo systemctl enable pantalla-xorg.service
+  sudo systemctl enable "pantalla-openbox@${USER_NAME}.service"
+
+  log "Reiniciando Xorg/Openbox…"
+  sudo systemctl restart pantalla-xorg.service
+  sleep 0.5
+  sudo systemctl restart "pantalla-openbox@${USER_NAME}.service"
+  sleep 1
+
+  log "Habilitando e iniciando Chromium kiosk…"
+  sudo systemctl enable --now "pantalla-kiosk-chromium@${USER_NAME}.service"
+}
+
+post_checks() {
+  log "Comprobación rápida:"
+  DISPLAY="$DISPLAY_NUM" XAUTHORITY="$XAUTH" xrandr --query | sed -n '1,12p' || true
+  DISPLAY="$DISPLAY_NUM" XAUTHORITY="$XAUTH" wmctrl -lx || true
+  sudo systemctl --no-pager -l status "pantalla-kiosk-chromium@${USER_NAME}.service" | sed -n '1,35p' || true
+  log "Si ves current 480 x 1920 y una ventana chromium.* en wmctrl, el kiosk está operativo."
+}
+
+ensure_packages
+prepare_dirs
+disable_epiphany
+install_artifacts
+enable_services
+post_checks

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -76,6 +76,7 @@ UDEV_RULE=/etc/udev/rules.d/70-pantalla-render.rules
 
 SYSTEMD_UNITS=(
   "pantalla-kiosk@${USER_NAME}.service"
+  "pantalla-kiosk-chromium@${USER_NAME}.service"
   "pantalla-portal@${USER_NAME}.service"
   "pantalla-openbox@${USER_NAME}.service"
   "pantalla-dash-backend@${USER_NAME}.service"
@@ -93,6 +94,7 @@ for unit in "${SYSTEMD_UNITS[@]}"; do
 done
 
 rm -f /etc/systemd/system/pantalla-kiosk@.service
+rm -f /etc/systemd/system/pantalla-kiosk-chromium@.service
 rm -f /etc/systemd/system/pantalla-openbox@.service
 rm -f /etc/systemd/system/pantalla-xorg.service
 rm -f /etc/systemd/system/pantalla-dash-backend@.service

--- a/systemd/pantalla-kiosk-chromium@.service
+++ b/systemd/pantalla-kiosk-chromium@.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Pantalla_reloj Kiosk (Chromium) for user %i
+After=pantalla-openbox@%i.service
+Wants=pantalla-openbox@%i.service
+
+[Service]
+User=%i
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
+Environment=GDK_BACKEND=x11
+Environment=GTK_USE_PORTAL=0
+Environment=GIO_USE_PORTALS=0
+Environment=CHROMIUM_USER_DATA_DIR=/var/lib/pantalla-reloj/state/chromium
+Environment=CHROMIUM_CACHE_DIR=/var/lib/pantalla-reloj/cache/chromium
+Environment=KIOSK_URL=http://127.0.0.1
+
+# --- Geometría estable 480x1920 rotada a la izquierda ---
+ExecStartPre=/bin/sh -lc 'xset -dpms; xset s off; xset s noblank || true'
+ExecStartPre=/bin/sh -lc 'xrandr --fb 1920x1920 || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --rotate normal || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --mode 480x1920 --primary --pos 0x0 || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --rotate left || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --fb 480x1920 || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --mode 480x1920 --rotate left --primary --pos 0x0 || true; sleep 0.2'
+ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --mode 480x1920 --rotate left --primary --pos 0x0 || true'
+ExecStartPre=/bin/sh -lc 'pkill -u %U -x chromium-browser 2>/dev/null || true'
+ExecStartPre=/bin/sh -lc 'pkill -u %U -f "/snap/chromium/.*/chromium.*" 2>/dev/null || true'
+
+ExecStart=/usr/local/bin/pantalla-kiosk-chromium
+
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/local/bin/pantalla-kiosk-chromium
+++ b/usr/local/bin/pantalla-kiosk-chromium
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[pantalla-kiosk-chromium] %s\n' "$*"
+}
+
+find_chromium() {
+  local candidate
+  for candidate in "${CHROMIUM_BIN_OVERRIDE:-}" chromium-browser chromium /snap/bin/chromium; do
+    if [[ -n "$candidate" ]] && command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+main() {
+  local chromium_bin url user_data_dir cache_dir
+
+  if ! chromium_bin="$(find_chromium)"; then
+    log "ERROR: No se encontró un binario de Chromium disponible"
+    exit 1
+  fi
+
+  url="${KIOSK_URL:-http://127.0.0.1}"
+  user_data_dir="${CHROMIUM_USER_DATA_DIR:-/var/lib/pantalla-reloj/state/chromium}"
+  cache_dir="${CHROMIUM_CACHE_DIR:-/var/lib/pantalla-reloj/cache/chromium}"
+
+  install -d -m 0700 "$user_data_dir"
+  install -d -m 0755 "$cache_dir"
+
+  log "Usando Chromium en: ${chromium_bin}"
+  log "Perfil: ${user_data_dir}"
+  log "Cache: ${cache_dir}"
+  log "URL: ${url}"
+
+  exec "$chromium_bin" \
+    --kiosk --start-fullscreen \
+    --app="${url}" \
+    --no-first-run --no-default-browser-check \
+    --disable-translate --disable-infobars \
+    --overscroll-history-navigation=0 \
+    --password-store=basic \
+    --test-type \
+    --ozone-platform=x11 \
+    --disable-gpu \
+    --disk-cache-dir="${cache_dir}" \
+    --user-data-dir="${user_data_dir}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a Chromium-based kiosk launcher and systemd unit with robust geometry handling
- provide a setup helper that installs Chromium, disables Epiphany services, and enables the new unit
- update installer, uninstaller, and docs to expose the Chromium kiosk option

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fddba2aee48326b456184881d4191a