### PR TITLE
fix: ensure deterministic kiosk startup

### DIFF
--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -4,6 +4,11 @@ set -euo pipefail
 export DISPLAY="${DISPLAY:-:0}"
 export XAUTHORITY="${XAUTHORITY:-${HOME:-/home/dani}/.Xauthority}"
 
+# Fondo negro para evitar flash blanco en el arranque.
+if command -v xsetroot >/dev/null 2>&1; then
+  DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xsetroot -solid black >/dev/null 2>&1 || true
+fi
+
 # El navegador se lanza desde systemd (pantalla-kiosk-chromium@); no iniciar nada aquí.
 
 STATE_DIR=/var/lib/pantalla-reloj/state

--- a/systemd/pantalla-kiosk-chromium@dani.service.d/override.conf
+++ b/systemd/pantalla-kiosk-chromium@dani.service.d/override.conf
@@ -1,0 +1,21 @@
+[Service]
+Environment=
+Environment=DISPLAY=:0
+Environment=XAUTHORITY=/home/dani/.Xauthority
+
+ExecStart=
+ExecStart=/bin/sh -lc "chromium-browser \
+  --class=pantalla-kiosk \
+  --kiosk --start-fullscreen \
+  --app=http://127.0.0.1 \
+  --no-first-run --no-default-browser-check \
+  --disable-translate --disable-infobars \
+  --disable-session-crashed-bubble --noerrdialogs \
+  --disable-features=InfiniteSessionRestore,Translate,HardwareMediaKeyHandling \
+  --hide-scrollbars --overscroll-history-navigation=0 \
+  --password-store=basic \
+  --test-type \
+  --ozone-platform=x11 \
+  --disable-gpu \
+  --disk-cache-dir=/var/lib/pantalla-reloj/cache/chromium \
+  --user-data-dir=/var/lib/pantalla-reloj/state/chromium"

--- a/usr/lib/pantalla-reloj/xorg-launch.sh
+++ b/usr/lib/pantalla-reloj/xorg-launch.sh
@@ -55,24 +55,14 @@ else
 fi
 
 HOME_AUTH="/home/${USER_NAME}/.Xauthority"
-HOME_AUTH_BACKUP="${HOME_AUTH}.bak"
 
-if [ -e "$HOME_AUTH" ] && [ ! -L "$HOME_AUTH" ]; then
-  if [ -e "$HOME_AUTH_BACKUP" ] && [ ! -L "$HOME_AUTH_BACKUP" ]; then
-    log "Sobrescribiendo backup existente ${HOME_AUTH_BACKUP}"
-    rm -f "$HOME_AUTH_BACKUP"
-  fi
-  log "Renombrando ${HOME_AUTH} a ${HOME_AUTH_BACKUP}"
-  mv -f "$HOME_AUTH" "$HOME_AUTH_BACKUP"
+if [ -L "$HOME_AUTH" ]; then
+  log "Eliminando symlink previo ${HOME_AUTH}"
+  rm -f "$HOME_AUTH"
 fi
 
-ln -sfn "$AUTH_FILE" "$HOME_AUTH"
-
-if chown -h "$USER_NAME:$USER_NAME" "$HOME_AUTH" 2>/dev/null; then
-  :
-else
-  log "No se pudo ajustar propietario del symlink ${HOME_AUTH}; continuando"
-fi
+install -d -m 0700 -o "$USER_NAME" -g "$USER_NAME" "/home/${USER_NAME}" >/dev/null 2>&1 || true
+install -m 0600 -o "$USER_NAME" -g "$USER_NAME" "$AUTH_FILE" "$HOME_AUTH"
 
 if (( prepare_only )); then
   exit 0

--- a/usr/local/bin/pantalla-backend-launch
+++ b/usr/local/bin/pantalla-backend-launch
@@ -4,11 +4,12 @@ LOG=/tmp/backend-launch.log
 exec >>"$LOG" 2>&1
 echo "[backend] $(date -Is) start"
 
-APP_DIR="/opt/pantalla-reloj/backend"
-PY="$APP_DIR/.venv/bin/python"
+APP_ROOT="/opt/pantalla-reloj"
+BACKEND_DIR="${APP_ROOT}/backend"
+PY="$BACKEND_DIR/.venv/bin/python"
 
-if [[ ! -d "$APP_DIR" ]]; then
-  echo "[backend] ERROR: APP_DIR no existe: $APP_DIR" >&2
+if [[ ! -d "$BACKEND_DIR" ]]; then
+  echo "[backend] ERROR: BACKEND_DIR no existe: $BACKEND_DIR" >&2
   exit 2
 fi
 
@@ -17,8 +18,8 @@ if [[ ! -x "$PY" ]]; then
   exit 2
 fi
 
-cd "$APP_DIR"
-export PYTHONPATH="$APP_DIR"
+cd "$APP_ROOT"
+export PYTHONPATH="$APP_ROOT"
 
 "$PY" - <<'PYCODE'
 import importlib, sys


### PR DESCRIPTION
## Summary
- ensure the backend launcher sets PYTHONPATH to /opt/pantalla-reloj and runs backend.main
- install a Chromium kiosk override that binds to the user Xauthority file and document deterministic startup steps
- create real ~/.Xauthority files during install, set a black Openbox background, and stop enabling optional services by default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fdf1a7893c8326b4e238fd40d6b2cd