### PR TITLE
Fix portal launch environment and enable systemd templates

### DIFF
--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -26,4 +26,5 @@ ExecStartPost=/usr/local/bin/pantalla-kiosk-verify
 Restart=on-failure
 RestartSec=2
 
-# No [Install] section on purpose: this unit is not enabled by default.
+[Install]
+WantedBy=multi-user.target

--- a/systemd/pantalla-portal@.service
+++ b/systemd/pantalla-portal@.service
@@ -18,4 +18,5 @@ ExecStart=/opt/pantalla/bin/pantalla-portal-launch.sh
 Restart=on-failure
 RestartSec=2
 
-# No [Install] section: the unit is optional and disabled by default
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- ensure the portal launcher preserves user identity variables when starting the portal processes
- add installation targets to the portal and legacy kiosk template services so `systemctl enable` succeeds

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68fdeb00352883269107fc31fa5e3535