### PR TITLE
Refine public display with non-interactive map and auto-scroll text

### DIFF
--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -36,10 +36,28 @@
     "last_triggered": null
   },
   "ui": {
-    "layout": "full",
-    "side_panel": "right",
-    "show_config": false,
-    "enable_demo": false,
-    "carousel": false
+    "rotation": {
+      "enabled": true,
+      "duration_sec": 10,
+      "panels": ["news", "ephemerides", "moon", "forecast", "calendar"]
+    },
+    "fixed": {
+      "clock": { "format": "HH:mm" },
+      "temperature": { "unit": "C" }
+    },
+    "map": {
+      "provider": "osm",
+      "center": [0, 0],
+      "zoom": 2,
+      "interactive": false,
+      "controls": false
+    },
+    "text": {
+      "scroll": {
+        "news": { "enabled": true, "direction": "left", "speed": "normal", "gap_px": 48 },
+        "ephemerides": { "enabled": true, "direction": "up", "speed": "slow", "gap_px": 24 },
+        "forecast": { "enabled": true, "direction": "up", "speed": "slow", "gap_px": 24 }
+      }
+    }
   }
 }

--- a/dash-ui/package-lock.json
+++ b/dash-ui/package-lock.json
@@ -1,0 +1,1730 @@
+{
+  "name": "pantalla-reloj-ui",
+  "version": "2025.10.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pantalla-reloj-ui",
+      "version": "2025.10.0",
+      "dependencies": {
+        "dayjs": "^1.11.10",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.22.3"
+      },
+      "devDependencies": {
+        "@types/react": "^18.2.48",
+        "@types/react-dom": "^18.2.18",
+        "@vitejs/plugin-react": "^4.2.1",
+        "typescript": "^5.4.5",
+        "vite": "^5.2.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
+      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
+      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.5",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.5",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
+      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.5",
+        "@babel/types": "^7.28.5",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.5",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.5",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.5",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.26",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
+      "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
+      "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
+      "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.19",
+        "caniuse-lite": "^1.0.30001751",
+        "electron-to-chromium": "^1.5.238",
+        "node-releases": "^2.0.26",
+        "update-browserslist-db": "^1.1.4"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.18",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.240",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.240.tgz",
+      "integrity": "sha512-OBwbZjWgrCOH+g6uJsA2/7Twpas2OlepS9uvByJjR2datRDuKGYeD+nP8lBBks2qnB7bGJNHDUx7c/YLaT3QMQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.26.tgz",
+      "integrity": "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
+      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/dash-ui/src/components/AutoScrollText.tsx
+++ b/dash-ui/src/components/AutoScrollText.tsx
@@ -1,0 +1,149 @@
+import React, {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+
+import type { UIScrollSpeed } from "../types/config";
+
+export type AutoScrollTextProps = {
+  content: string;
+  direction?: "left" | "up";
+  speed?: UIScrollSpeed;
+  gap?: number;
+  enabled?: boolean;
+  className?: string;
+  ariaLabel?: string;
+};
+
+const SPEED_MAP: Record<"slow" | "normal" | "fast", number> = {
+  slow: 45,
+  normal: 80,
+  fast: 120
+};
+
+const clampSpeed = (speed?: UIScrollSpeed): number => {
+  if (speed === undefined || speed === null) {
+    return SPEED_MAP.normal;
+  }
+  if (typeof speed === "number" && Number.isFinite(speed) && speed > 0) {
+    return speed;
+  }
+  if (typeof speed === "string") {
+    if (speed in SPEED_MAP) {
+      return SPEED_MAP[speed as keyof typeof SPEED_MAP];
+    }
+    const parsed = Number(speed);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return SPEED_MAP.normal;
+};
+
+export const AutoScrollText: React.FC<AutoScrollTextProps> = ({
+  content,
+  direction = "left",
+  speed = "normal",
+  gap = 48,
+  enabled = true,
+  className,
+  ariaLabel
+}) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [shouldScroll, setShouldScroll] = useState(false);
+  const [duration, setDuration] = useState(0);
+
+  const resolvedSpeed = useMemo(() => clampSpeed(speed), [speed]);
+  const sanitizedGap = Number.isFinite(Number(gap)) ? Math.max(Number(gap), 0) : 48;
+
+  const measure = useCallback(() => {
+    if (!enabled) {
+      setShouldScroll(false);
+      setDuration(0);
+      return;
+    }
+    const container = containerRef.current;
+    const inner = contentRef.current;
+    if (!container || !inner) {
+      return;
+    }
+    const containerSize = direction === "left" ? container.offsetWidth : container.offsetHeight;
+    const contentSize = direction === "left" ? inner.scrollWidth : inner.scrollHeight;
+
+    if (!containerSize || contentSize <= containerSize + 1) {
+      setShouldScroll(false);
+      setDuration(0);
+      return;
+    }
+
+    const calculatedDuration = contentSize / Math.max(resolvedSpeed, 1);
+    setShouldScroll(true);
+    setDuration(calculatedDuration);
+  }, [direction, enabled, resolvedSpeed]);
+
+  useLayoutEffect(() => {
+    measure();
+  }, [measure, content, direction, resolvedSpeed, sanitizedGap]);
+
+  useEffect(() => {
+    if (typeof ResizeObserver === "undefined") {
+      window.addEventListener("resize", measure);
+      return () => window.removeEventListener("resize", measure);
+    }
+    const observer = new ResizeObserver(() => measure());
+    const container = containerRef.current;
+    const inner = contentRef.current;
+    if (container) {
+      observer.observe(container);
+    }
+    if (inner) {
+      observer.observe(inner);
+    }
+    return () => observer.disconnect();
+  }, [measure]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setShouldScroll(false);
+      setDuration(0);
+    }
+  }, [enabled]);
+
+  const classes = useMemo(() => {
+    const base = direction === "left" ? "ticker" : "vscroll";
+    return [base, "auto-scroll", className].filter(Boolean).join(" ");
+  }, [className, direction]);
+
+  const isActive = enabled && shouldScroll;
+  const animationDuration = isActive ? Math.max(duration, 0.5) : 0;
+
+  const containerStyle = useMemo<CSSProperties>(() => {
+    return { "--ticker-gap": `${sanitizedGap}px` } as CSSProperties;
+  }, [sanitizedGap]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={classes}
+      data-scroll-active={isActive ? "true" : "false"}
+      style={containerStyle}
+      aria-label={ariaLabel}
+    >
+      <div
+        className={direction === "left" ? "ticker__track" : "vscroll__track"}
+        style={isActive ? { animationDuration: `${animationDuration}s` } : {}}
+      >
+        <div className="auto-scroll__segment" ref={contentRef} dangerouslySetInnerHTML={{ __html: content }} />
+        {isActive && (
+          <div className="auto-scroll__segment auto-scroll__segment--clone" aria-hidden="true" dangerouslySetInnerHTML={{ __html: content }} />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/dash-ui/src/components/ClockDisplay.tsx
+++ b/dash-ui/src/components/ClockDisplay.tsx
@@ -1,0 +1,33 @@
+import dayjs from "dayjs";
+import "dayjs/locale/es";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+import React, { useEffect, useState } from "react";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.locale("es");
+
+type ClockDisplayProps = {
+  timezone: string;
+  format: string;
+};
+
+export const ClockDisplay: React.FC<ClockDisplayProps> = ({ timezone, format }) => {
+  const [now, setNow] = useState(() => dayjs().tz(timezone));
+
+  useEffect(() => {
+    setNow(dayjs().tz(timezone));
+    const timer = window.setInterval(() => {
+      setNow(dayjs().tz(timezone));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [timezone]);
+
+  return (
+    <div className="public-clock" aria-live="polite">
+      <div className="public-clock__time">{now.format(format)}</div>
+      <div className="public-clock__date">{now.format("dddd, D [de] MMMM YYYY")}</div>
+    </div>
+  );
+};

--- a/dash-ui/src/components/RotatingCard.tsx
+++ b/dash-ui/src/components/RotatingCard.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import type { UIScrollSpeed } from "../types/config";
+
+import { AutoScrollText } from "./AutoScrollText";
+
+export type RotatingPanel = {
+  id: string;
+  title: string;
+  content: string;
+  direction: "left" | "up";
+  enableScroll: boolean;
+  speed: UIScrollSpeed;
+  gap: number;
+};
+
+export type RotatingCardProps = {
+  panels: RotatingPanel[];
+  rotationEnabled: boolean;
+  durationSeconds: number;
+};
+
+const MIN_DURATION = 4;
+
+export const RotatingCard: React.FC<RotatingCardProps> = ({ panels, rotationEnabled, durationSeconds }) => {
+  const safePanels = useMemo<RotatingPanel[]>(() => {
+    if (panels.length > 0) {
+      return panels;
+    }
+    return [
+      {
+        id: "placeholder",
+        title: "Panel informativo",
+        content: "Sin contenido disponible",
+        direction: "left",
+        enableScroll: false,
+        speed: "normal",
+        gap: 48
+      }
+    ];
+  }, [panels]);
+
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [safePanels]);
+
+  useEffect(() => {
+    if (!rotationEnabled || safePanels.length <= 1) {
+      return undefined;
+    }
+    const interval = window.setInterval(() => {
+      setActiveIndex((index) => (index + 1) % safePanels.length);
+    }, Math.max(durationSeconds, MIN_DURATION) * 1000);
+    return () => window.clearInterval(interval);
+  }, [rotationEnabled, durationSeconds, safePanels.length]);
+
+  return (
+    <div className="rotating-card" role="region" aria-live="polite">
+      {safePanels.map((panel, index) => {
+        const isActive = index === activeIndex;
+        return (
+          <article
+            key={`${panel.id}-${index}`}
+            className={`rotating-card__panel${isActive ? " is-active" : ""}`}
+            aria-hidden={isActive ? undefined : true}
+          >
+            <header className="rotating-card__header">
+              <h2>{panel.title}</h2>
+            </header>
+            <div className="rotating-card__body">
+              <AutoScrollText
+                content={panel.content}
+                direction={panel.direction}
+                enabled={panel.enableScroll}
+                speed={panel.speed}
+                gap={panel.gap}
+              />
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+};

--- a/dash-ui/src/components/WorldMap.tsx
+++ b/dash-ui/src/components/WorldMap.tsx
@@ -1,0 +1,165 @@
+import React, { useEffect, useRef } from "react";
+
+type LeafletMap = {
+  setView: (center: [number, number], zoom: number) => LeafletMap;
+  remove: () => void;
+  invalidateSize: () => LeafletMap;
+};
+
+type LeafletTileLayer = {
+  addTo: (map: LeafletMap) => LeafletTileLayer;
+  remove: () => void;
+  setUrl: (url: string) => LeafletTileLayer;
+};
+
+type LeafletModule = {
+  map: (container: HTMLDivElement, options: Record<string, unknown>) => LeafletMap;
+  tileLayer: (url: string, options?: Record<string, unknown>) => LeafletTileLayer;
+};
+
+type WorldMapProps = {
+  center: [number, number];
+  zoom: number;
+  provider?: string;
+  className?: string;
+};
+
+const TILE_PROVIDERS: Record<string, string> = {
+  osm: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+};
+
+const DEFAULT_PROVIDER = "osm";
+const LEAFLET_SCRIPT = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js";
+const LEAFLET_STYLES = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css";
+
+let leafletPromise: Promise<LeafletModule> | null = null;
+
+const ensureLeaflet = (): Promise<LeafletModule> => {
+  if (leafletPromise) {
+    return leafletPromise;
+  }
+  leafletPromise = new Promise((resolve, reject) => {
+    if (typeof window === "undefined") {
+      reject(new Error("Leaflet requires a browser environment"));
+      return;
+    }
+
+    const existing = (window as unknown as { L?: LeafletModule }).L;
+    if (existing) {
+      resolve(existing);
+      return;
+    }
+
+    if (!document.querySelector("link[data-leaflet]")) {
+      const link = document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = LEAFLET_STYLES;
+      link.setAttribute("data-leaflet", "true");
+      document.head.appendChild(link);
+    }
+
+    const script = document.createElement("script");
+    script.src = LEAFLET_SCRIPT;
+    script.async = true;
+    script.onload = () => {
+      const globalLeaflet = (window as unknown as { L?: LeafletModule }).L;
+      if (globalLeaflet) {
+        resolve(globalLeaflet);
+      } else {
+        reject(new Error("Leaflet script loaded but global L is undefined"));
+      }
+    };
+    script.onerror = () => reject(new Error("No se pudo cargar Leaflet"));
+    document.head.appendChild(script);
+  });
+
+  return leafletPromise;
+};
+
+export const WorldMap: React.FC<WorldMapProps> = ({ center, zoom, provider = DEFAULT_PROVIDER, className }) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
+  const layerRef = useRef<LeafletTileLayer | null>(null);
+  const moduleRef = useRef<LeafletModule | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const mount = async () => {
+      try {
+        const leaflet = await ensureLeaflet();
+        if (cancelled || mapRef.current || !containerRef.current) {
+          return;
+        }
+        moduleRef.current = leaflet;
+        const map = leaflet.map(containerRef.current, {
+          zoomControl: false,
+          dragging: false,
+          scrollWheelZoom: false,
+          doubleClickZoom: false,
+          touchZoom: false,
+          boxZoom: false,
+          keyboard: false,
+          attributionControl: false
+        });
+        mapRef.current = map;
+
+        const tileUrl = TILE_PROVIDERS[provider] ?? TILE_PROVIDERS[DEFAULT_PROVIDER];
+        const layer = leaflet.tileLayer(tileUrl, {
+          minZoom: 1,
+          maxZoom: 18,
+          detectRetina: true,
+          crossOrigin: true
+        });
+        layer.addTo(map);
+        layerRef.current = layer;
+
+        map.setView(center, zoom);
+        window.setTimeout(() => map.invalidateSize(), 0);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    void mount();
+
+    return () => {
+      cancelled = true;
+      layerRef.current?.remove();
+      layerRef.current = null;
+      mapRef.current?.remove();
+      mapRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) {
+      return;
+    }
+    map.setView(center, zoom);
+  }, [center, zoom]);
+
+  useEffect(() => {
+    const leaflet = moduleRef.current;
+    const map = mapRef.current;
+    if (!leaflet || !map) {
+      return;
+    }
+    const tileUrl = TILE_PROVIDERS[provider] ?? TILE_PROVIDERS[DEFAULT_PROVIDER];
+    if (!layerRef.current) {
+      const layer = leaflet.tileLayer(tileUrl, {
+        minZoom: 1,
+        maxZoom: 18,
+        detectRetina: true,
+        crossOrigin: true
+      });
+      layer.addTo(map);
+      layerRef.current = layer;
+      return;
+    }
+    layerRef.current.setUrl(tileUrl);
+  }, [provider]);
+
+  return <div ref={containerRef} className={`map-container${className ? ` ${className}` : ""}`} />;
+};

--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -1,26 +1,10 @@
-import type { AppConfig, DisplayModule, UISettings } from "../types/config";
-
-const parseBoolean = (value: string | undefined, fallback: boolean): boolean => {
-  if (value === undefined) {
-    return fallback;
-  }
-  const normalized = value.trim().toLowerCase();
-  if (["1", "true", "yes", "on"].includes(normalized)) {
-    return true;
-  }
-  if (["0", "false", "no", "off", ""].includes(normalized)) {
-    return false;
-  }
-  return fallback;
-};
-
-const layoutFromEnv = (value: string | undefined): UISettings["layout"] => {
-  return value === "widgets" ? "widgets" : "full";
-};
-
-const sidePanelFromEnv = (value: string | undefined): UISettings["side_panel"] => {
-  return value === "left" ? "left" : "right";
-};
+import type {
+  AppConfig,
+  DisplayModule,
+  UISettings,
+  UIScrollSettings,
+  UIScrollSpeed,
+} from "../types/config";
 
 const createDefaultModules = (): DisplayModule[] => [
   { name: "clock", enabled: true, duration_seconds: 20 },
@@ -31,12 +15,32 @@ const createDefaultModules = (): DisplayModule[] => [
   { name: "calendar", enabled: true, duration_seconds: 20 }
 ];
 
+const createScrollDefaults = (): Record<string, UIScrollSettings> => ({
+  news: { enabled: true, direction: "left", speed: "normal", gap_px: 48 },
+  ephemerides: { enabled: true, direction: "up", speed: "slow", gap_px: 24 },
+  forecast: { enabled: true, direction: "up", speed: "slow", gap_px: 24 }
+});
+
 export const UI_DEFAULTS: UISettings = {
-  layout: layoutFromEnv(import.meta.env.VITE_DEFAULT_LAYOUT),
-  side_panel: sidePanelFromEnv(import.meta.env.VITE_SIDE_PANEL),
-  show_config: parseBoolean(import.meta.env.VITE_SHOW_CONFIG, false),
-  enable_demo: parseBoolean(import.meta.env.VITE_ENABLE_DEMO, false),
-  carousel: parseBoolean(import.meta.env.VITE_CAROUSEL, false)
+  rotation: {
+    enabled: true,
+    duration_sec: 10,
+    panels: ["news", "ephemerides", "moon", "forecast", "calendar"]
+  },
+  fixed: {
+    clock: { format: "HH:mm" },
+    temperature: { unit: "C" }
+  },
+  map: {
+    provider: "osm",
+    center: [0, 0],
+    zoom: 2,
+    interactive: false,
+    controls: false
+  },
+  text: {
+    scroll: createScrollDefaults()
+  }
 };
 
 export const DEFAULT_CONFIG: AppConfig = {
@@ -79,6 +83,39 @@ export const withConfigDefaults = (payload?: Partial<AppConfig>): AppConfig => {
 
   const displayModules = payload.display?.modules ?? DEFAULT_CONFIG.display.modules;
 
+  const mergeScroll = (scroll?: UISettings["text"]["scroll"]): UISettings["text"] => {
+    const defaults = createScrollDefaults();
+    if (!scroll) {
+      return { scroll: defaults };
+    }
+    const result: Record<string, UIScrollSettings> = { ...defaults };
+    for (const [key, value] of Object.entries(scroll)) {
+      result[key] = { ...defaults[key], ...value };
+    }
+    return { scroll: result };
+  };
+
+  const mergeSpeed = (speed: UIScrollSpeed | undefined): UIScrollSpeed => {
+    if (speed === undefined || speed === null) {
+      return "normal";
+    }
+    if (typeof speed === "string" && ["slow", "normal", "fast"].includes(speed)) {
+      return speed;
+    }
+    if (Number.isFinite(Number(speed))) {
+      return Number(speed);
+    }
+    return "normal";
+  };
+
+  const mergedScroll = mergeScroll(payload.ui?.text?.scroll);
+  for (const [key, value] of Object.entries(mergedScroll.scroll)) {
+    value.speed = mergeSpeed(value.speed);
+    const gap = Number(value.gap_px);
+    const fallback = createScrollDefaults()[key]?.gap_px ?? 48;
+    value.gap_px = Number.isFinite(gap) && gap >= 0 ? gap : fallback;
+  }
+
   return {
     display: {
       ...DEFAULT_CONFIG.display,
@@ -102,8 +139,30 @@ export const withConfigDefaults = (payload?: Partial<AppConfig>): AppConfig => {
       ...payload.storm_mode
     },
     ui: {
-      ...UI_DEFAULTS,
-      ...(payload.ui ?? {})
+      rotation: {
+        ...UI_DEFAULTS.rotation,
+        ...(payload.ui?.rotation ?? {})
+      },
+      fixed: {
+        clock: {
+          ...UI_DEFAULTS.fixed.clock,
+          ...(payload.ui?.fixed?.clock ?? {})
+        },
+        temperature: {
+          ...UI_DEFAULTS.fixed.temperature,
+          ...(payload.ui?.fixed?.temperature ?? {})
+        }
+      },
+      map: {
+        ...UI_DEFAULTS.map,
+        ...(payload.ui?.map ?? {})
+      },
+      text: mergedScroll,
+      layout: payload.ui?.layout,
+      side_panel: payload.ui?.side_panel,
+      show_config: payload.ui?.show_config,
+      enable_demo: payload.ui?.enable_demo,
+      carousel: payload.ui?.carousel
     }
   };
 };

--- a/dash-ui/src/pages/ConfigPage.tsx
+++ b/dash-ui/src/pages/ConfigPage.tsx
@@ -1,29 +1,47 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { UI_DEFAULTS } from "../config/defaults";
 import { useConfig } from "../context/ConfigContext";
-import type { AppConfig, UISettings } from "../types/config";
-
-const rotationOptions = [
-  { value: "left", label: "Izquierda" },
-  { value: "normal", label: "Normal" },
-  { value: "right", label: "Derecha" }
-];
-
-const layoutOptions = [
-  { value: "full", label: "Panel completo" },
-  { value: "widgets", label: "Rotación de módulos" }
-];
-
-const sidePanelOptions = [
-  { value: "left", label: "Izquierda" },
-  { value: "right", label: "Derecha" }
-];
+import type { AppConfig, UIScrollSettings } from "../types/config";
 
 const booleanOptions = [
   { value: "true", label: "Sí" },
   { value: "false", label: "No" }
 ];
+
+const directionOptions = [
+  { value: "left", label: "Horizontal" },
+  { value: "up", label: "Vertical" }
+];
+
+const speedPlaceholders = "slow / normal / fast o px/s";
+
+const defaultScroll = (panel: string): UIScrollSettings => {
+  return UI_DEFAULTS.text.scroll[panel] ?? { enabled: true, direction: "left", speed: "normal", gap_px: 48 };
+};
+
+const parseSpeedInput = (value: string, current: UIScrollSettings["speed"]): UIScrollSettings["speed"] => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return current;
+  }
+  if (["slow", "normal", "fast"].includes(trimmed)) {
+    return trimmed as UIScrollSettings["speed"];
+  }
+  const numeric = Number(trimmed);
+  if (Number.isFinite(numeric) && numeric > 0) {
+    return numeric;
+  }
+  return current;
+};
+
+const parsePanelsInput = (value: string): string[] => {
+  return value
+    .split(/[\n,]+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+};
 
 export type ConfigFormProps = {
   mode: "page" | "overlay";
@@ -43,6 +61,30 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
   const update = useCallback(<K extends keyof AppConfig>(section: K, value: AppConfig[K]) => {
     setForm((prev) => ({ ...prev, [section]: value }));
   }, []);
+
+  const scrollPanels = useMemo(() => {
+    const keys = new Set<string>([...Object.keys(UI_DEFAULTS.text.scroll), ...Object.keys(form.ui.text.scroll)]);
+    return Array.from(keys);
+  }, [form.ui.text.scroll]);
+
+  const rotationEnabled = form.ui.rotation.enabled;
+
+  const handleScrollChange = useCallback(
+    (panel: string, partial: Partial<UIScrollSettings>) => {
+      const current = form.ui.text.scroll[panel] ?? defaultScroll(panel);
+      update("ui", {
+        ...form.ui,
+        text: {
+          ...form.ui.text,
+          scroll: {
+            ...form.ui.text.scroll,
+            [panel]: { ...current, ...partial }
+          }
+        }
+      });
+    },
+    [form.ui, update]
+  );
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -69,21 +111,19 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
       <div>
         <h1>Configuración de Pantalla</h1>
         <p style={{ color: "rgba(173,203,239,0.7)" }}>
-          Ajusta la rotación, el diseño del panel y la conectividad de la pantalla de información.
+          Ajusta la rotación pública, el mapa, el scroll de texto y la conectividad del dispositivo.
         </p>
       </div>
       <form id="config-form" className="config-form" onSubmit={handleSubmit}>
         <label>
-          Rotación
+          Rotación de módulos (legacy)
           <select
             value={form.display.rotation}
             onChange={(event) => update("display", { ...form.display, rotation: event.target.value })}
           >
-            {rotationOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
+            <option value="left">Izquierda</option>
+            <option value="normal">Normal</option>
+            <option value="right">Derecha</option>
           </select>
         </label>
         <label>
@@ -95,7 +135,7 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
           />
         </label>
         <label>
-          Segundos por módulo
+          Segundos por módulo (legacy)
           <input
             type="number"
             min={5}
@@ -106,28 +146,20 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
             }
           />
         </label>
+
+        <h2>Rotación de tarjeta</h2>
         <label>
-          Diseño predeterminado
+          Rotación habilitada
           <select
-            value={form.ui.layout}
-            onChange={(event) => update("ui", { ...form.ui, layout: event.target.value as UISettings["layout"] })}
-          >
-            {layoutOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          Panel lateral
-          <select
-            value={form.ui.side_panel}
+            value={rotationEnabled ? "true" : "false"}
             onChange={(event) =>
-              update("ui", { ...form.ui, side_panel: event.target.value as UISettings["side_panel"] })
+              update("ui", {
+                ...form.ui,
+                rotation: { ...form.ui.rotation, enabled: event.target.value === "true" }
+              })
             }
           >
-            {sidePanelOptions.map((option) => (
+            {booleanOptions.map((option) => (
               <option key={option.value} value={option.value}>
                 {option.label}
               </option>
@@ -135,10 +167,89 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
           </select>
         </label>
         <label>
-          Mostrar overlay en dashboard
+          Duración por panel (segundos)
+          <input
+            type="number"
+            min={3}
+            max={3600}
+            value={form.ui.rotation.duration_sec}
+            onChange={(event) =>
+              update("ui", {
+                ...form.ui,
+                rotation: { ...form.ui.rotation, duration_sec: Number(event.target.value) }
+              })
+            }
+          />
+        </label>
+        <label>
+          Paneles en rotación (uno por línea)
+          <textarea
+            rows={5}
+            value={form.ui.rotation.panels.join("\n")}
+            onChange={(event) =>
+              update("ui", {
+                ...form.ui,
+                rotation: { ...form.ui.rotation, panels: parsePanelsInput(event.target.value) }
+              })
+            }
+          />
+        </label>
+
+        <h2>Mapa mundial</h2>
+        <label>
+          Proveedor de mapas
+          <input
+            type="text"
+            value={form.ui.map.provider}
+            onChange={(event) => update("ui", { ...form.ui, map: { ...form.ui.map, provider: event.target.value } })}
+          />
+        </label>
+        <label>
+          Centro (latitud)
+          <input
+            type="number"
+            value={form.ui.map.center[0]}
+            onChange={(event) =>
+              update("ui", {
+                ...form.ui,
+                map: { ...form.ui.map, center: [Number(event.target.value), form.ui.map.center[1]] }
+              })
+            }
+          />
+        </label>
+        <label>
+          Centro (longitud)
+          <input
+            type="number"
+            value={form.ui.map.center[1]}
+            onChange={(event) =>
+              update("ui", {
+                ...form.ui,
+                map: { ...form.ui.map, center: [form.ui.map.center[0], Number(event.target.value)] }
+              })
+            }
+          />
+        </label>
+        <label>
+          Zoom
+          <input
+            type="number"
+            min={0}
+            max={18}
+            value={form.ui.map.zoom}
+            onChange={(event) => update("ui", { ...form.ui, map: { ...form.ui.map, zoom: Number(event.target.value) } })}
+          />
+        </label>
+        <label>
+          Permitir interacción
           <select
-            value={form.ui.show_config ? "true" : "false"}
-            onChange={(event) => update("ui", { ...form.ui, show_config: event.target.value === "true" })}
+            value={form.ui.map.interactive ? "true" : "false"}
+            onChange={(event) =>
+              update("ui", {
+                ...form.ui,
+                map: { ...form.ui.map, interactive: event.target.value === "true" }
+              })
+            }
           >
             {booleanOptions.map((option) => (
               <option key={option.value} value={option.value}>
@@ -148,10 +259,15 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
           </select>
         </label>
         <label>
-          Activar modo demo
+          Mostrar controles
           <select
-            value={form.ui.enable_demo ? "true" : "false"}
-            onChange={(event) => update("ui", { ...form.ui, enable_demo: event.target.value === "true" })}
+            value={form.ui.map.controls ? "true" : "false"}
+            onChange={(event) =>
+              update("ui", {
+                ...form.ui,
+                map: { ...form.ui.map, controls: event.target.value === "true" }
+              })
+            }
           >
             {booleanOptions.map((option) => (
               <option key={option.value} value={option.value}>
@@ -159,20 +275,107 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
               </option>
             ))}
           </select>
+        </label>
+
+        <h2>Formato de reloj y temperatura</h2>
+        <label>
+          Formato de hora
+          <input
+            type="text"
+            value={form.ui.fixed.clock.format}
+            onChange={(event) =>
+              update("ui", {
+                ...form.ui,
+                fixed: {
+                  ...form.ui.fixed,
+                  clock: { ...form.ui.fixed.clock, format: event.target.value }
+                }
+              })
+            }
+          />
         </label>
         <label>
-          Rotar módulos (carousel)
-          <select
-            value={form.ui.carousel ? "true" : "false"}
-            onChange={(event) => update("ui", { ...form.ui, carousel: event.target.value === "true" })}
-          >
-            {booleanOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          Unidad de temperatura (C/F/K)
+          <input
+            type="text"
+            value={form.ui.fixed.temperature.unit}
+            onChange={(event) =>
+              update("ui", {
+                ...form.ui,
+                fixed: {
+                  ...form.ui.fixed,
+                  temperature: { ...form.ui.fixed.temperature, unit: event.target.value }
+                }
+              })
+            }
+          />
         </label>
+
+        <h2>Scroll automático por panel</h2>
+        {scrollPanels.map((panel) => {
+          const current = form.ui.text.scroll[panel] ?? defaultScroll(panel);
+          const speedValue = typeof current.speed === "number" ? String(current.speed) : current.speed;
+          return (
+            <fieldset key={panel} style={{ border: "1px solid rgba(173,203,239,0.25)", borderRadius: "12px", padding: "12px 16px" }}>
+              <legend style={{ padding: "0 8px", fontSize: "0.95rem" }}>{panel}</legend>
+              <label>
+                Activar scroll
+                <select
+                  value={current.enabled ? "true" : "false"}
+                  onChange={(event) =>
+                    handleScrollChange(panel, { enabled: event.target.value === "true" })
+                  }
+                >
+                  {booleanOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Dirección
+                <select
+                  value={current.direction}
+                  onChange={(event) => handleScrollChange(panel, { direction: event.target.value as "left" | "up" })}
+                >
+                  {directionOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Velocidad ({speedPlaceholders})
+                <input
+                  type="text"
+                  value={speedValue}
+                  onChange={(event) =>
+                    handleScrollChange(panel, { speed: parseSpeedInput(event.target.value, current.speed) })
+                  }
+                  list={`speed-${panel}`}
+                />
+                <datalist id={`speed-${panel}`}>
+                  <option value="slow" />
+                  <option value="normal" />
+                  <option value="fast" />
+                </datalist>
+              </label>
+              <label>
+                Gap (px)
+                <input
+                  type="number"
+                  min={0}
+                  value={current.gap_px}
+                  onChange={(event) => handleScrollChange(panel, { gap_px: Number(event.target.value) })}
+                />
+              </label>
+            </fieldset>
+          );
+        })}
+
+        <h2>Claves API</h2>
         <label>
           API Clima
           <input
@@ -205,6 +408,8 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
             onChange={(event) => update("api_keys", { ...form.api_keys, calendar: event.target.value })}
           />
         </label>
+
+        <h2>MQTT</h2>
         <label>
           MQTT Activo
           <select
@@ -258,6 +463,8 @@ export const ConfigForm: React.FC<ConfigFormProps> = ({ mode, onClose }) => {
             onChange={(event) => update("mqtt", { ...form.mqtt, password: event.target.value })}
           />
         </label>
+
+        <h2>Wi-Fi</h2>
         <label>
           Wi-Fi Interfaz
           <input

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -1,404 +1,286 @@
+* {
+  box-sizing: border-box;
+}
+
 :root {
   color-scheme: dark;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #050607;
+  background-color: #04070c;
   color: #f5f8ff;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top left, rgba(15, 75, 140, 0.35), transparent 65%),
-    linear-gradient(120deg, rgba(6, 18, 30, 0.95), rgba(5, 5, 8, 0.98));
+  background:
+    radial-gradient(circle at top left, rgba(18, 96, 163, 0.35), transparent 62%),
+    linear-gradient(125deg, rgba(7, 15, 27, 0.96), rgba(3, 7, 12, 0.98));
+  color: inherit;
   overflow: hidden;
 }
 
 #root {
-  height: 100vh;
   width: 100vw;
+  height: 100vh;
   display: flex;
 }
 
-.dashboard-layout {
+.public-dashboard {
   display: grid;
-  grid-template-columns: 1fr 420px;
+  grid-template-columns: minmax(0, 3fr) minmax(320px, 2fr);
+  gap: 40px;
   width: 100%;
   height: 100%;
-  position: relative;
-}
-
-.dashboard-layout.side-left {
-  grid-template-columns: 420px 1fr;
-}
-
-.dashboard-layout.side-left .dashboard-panel {
-  border-left: none;
-  border-right: 1px solid rgba(69, 124, 181, 0.28);
-  box-shadow: 8px 0 24px rgba(0, 0, 0, 0.35);
-}
-
-.dashboard-layout.side-left .dashboard-main {
-  order: 2;
-}
-
-.dashboard-layout.side-left .dashboard-panel {
-  order: 1;
-}
-
-.dashboard-main {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 48px;
-  position: relative;
-}
-
-.dashboard-panel {
-  backdrop-filter: blur(22px);
-  background: rgba(9, 16, 26, 0.68);
-  border-left: 1px solid rgba(69, 124, 181, 0.28);
-  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.35);
-  padding: 32px;
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.panel-summary {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.panel-summary__title {
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: rgba(173, 203, 239, 0.7);
-  font-size: 0.75rem;
-}
-
-.panel-summary__value {
-  font-size: 1.6rem;
-  font-weight: 600;
-}
-
-.panel-summary__meta {
-  color: rgba(173, 203, 239, 0.6);
-  font-size: 0.9rem;
-}
-
-.panel-cards {
-  display: grid;
-  gap: 14px;
-}
-
-.panel-card {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 12px 16px;
-  border-radius: 16px;
-  background: rgba(22, 42, 60, 0.35);
-  border: 1px solid rgba(77, 128, 184, 0.18);
-}
-
-.panel-card__label {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: rgba(173, 203, 239, 0.6);
-}
-
-.panel-card__value {
-  font-size: 1.4rem;
-  font-weight: 600;
-}
-
-.news-item {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 12px 16px;
-  border-radius: 16px;
-  background: rgba(22, 42, 60, 0.35);
-  border: 1px solid rgba(77, 128, 184, 0.18);
-}
-
-.module-wrapper {
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  height: 100%;
-  color: #e9f2ff;
-}
-
-.module-wrapper h2 {
-  text-transform: uppercase;
-  letter-spacing: 0.28rem;
-  font-size: 0.85rem;
-  color: rgba(173, 203, 239, 0.7);
-  margin-bottom: 12px;
-}
-
-.module-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 18px;
-}
-
-.clock-display {
-  font-size: clamp(72px, 10vw, 140px);
-  font-weight: 600;
-  letter-spacing: 0.06em;
-}
-
-.clock-date {
-  font-size: 1.6rem;
-  color: rgba(231, 240, 255, 0.78);
-}
-
-
-.full-dashboard {
-  display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
-  gap: 24px;
-  width: 100%;
-  height: 100%;
-}
-
-.full-dashboard__map {
-  position: relative;
-  border-radius: 28px;
-  overflow: hidden;
-  background: linear-gradient(160deg, rgba(20, 34, 52, 0.85), rgba(8, 13, 20, 0.95));
-  min-height: 100%;
-}
-
-.full-dashboard__map iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
-}
-
-.full-dashboard__map-overlay {
-  position: absolute;
-  left: 24px;
-  bottom: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 16px 20px;
-  border-radius: 18px;
-  background: rgba(5, 10, 18, 0.65);
-  border: 1px solid rgba(77, 128, 184, 0.35);
-}
-
-.full-dashboard__map-location {
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  font-size: 0.8rem;
-  color: rgba(173, 203, 239, 0.7);
-}
-
-.full-dashboard__map-temp {
-  font-size: 2.8rem;
-  font-weight: 600;
-}
-
-.full-dashboard__map-condition {
-  color: rgba(231, 240, 255, 0.78);
-}
-
-.full-dashboard__cards {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 18px;
-}
-
-.full-dashboard__card {
-  padding: 18px 20px;
-  border-radius: 20px;
-  background: rgba(15, 30, 48, 0.55);
-  border: 1px solid rgba(77, 128, 184, 0.22);
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.full-dashboard__card h3 {
-  margin: 0;
-  font-size: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: rgba(173, 203, 239, 0.7);
-}
-
-.full-dashboard__card p {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.full-dashboard__card small {
-  color: rgba(173, 203, 239, 0.6);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.config-wrapper {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  padding: 40px 56px;
-  box-sizing: border-box;
-  overflow-y: auto;
-}
-
-.config-wrapper h1 {
-  font-size: 2rem;
-  margin: 0;
-}
-
-.config-form {
-  display: grid;
-  gap: 18px;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-}
-
-.config-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  font-size: 0.95rem;
-  color: rgba(173, 203, 239, 0.7);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-}
-
-.config-form input,
-.config-form select {
-  background: rgba(12, 22, 35, 0.8);
-  border: 1px solid rgba(77, 128, 184, 0.35);
-  border-radius: 10px;
-  padding: 12px 14px;
-  color: #f5f8ff;
-  font-size: 1rem;
-}
-
-.config-actions {
-  display: flex;
-  gap: 12px;
-  margin-top: 24px;
-}
-
-.config-wrapper--overlay {
-  height: auto;
-  max-height: calc(90vh - 96px);
-  padding: 32px 40px;
-  overflow-y: auto;
-}
-
-button.primary {
-  background: linear-gradient(120deg, #2d7be4, #35b4f5);
-  border: none;
-  border-radius: 999px;
-  padding: 12px 26px;
-  font-size: 1rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  color: #fff;
-  cursor: pointer;
-  box-shadow: 0 12px 24px rgba(45, 123, 228, 0.25);
-}
-
-button.secondary {
-  background: transparent;
-  border: 1px solid rgba(77, 128, 184, 0.35);
-  border-radius: 999px;
-  padding: 12px 26px;
-  font-size: 1rem;
-  font-weight: 500;
-  letter-spacing: 0.05em;
-  color: rgba(209, 226, 255, 0.75);
-  cursor: pointer;
-}
-
-.module-tabs {
-  display: flex;
-  gap: 14px;
-}
-
-.module-tab {
-  padding: 10px 18px;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  background: rgba(33, 59, 85, 0.45);
-  color: rgba(209, 226, 255, 0.7);
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  font-size: 0.75rem;
-}
-
-.module-tab.active {
-  border-color: rgba(77, 128, 184, 0.8);
-  background: rgba(45, 123, 228, 0.65);
-  color: #fff;
-}
-
-.config-overlay {
-  position: absolute;
-  inset: 0;
-  background: rgba(5, 8, 12, 0.75);
-  backdrop-filter: blur(10px);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 48px;
-  z-index: 20;
-}
-
-.config-overlay__panel {
-  position: relative;
-  width: min(960px, 90vw);
-  max-height: 90vh;
-  background: rgba(9, 16, 26, 0.95);
-  border-radius: 28px;
-  border: 1px solid rgba(77, 128, 184, 0.35);
-  box-shadow: 0 32px 64px rgba(0, 0, 0, 0.45);
-  overflow: hidden;
-}
-
-.config-overlay__close {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  background: transparent;
-  border: none;
-  color: rgba(231, 240, 255, 0.8);
-  font-size: 1.8rem;
-  cursor: pointer;
-}
-
-@media (max-width: 1600px) {
-  .dashboard-layout {
-    grid-template-columns: 1fr 380px;
-  }
+  padding: 48px 56px;
 }
 
 @media (max-width: 1280px) {
-  .dashboard-layout {
+  .public-dashboard {
     grid-template-columns: 1fr;
+    grid-template-rows: minmax(0, 2fr) minmax(0, 1fr);
+    padding: 32px;
   }
+}
 
-  .dashboard-panel {
-    border-left: none;
-    border-top: 1px solid rgba(69, 124, 181, 0.28);
-  }
+.public-dashboard__map {
+  position: relative;
+  border-radius: 36px;
+  overflow: hidden;
+  background: linear-gradient(160deg, rgba(18, 36, 56, 0.8), rgba(6, 12, 20, 0.92));
+  box-shadow: 0 32px 64px rgba(0, 0, 0, 0.35);
+}
 
-  .full-dashboard {
-    grid-template-columns: 1fr;
+.map-container {
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.public-dashboard__map-overlay {
+  position: absolute;
+  left: 32px;
+  bottom: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 20px 24px;
+  border-radius: 22px;
+  background: rgba(4, 9, 16, 0.7);
+  border: 1px solid rgba(86, 142, 205, 0.4);
+  color: #eef5ff;
+  pointer-events: none;
+  backdrop-filter: blur(12px);
+}
+
+.public-dashboard__map-location {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.95rem;
+  color: rgba(223, 238, 255, 0.88);
+}
+
+.public-dashboard__map-temp {
+  font-size: 2.4rem;
+  font-weight: 600;
+}
+
+.public-dashboard__map-condition {
+  font-size: 1.2rem;
+  color: rgba(223, 238, 255, 0.75);
+}
+
+.public-dashboard__map-attribution {
+  position: absolute;
+  right: 24px;
+  bottom: 18px;
+  font-size: 0.75rem;
+  color: rgba(210, 227, 255, 0.55);
+  letter-spacing: 0.08em;
+  pointer-events: none;
+  user-select: none;
+}
+
+.public-dashboard__info {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  justify-content: flex-start;
+  height: 100%;
+}
+
+.public-clock {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.public-clock__time {
+  font-size: clamp(96px, 12vw, 160px);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-shadow: 0 12px 30px rgba(0, 0, 0, 0.32);
+}
+
+.public-clock__date {
+  font-size: 1.6rem;
+  color: rgba(229, 238, 255, 0.8);
+  text-transform: capitalize;
+}
+
+.public-weather {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px 28px;
+  border-radius: 26px;
+  background: rgba(13, 24, 38, 0.82);
+  border: 1px solid rgba(90, 142, 200, 0.36);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+}
+
+.public-weather__temp {
+  font-size: clamp(42px, 6vw, 68px);
+  font-weight: 600;
+}
+
+.public-weather__condition {
+  font-size: 1.4rem;
+  color: rgba(224, 235, 255, 0.78);
+  text-transform: capitalize;
+}
+
+.public-weather__meta {
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(197, 216, 245, 0.6);
+}
+
+.rotating-card {
+  position: relative;
+  flex: 1;
+  padding: 32px;
+  border-radius: 28px;
+  background: rgba(8, 16, 28, 0.9);
+  border: 1px solid rgba(88, 140, 204, 0.3);
+  box-shadow: 0 28px 54px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  color: #f7f9ff;
+  min-height: 260px;
+}
+
+.rotating-card__panel {
+  position: absolute;
+  inset: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  opacity: 0;
+  transition: opacity 360ms ease-in-out;
+  pointer-events: none;
+}
+
+.rotating-card__panel.is-active {
+  opacity: 1;
+  pointer-events: auto;
+  position: relative;
+}
+
+.rotating-card__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(213, 229, 255, 0.8);
+}
+
+.rotating-card__body {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  font-size: 1.6rem;
+  line-height: 1.45;
+}
+
+.auto-scroll {
+  width: 100%;
+  color: inherit;
+}
+
+.ticker {
+  position: relative;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.ticker__track {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ticker-gap, 48px);
+  will-change: transform;
+  animation-name: ticker-move;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.vscroll {
+  position: relative;
+  overflow: hidden;
+}
+
+.vscroll__track {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ticker-gap, 48px);
+  will-change: transform;
+  animation-name: vscroll-move;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+
+.ticker[data-scroll-active="false"] .ticker__track,
+.vscroll[data-scroll-active="false"] .vscroll__track {
+  animation: none;
+  transform: translate3d(0, 0, 0);
+}
+
+.auto-scroll__segment {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  gap: 18px;
+}
+
+.vscroll .auto-scroll__segment {
+  display: block;
+  white-space: normal;
+}
+
+.auto-scroll__segment--clone {
+  opacity: 0.9;
+}
+
+@keyframes ticker-move {
+  from {
+    transform: translateX(0);
   }
+  to {
+    transform: translateX(-50%);
+  }
+}
+
+@keyframes vscroll-move {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-50%);
+  }
+}
+
+.leaflet-control,
+.leaflet-control-container {
+  display: none !important;
 }

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -38,12 +38,48 @@ export type StormMode = {
   last_triggered: string | null;
 };
 
+export type UIScrollSpeed = number | "slow" | "normal" | "fast";
+
+export type UIScrollSettings = {
+  enabled: boolean;
+  direction: "left" | "up";
+  speed: UIScrollSpeed;
+  gap_px: number;
+};
+
+export type UITextSettings = {
+  scroll: Record<string, UIScrollSettings>;
+};
+
+export type UIFixedSettings = {
+  clock: { format: string };
+  temperature: { unit: string };
+};
+
+export type UIRotationSettings = {
+  enabled: boolean;
+  duration_sec: number;
+  panels: string[];
+};
+
+export type UIMapSettings = {
+  provider: string;
+  center: [number, number];
+  zoom: number;
+  interactive: boolean;
+  controls: boolean;
+};
+
 export type UISettings = {
-  layout: "full" | "widgets";
-  side_panel: "left" | "right";
-  show_config: boolean;
-  enable_demo: boolean;
-  carousel: boolean;
+  rotation: UIRotationSettings;
+  fixed: UIFixedSettings;
+  map: UIMapSettings;
+  text: UITextSettings;
+  layout?: "full" | "widgets";
+  side_panel?: "left" | "right";
+  show_config?: boolean;
+  enable_demo?: boolean;
+  carousel?: boolean;
 };
 
 export type AppConfig = {

--- a/dash-ui/src/utils/sanitize.ts
+++ b/dash-ui/src/utils/sanitize.ts
@@ -1,0 +1,63 @@
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const allowedTags = new Set(["B", "STRONG", "I", "EM", "BR"]);
+
+export const sanitizeRichText = (value: unknown): string => {
+  if (typeof value !== "string") {
+    if (value === null || value === undefined) {
+      return "";
+    }
+    return escapeHtml(String(value));
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (typeof window === "undefined" || typeof window.DOMParser === "undefined") {
+    return escapeHtml(trimmed);
+  }
+
+  const parser = new DOMParser();
+  const documentWrapper = parser.parseFromString(`<div>${trimmed}</div>`, "text/html");
+  const root = documentWrapper.body;
+
+  const cleanse = (node: Node): void => {
+    const childNodes = Array.from(node.childNodes);
+    for (const child of childNodes) {
+      if (child.nodeType === Node.ELEMENT_NODE) {
+        const element = child as HTMLElement;
+        if (!allowedTags.has(element.tagName)) {
+          const parent = element.parentNode;
+          while (element.firstChild) {
+            parent?.insertBefore(element.firstChild, element);
+          }
+          parent?.removeChild(element);
+          continue;
+        }
+        while (element.attributes.length > 0) {
+          element.removeAttribute(element.attributes[0].name);
+        }
+      }
+      cleanse(child);
+    }
+  };
+
+  cleanse(root);
+  return root.innerHTML;
+};
+
+export const ensurePlainText = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value.trim();
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value).trim();
+};


### PR DESCRIPTION
## Summary
- restructure backend UI config defaults and models to include rotation, fixed clock/temperature, map, and text scroll settings
- add reusable AutoScrollText, RotatingCard, ClockDisplay, and WorldMap components with sanitized rich text and Leaflet loading
- redesign the dashboard layout for a control-free public screen with clock, weather, hardened world map, and rotating panels, and expand /config to tune map and scroll behaviour
- refresh global styling for the new layout and text ticker animations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fdf7cbe70883268e32627a08d5647c