### PR TITLE
Configure kiosk scaling and portrait map cropping

### DIFF
--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -2,6 +2,19 @@
   box-sizing: border-box;
 }
 
+html,
+body,
+#root,
+#app,
+#map {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  background: #000;
+}
+
 :root {
   color-scheme: dark;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -11,6 +24,7 @@
 
 body {
   margin: 0;
+  background-color: #000;
   min-height: 100vh;
   background:
     radial-gradient(circle at top left, rgba(18, 96, 163, 0.35), transparent 62%),


### PR DESCRIPTION
## Summary
- update the Leaflet world map to disable world copies and fit a portrait-friendly viewport
- ensure global styles fill the viewport and default to a black background to prevent white flashes
- parameterize the Chromium kiosk drop-in and installer for CHROMIUM_SCALE and the user XAUTHORITY cookie

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fdff03f8008326bd4d987ec92019aa