### PR TITLE
Serve local raster map style and hide kiosk cursor

### DIFF
--- a/dash-ui/src/pages/DashboardPage.tsx
+++ b/dash-ui/src/pages/DashboardPage.tsx
@@ -343,17 +343,10 @@ export const DashboardPage: React.FC = () => {
     weather
   ]);
 
-  const mapSettings = config.ui.map ?? UI_DEFAULTS.map;
-  const mapCenter = Array.isArray(mapSettings.center)
-    ? ([Number(mapSettings.center[0]) || 0, Number(mapSettings.center[1]) || 0] as [number, number])
-    : (UI_DEFAULTS.map.center as [number, number]);
-  const mapZoom = typeof mapSettings.zoom === "number" ? mapSettings.zoom : UI_DEFAULTS.map.zoom;
-  const mapProvider = mapSettings.provider || UI_DEFAULTS.map.provider;
-
   return (
     <div className="public-dashboard" aria-busy={loading}>
       <div className="public-dashboard__map">
-        <WorldMap center={mapCenter} zoom={mapZoom} provider={mapProvider} />
+        <WorldMap />
         <div className="public-dashboard__map-overlay">
           <span className="public-dashboard__map-location">{location}</span>
           <span className="public-dashboard__map-temp">

--- a/opt/pantalla/openbox/autostart
+++ b/opt/pantalla/openbox/autostart
@@ -108,6 +108,14 @@ else
   log_session "xset-missing"
 fi
 
+if command -v unclutter >/dev/null 2>&1; then
+  DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" \
+    unclutter -idle 0 -root -noevents -grab >/dev/null 2>&1 &
+  log_session "unclutter-started"
+else
+  log_session "unclutter-missing"
+fi
+
 log_session "xset-hook-finished"
 
 sleep 0.5 2>/dev/null || sleep 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -83,6 +83,7 @@ install -d -m 0755 "$REPO_ROOT/home/dani/.local/share/applications" >/dev/null 2
 install -d -m 0700 -o "$USER_NAME" -g "$USER_NAME" "$USER_HOME"
 install -d -m 0755 "$PANTALLA_PREFIX" "$SESSION_PREFIX"
 install -d -m 0755 "$SESSION_PREFIX/bin" "$SESSION_PREFIX/openbox"
+install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" /opt/pantalla-reloj/frontend/static
 install -d -m 0755 -o root -g root /var/lib/pantalla
 install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$KIOSK_LOG_DIR"
 install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$LOG_DIR"
@@ -117,6 +118,7 @@ APT_PACKAGES=(
   file
   xauth
   python3-venv
+  unclutter-xfixes
 )
 apt-get update -y
 DEBIAN_FRONTEND=noninteractive apt-get install -y "${APT_PACKAGES[@]}"


### PR DESCRIPTION
## Summary
- serve /static via FastAPI and bootstrap a local raster style.json
- update the dashboard map to load a local MapLibre style without interaction or duplicates
- install and launch unclutter from Openbox to keep the pointer hidden during sessions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe0567503c83268c6ad98b7211c3d3