### PR TITLE
Stabilize kiosk boot sequence for Pantalla_reloj

### DIFF
--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -1,0 +1,49 @@
+# Pantalla_reloj kiosk mode
+
+## Configuración de video
+
+La rotación y el modo preferido del panel HDMI quedan fijados desde Xorg. El archivo [`xorg/10-monitor.conf`](../xorg/10-monitor.conf) declara el monitor `HDMI-1` con el modo `480x1920`, rotación a la izquierda y un framebuffer virtual de `1920x1920` para evitar ajustes dinámicos vía `xrandr` en tiempo de ejecución.
+
+Con esta configuración, al iniciar `pantalla-xorg.service` se obtiene un arranque determinista y sin parpadeos. El uso de `xrandr` queda reservado únicamente para diagnóstico manual.
+
+## Autenticación X11
+
+Chromium se ejecuta desde el usuario normal y necesita la cookie real de Xauthority. Asegúrate de que `~/.Xauthority` exista y sea un archivo regular (`-rw-------`) perteneciente a `dani:dani`. El servicio de Xorg ya se inicia con `-auth /home/dani/.Xauthority`, por lo que no es necesario crear enlaces simbólicos en `/var/lib`.
+
+## Servicios systemd relevantes
+
+```bash
+sudo systemctl enable --now pantalla-xorg.service
+sudo systemctl enable --now pantalla-openbox@dani.service
+sudo systemctl enable --now pantalla-kiosk-chromium@dani.service
+```
+
+El servicio [`pantalla-kiosk-chromium@.service`](../systemd/pantalla-kiosk-chromium@.service) ejecuta Chromium en modo kiosk con la clase de ventana `pantalla-kiosk`, sin ventanas emergentes de error y con la plataforma X11 forzada (`--ozone-platform=x11 --disable-gpu`).
+
+### Escala de la interfaz
+
+La escala de Chromium se controla mediante la variable de entorno `CHROMIUM_SCALE` que por defecto vale `0.84`. Para ajustarla sin editar la unidad:
+
+```bash
+sudo systemctl set-environment CHROMIUM_SCALE=0.86
+sudo systemctl restart pantalla-kiosk-chromium@dani.service
+```
+
+### Evitar ventanas duplicadas
+
+Openbox no lanza navegadores automáticamente y el servicio de kiosk elimina instancias previas por clase de ventana (`wmctrl -lx`). Si aparece una ventana blanca o se percibe una "doble pantalla", verifica que sólo exista una ventana con clase `pantalla-kiosk`:
+
+```bash
+wmctrl -lx | grep pantalla-kiosk
+```
+
+Si hay más de una, ciérralas con `wmctrl -ic <ID>` y revisa que no existan otros lanzadores activos.
+
+### Troubleshooting de video
+
+* `DISPLAY=:0 xrandr --query` debe mostrar la resolución actual `1920 x 480` y el modo `480x1920` asociado a `HDMI-1` con rotación izquierda. Si no aparece, revisa [`xorg/10-monitor.conf`](../xorg/10-monitor.conf).
+* Asegúrate de que `wmctrl -lx` sólo liste una ventana con clase `pantalla-kiosk`.
+
+## Servicios opcionales
+
+El viejo servicio `pantalla-kiosk@.service` (Epiphany) permanece disponible pero está marcado como **deprecated** y no se habilita por defecto. De igual forma, `pantalla-portal@.service` no se activa automáticamente para evitar ventanas auxiliares; habilítalo manualmente sólo si es necesario.

--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -2,15 +2,14 @@
 set -euo pipefail
 
 export DISPLAY="${DISPLAY:-:0}"
-export XAUTHORITY="${XAUTHORITY:-/var/lib/pantalla-reloj/.Xauthority}"
+export XAUTHORITY="${XAUTHORITY:-${HOME:-/home/dani}/.Xauthority}"
+
+# El navegador se lanza desde systemd (pantalla-kiosk-chromium@); no iniciar nada aquí.
 
 STATE_DIR=/var/lib/pantalla-reloj/state
 SESSION_FILE="${STATE_DIR}/session.env"
 LOG_DIR=/var/log/pantalla
 SESSION_LOG="${LOG_DIR}/session.env.log"
-GEOMETRY_LOG="${LOG_DIR}/geometry.log"
-GEOMETRY_SCRIPT=/opt/pantalla/bin/pantalla-geometry.sh
-WAIT_X=/opt/pantalla/bin/wait-x.sh
 
 mkdir -p "$LOG_DIR" >/dev/null 2>&1 || true
 install -d -m 0700 "$STATE_DIR" >/dev/null 2>&1 || true
@@ -83,7 +82,7 @@ ensure_dbus
 propagate_environment
 write_session_state
 
-log_session "geometry-hook-start"
+log_session "xset-hook-start"
 if command -v xset >/dev/null 2>&1; then
   if DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xset -dpms >/dev/null 2>&1; then
     log_session "xset-dpms-off"
@@ -104,11 +103,6 @@ else
   log_session "xset-missing"
 fi
 
-if [[ -x "$GEOMETRY_SCRIPT" ]]; then
-  DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" "$GEOMETRY_SCRIPT" --wait >/dev/null 2>&1 || true
-else
-  log_session "geometry-script-missing path=$GEOMETRY_SCRIPT"
-fi
-log_session "geometry-hook-finished"
+log_session "xset-hook-finished"
 
 sleep 0.5 2>/dev/null || sleep 1

--- a/systemd/pantalla-kiosk-chromium@.service
+++ b/systemd/pantalla-kiosk-chromium@.service
@@ -10,23 +10,25 @@ Environment=XAUTHORITY=/home/%i/.Xauthority
 Environment=GDK_BACKEND=x11
 Environment=GTK_USE_PORTAL=0
 Environment=GIO_USE_PORTALS=0
