### PR TITLE
Fix static directory bootstrap and map style URL

### DIFF
--- a/dash-ui/src/components/WorldMap.tsx
+++ b/dash-ui/src/components/WorldMap.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from "react";
 
+import { API_BASE } from "../services/api";
+
 type MapPadding = {
   top: number;
   bottom: number;
@@ -34,7 +36,7 @@ type WorldMapProps = {
 };
 
 const MAP_CONTAINER_ID = "map";
-const MAP_STYLE_URL = "http://127.0.0.1:8081/static/style.json";
+const MAP_STYLE_URL = new URL("/static/style.json", API_BASE).toString();
 const MAPLIBRE_SCRIPT = "https://unpkg.com/maplibre-gl@3.6.1/dist/maplibre-gl.js";
 const MAPLIBRE_STYLES = "https://unpkg.com/maplibre-gl@3.6.1/dist/maplibre-gl.css";
 const SOUTH_WEST: [number, number] = [-170, -60];

--- a/dash-ui/src/services/api.ts
+++ b/dash-ui/src/services/api.ts
@@ -1,6 +1,6 @@
 import type { AppConfig } from "../types/config";
 
-const API_BASE = import.meta.env.VITE_BACKEND_URL ?? "http://127.0.0.1:8081";
+export const API_BASE = import.meta.env.VITE_BACKEND_URL ?? "http://127.0.0.1:8081";
 
 async function get<T>(path: string): Promise<T> {
   const response = await fetch(`${API_BASE}${path}`);


### PR DESCRIPTION
## Summary
- defer static asset bootstrap to application startup and fall back to a writable directory when /opt is unavailable
- expose the shared API base URL and have the dashboard map load its style from the configured backend

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe0891e4008326a0a3a9b39153abac