+Environment=CHROMIUM_SCALE=0.84
 
-# Minimal and stable pre-commands
 ExecStartPre=/bin/sh -lc 'xset -dpms; xset s off; xset s noblank || true'
-ExecStartPre=/bin/sh -lc 'xrandr --fb 1920x1920 || true'
-ExecStartPre=/bin/sh -lc 'xrandr --output HDMI-1 --mode 480x1920 --primary --pos 0x0 --rotate left || true'
+ExecStartPre=/bin/sh -lc 'wmctrl -lx | awk "/pantalla-kiosk/ {print \\$1}" | xargs -r -n1 wmctrl -ic || true'
 
 ExecStart=/bin/sh -lc '\
   chromium-browser \
+    --class=pantalla-kiosk \
     --kiosk --start-fullscreen \
     --app=http://127.0.0.1 \
     --no-first-run --no-default-browser-check \
-    --disable-translate --disable-infobars \
-    --overscroll-history-navigation=0 \
+    --disable-translate --disable-infobars --disable-session-crashed-bubble --noerrdialogs \
+    --disable-features=InfiniteSessionRestore,Translate,HardwareMediaKeyHandling \
+    --hide-scrollbars --overscroll-history-navigation=0 \
     --password-store=basic \
     --test-type \
     --ozone-platform=x11 \
     --disable-gpu \
+    --force-device-scale-factor=${CHROMIUM_SCALE} \
     --disk-cache-dir=/var/lib/pantalla-reloj/cache/chromium \
     --user-data-dir=/var/lib/pantalla-reloj/state/chromium \
 '

--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -1,6 +1,6 @@
 # Deprecated in favor of pantalla-kiosk-chromium@.service
 [Unit]
-Description=Pantalla_reloj Kiosk (Epiphany) for user %i
+Description=Pantalla_reloj Kiosk (Epiphany, deprecated) for user %i
 After=pantalla-openbox@%i.service pantalla-dash-backend@%i.service
 Requires=pantalla-openbox@%i.service
 Wants=pantalla-openbox@%i.service pantalla-dash-backend@%i.service
@@ -8,7 +8,7 @@ Wants=pantalla-openbox@%i.service pantalla-dash-backend@%i.service
 [Service]
 User=%i
 Environment=DISPLAY=:0
-Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
+Environment=XAUTHORITY=/home/%i/.Xauthority
 Environment=GDK_BACKEND=x11
 Environment=WEBKIT_DISABLE_DMABUF_RENDERER=1
 EnvironmentFile=-/var/lib/pantalla-reloj/state/session.env
@@ -26,5 +26,4 @@ ExecStartPost=/usr/local/bin/pantalla-kiosk-verify
 Restart=on-failure
 RestartSec=2
 
-[Install]
-WantedBy=multi-user.target
+# No [Install] section on purpose: this unit is not enabled by default.

--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -7,7 +7,7 @@ Wants=pantalla-xorg.service
 User=%i
 PermissionsStartOnly=yes
 Environment=DISPLAY=:0
-Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
+Environment=XAUTHORITY=/home/%i/.Xauthority
 Environment=XDG_RUNTIME_DIR=/run/user/%U
 EnvironmentFile=-/var/lib/pantalla-reloj/state/session.env
 ExecStartPre=/bin/sh -c 'install -d -m 0700 -o %i -g %i /run/user/$(id -u %i)'

--- a/systemd/pantalla-portal@.service
+++ b/systemd/pantalla-portal@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pantalla_reloj XDG desktop portal for user %i
+Description=Pantalla_reloj XDG desktop portal for user %i (optional)
 After=pantalla-openbox@%i.service
 
 [Service]
@@ -7,7 +7,7 @@ User=%i
 PermissionsStartOnly=yes
 Environment=XDG_RUNTIME_DIR=/run/user/%U
 Environment=DISPLAY=:0
-Environment=XAUTHORITY=/var/lib/pantalla-reloj/.Xauthority
+Environment=XAUTHORITY=/home/%i/.Xauthority
 EnvironmentFile=-/var/lib/pantalla-reloj/state/session.env
 ExecStartPre=/usr/bin/test -x /usr/libexec/xdg-desktop-portal-gtk
 ExecStartPre=/usr/bin/test -x /usr/libexec/xdg-desktop-portal
@@ -18,5 +18,4 @@ ExecStart=/opt/pantalla/bin/pantalla-portal-launch.sh
 Restart=on-failure
 RestartSec=2
 
-[Install]
-WantedBy=multi-user.target
+# No [Install] section: the unit is optional and disabled by default

--- a/xorg/10-monitor.conf
+++ b/xorg/10-monitor.conf
@@ -1,0 +1,25 @@
+Section "Monitor"
+  Identifier "HDMI-1"
+  Option     "PreferredMode" "480x1920"
+  Option     "Rotate" "left"
+EndSection
+
+Section "Screen"
+  Identifier "Screen0"
+  Monitor    "HDMI-1"
+  DefaultDepth 24
+  SubSection "Display"
+    Depth 24
+    Virtual 1920 1920
+  EndSubSection
+EndSection
+
+Section "Device"
+  Identifier "Device0"
+  Driver     "modeset"
+EndSection
+
+Section "ServerLayout"
+  Identifier "Layout0"
+  Screen     "Screen0"
+EndSection


### PR DESCRIPTION
## Summary
- lock the HDMI panel geometry in Xorg and stop running xrandr at session start
- update the Chromium kiosk unit to rely on the real Xauthority cookie, kiosk window class, and configurable scale
- simplify the Openbox session helpers, disable legacy Epiphany/portal autostarts, and document the deterministic kiosk flow

## Testing
- not run (configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68fde580783883269f4d725dc9f43cf2