### PR TITLE
Refine dashboard overlays layout

### DIFF
--- a/dash-ui/src/components/ClockDisplay.tsx
+++ b/dash-ui/src/components/ClockDisplay.tsx
@@ -11,9 +11,18 @@ dayjs.locale("es");
 type ClockDisplayProps = {
   timezone: string;
   format: string;
+  className?: string;
+  timeClassName?: string;
+  dateClassName?: string;
 };
 
-export const ClockDisplay: React.FC<ClockDisplayProps> = ({ timezone, format }) => {
+export const ClockDisplay: React.FC<ClockDisplayProps> = ({
+  timezone,
+  format,
+  className,
+  timeClassName,
+  dateClassName
+}) => {
   const [now, setNow] = useState(() => dayjs().tz(timezone));
 
   useEffect(() => {
@@ -24,10 +33,14 @@ export const ClockDisplay: React.FC<ClockDisplayProps> = ({ timezone, format }) 
     return () => window.clearInterval(timer);
   }, [timezone]);
 
+  const containerClass = className ?? "public-clock";
+  const timeClass = timeClassName ?? "public-clock__time";
+  const dateClass = dateClassName ?? "public-clock__date";
+
   return (
-    <div className="public-clock" aria-live="polite">
-      <div className="public-clock__time">{now.format(format)}</div>
-      <div className="public-clock__date">{now.format("dddd, D [de] MMMM YYYY")}</div>
+    <div className={containerClass} aria-live="polite">
+      <div className={timeClass}>{now.format(format)}</div>
+      <div className={dateClass}>{now.format("dddd, D [de] MMMM YYYY")}</div>
     </div>
   );
 };

--- a/dash-ui/src/components/RotatingCard.tsx
+++ b/dash-ui/src/components/RotatingCard.tsx
@@ -18,11 +18,23 @@ export type RotatingCardProps = {
   panels: RotatingPanel[];
   rotationEnabled: boolean;
   durationSeconds: number;
+  containerClassName?: string;
+  panelClassName?: string;
+  titleClassName?: string;
+  bodyClassName?: string;
 };
 
 const MIN_DURATION = 4;
 
-export const RotatingCard: React.FC<RotatingCardProps> = ({ panels, rotationEnabled, durationSeconds }) => {
+export const RotatingCard: React.FC<RotatingCardProps> = ({
+  panels,
+  rotationEnabled,
+  durationSeconds,
+  containerClassName,
+  panelClassName,
+  titleClassName,
+  bodyClassName
+}) => {
   const safePanels = useMemo<RotatingPanel[]>(() => {
     if (panels.length > 0) {
       return panels;
@@ -56,20 +68,33 @@ export const RotatingCard: React.FC<RotatingCardProps> = ({ panels, rotationEnab
     return () => window.clearInterval(interval);
   }, [rotationEnabled, durationSeconds, safePanels.length]);
 
+  const containerClasses = useMemo(
+    () => ["rotating-card", containerClassName].filter(Boolean).join(" "),
+    [containerClassName]
+  );
+  const titleClasses = useMemo(
+    () => ["rotating-card__title", titleClassName].filter(Boolean).join(" "),
+    [titleClassName]
+  );
+  const bodyClasses = useMemo(
+    () => ["rotating-card__body", bodyClassName].filter(Boolean).join(" "),
+    [bodyClassName]
+  );
+
   return (
-    <div className="rotating-card" role="region" aria-live="polite">
+    <div className={containerClasses} role="region" aria-live="polite">
       {safePanels.map((panel, index) => {
         const isActive = index === activeIndex;
         return (
           <article
             key={`${panel.id}-${index}`}
-            className={`rotating-card__panel${isActive ? " is-active" : ""}`}
+            className={["rotating-card__panel", panelClassName, isActive ? "is-active" : ""].filter(Boolean).join(" ")}
             aria-hidden={isActive ? undefined : true}
           >
             <header className="rotating-card__header">
-              <h2>{panel.title}</h2>
+              <h2 className={titleClasses}>{panel.title}</h2>
             </header>
-            <div className="rotating-card__body">
+            <div className={bodyClasses}>
               <AutoScrollText
                 content={panel.content}
                 direction={panel.direction}

--- a/dash-ui/src/pages/DashboardPage.tsx
+++ b/dash-ui/src/pages/DashboardPage.tsx
@@ -238,6 +238,32 @@ export const DashboardPage: React.FC = () => {
       };
     };
 
+    const buildWeatherPanel = (): RotatingPanel => {
+      const summary = sanitizeRichText(weather.summary) || sanitizeRichText(weather.condition);
+      const segments: string[] = [];
+      const formattedTemperature = temperatureValue !== "--" ? `${temperatureValue}${temperatureUnit}` : "";
+
+      if (formattedTemperature) {
+        segments.push(formattedTemperature);
+      }
+      if (summary) {
+        segments.push(summary);
+      }
+      if (location) {
+        segments.push(location);
+      }
+
+      return {
+        id: "weather",
+        title: "Clima actual",
+        content: segments.length > 0 ? joinWithBreaks(segments, true) : "Sin datos meteorológicos",
+        direction: forecastScroll.direction,
+        enableScroll: forecastScroll.enabled,
+        speed: forecastScroll.speed,
+        gap: forecastScroll.gap_px
+      };
+    };
+
     const buildForecastPanel = (): RotatingPanel => {
       const forecastItems = Array.isArray(weather.forecast)
         ? (weather.forecast as Record<string, unknown>[])
@@ -315,6 +341,7 @@ export const DashboardPage: React.FC = () => {
       news: buildNewsPanel,
       ephemerides: buildEphemeridesPanel,
       moon: buildMoonPanel,
+      weather: buildWeatherPanel,
       forecast: buildForecastPanel,
       calendar: buildCalendarPanel
     };
@@ -340,38 +367,34 @@ export const DashboardPage: React.FC = () => {
     newsScroll.gap_px,
     newsScroll.speed,
     rotationSettings.panels,
-    weather
+    weather,
+    condition,
+    location,
+    temperatureUnit,
+    temperatureValue
   ]);
 
   return (
-    <div className="public-dashboard" aria-busy={loading}>
-      <div className="public-dashboard__map">
-        <WorldMap />
-        <div className="public-dashboard__map-overlay">
-          <span className="public-dashboard__map-location">{location}</span>
-          <span className="public-dashboard__map-temp">
-            {temperatureValue}
-            {temperatureUnit}
-          </span>
-          <span className="public-dashboard__map-condition">{condition}</span>
+    <div className="app-shell" aria-busy={loading}>
+      <div className="stage">
+        <div className="map-wrap">
+          <WorldMap />
+          <ClockDisplay
+            timezone={config.display.timezone}
+            format={config.ui.fixed.clock.format}
+            className="overlay clock"
+            timeClassName="time"
+            dateClassName="date"
+          />
+          <RotatingCard
+            panels={panels}
+            rotationEnabled={rotationSettings.enabled}
+            durationSeconds={rotationSettings.duration_sec ?? UI_DEFAULTS.rotation.duration_sec}
+            containerClassName="overlay rotator"
+            titleClassName="title"
+            bodyClassName="card-body"
+          />
         </div>
-        <div className="public-dashboard__map-attribution">© OpenStreetMap contributors</div>
-      </div>
-      <div className="public-dashboard__info">
-        <ClockDisplay timezone={config.display.timezone} format={config.ui.fixed.clock.format} />
-        <div className="public-weather" aria-live="polite">
-          <div className="public-weather__temp">
-            {temperatureValue}
-            {temperatureUnit}
-          </div>
-          <div className="public-weather__condition">{condition}</div>
-          <div className="public-weather__meta">{location}</div>
-        </div>
-        <RotatingCard
-          panels={panels}
-          rotationEnabled={rotationSettings.enabled}
-          durationSeconds={rotationSettings.duration_sec ?? UI_DEFAULTS.rotation.duration_sec}
-        />
       </div>
     </div>
   );

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -39,148 +39,99 @@ body {
   display: flex;
 }
 
-.public-dashboard {
-  display: grid;
-  grid-template-columns: minmax(0, 3fr) minmax(320px, 2fr);
-  gap: 40px;
+.app-shell,
+.stage,
+.map-wrap {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+}
+
+.app-shell {
+  align-items: stretch;
+  justify-content: center;
+}
+
+.stage {
+  padding: clamp(16px, 3vw, 28px);
+}
+
+.map-wrap {
+  border-radius: clamp(12px, 2.4vw, 28px);
+  overflow: hidden;
+  box-shadow: 0 36px 72px rgba(0, 0, 0, 0.45);
+  background: linear-gradient(160deg, rgba(12, 24, 40, 0.85), rgba(4, 8, 14, 0.92));
+}
+
+#map {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
-  padding: 48px 56px;
-}
-
-@media (max-width: 1280px) {
-  .public-dashboard {
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(0, 2fr) minmax(0, 1fr);
-    padding: 32px;
-  }
-}
-
-.public-dashboard__map {
-  position: relative;
-  border-radius: 36px;
   overflow: hidden;
-  background: linear-gradient(160deg, rgba(18, 36, 56, 0.8), rgba(6, 12, 20, 0.92));
-  box-shadow: 0 32px 64px rgba(0, 0, 0, 0.35);
+  background: #000;
 }
 
 .map-container {
+  position: absolute;
+  inset: 0;
   width: 100%;
   height: 100%;
   pointer-events: none;
 }
 
-.public-dashboard__map-overlay {
+.overlay,
+.rotator,
+.clock {
   position: absolute;
-  left: 32px;
-  bottom: 32px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 20px 24px;
-  border-radius: 22px;
-  background: rgba(4, 9, 16, 0.7);
-  border: 1px solid rgba(86, 142, 205, 0.4);
-  color: #eef5ff;
+  z-index: 10;
   pointer-events: none;
-  backdrop-filter: blur(12px);
 }
 
-.public-dashboard__map-location {
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  font-size: 0.95rem;
-  color: rgba(223, 238, 255, 0.88);
-}
-
-.public-dashboard__map-temp {
-  font-size: 2.4rem;
+.clock {
+  top: 10px;
+  left: 14px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(0, 0, 0, 0.35);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
   font-weight: 600;
+  line-height: 1.1;
 }
 
-.public-dashboard__map-condition {
-  font-size: 1.2rem;
-  color: rgba(223, 238, 255, 0.75);
+.clock .time {
+  font-size: clamp(22px, 2.6vw, 34px);
 }
 
-.public-dashboard__map-attribution {
-  position: absolute;
-  right: 24px;
-  bottom: 18px;
-  font-size: 0.75rem;
-  color: rgba(210, 227, 255, 0.55);
-  letter-spacing: 0.08em;
-  pointer-events: none;
-  user-select: none;
+.clock .date {
+  margin-top: 2px;
+  font-size: clamp(12px, 1.4vw, 16px);
+  opacity: 0.9;
 }
 
-.public-dashboard__info {
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
-  justify-content: flex-start;
-  height: 100%;
-}
-
-.public-clock {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.public-clock__time {
-  font-size: clamp(96px, 12vw, 160px);
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-shadow: 0 12px 30px rgba(0, 0, 0, 0.32);
-}
-
-.public-clock__date {
-  font-size: 1.6rem;
-  color: rgba(229, 238, 255, 0.8);
-  text-transform: capitalize;
-}
-
-.public-weather {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 24px 28px;
-  border-radius: 26px;
-  background: rgba(13, 24, 38, 0.82);
-  border: 1px solid rgba(90, 142, 200, 0.36);
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
-}
-
-.public-weather__temp {
-  font-size: clamp(42px, 6vw, 68px);
-  font-weight: 600;
-}
-
-.public-weather__condition {
-  font-size: 1.4rem;
-  color: rgba(224, 235, 255, 0.78);
-  text-transform: capitalize;
-}
-
-.public-weather__meta {
-  font-size: 0.95rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(197, 216, 245, 0.6);
+.rotator {
+  right: 14px;
+  bottom: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.38);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  max-width: min(38vw, 520px);
+  max-height: min(36vh, 420px);
+  overflow: hidden;
 }
 
 .rotating-card {
   position: relative;
-  flex: 1;
-  padding: 32px;
-  border-radius: 28px;
-  background: rgba(8, 16, 28, 0.9);
-  border: 1px solid rgba(88, 140, 204, 0.3);
-  box-shadow: 0 28px 54px rgba(0, 0, 0, 0.35);
-  overflow: hidden;
-  color: #f7f9ff;
-  min-height: 260px;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  color: inherit;
 }
 
 .rotating-card__panel {
@@ -189,9 +140,9 @@ body {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 8px;
   opacity: 0;
-  transition: opacity 360ms ease-in-out;
+  transition: opacity 320ms ease-in-out;
   pointer-events: none;
 }
 
@@ -201,21 +152,85 @@ body {
   position: relative;
 }
 
-.rotating-card__header h2 {
+.rotating-card__header {
   margin: 0;
-  font-size: 1.2rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(213, 229, 255, 0.8);
+  padding: 0;
+}
+
+.rotating-card__title {
+  margin: 0;
+  font-size: inherit;
+  font-weight: 700;
 }
 
 .rotating-card__body {
-  flex: 1;
+  flex: 1 1 auto;
+  display: block;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.rotator .card-body {
+  pointer-events: auto;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  max-height: inherit;
+  font-size: clamp(12px, 1.4vw, 16px);
+  line-height: 1.25;
+  color: rgba(239, 246, 255, 0.95);
+}
+
+.rotator .title {
+  font-size: clamp(14px, 1.6vw, 18px);
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: #f9fbff;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.rotator .card-body .auto-scroll__segment {
+  display: block;
+  white-space: normal;
+}
+
+.rotator .card-body .auto-scroll {
+  width: 100%;
+}
+
+.badges {
+  position: absolute;
+  top: 10px;
+  right: 12px;
   display: flex;
-  align-items: center;
-  font-size: 1.6rem;
-  line-height: 1.45;
+  gap: 6px;
+  z-index: 11;
+}
+
+.mapboxgl-ctrl,
+.maplibregl-ctrl,
+.mapboxgl-ctrl-logo,
+.maplibregl-ctrl-logo,
+.mapboxgl-ctrl-attrib,
+.maplibregl-ctrl-attrib {
+  display: none !important;
+}
+
+html,
+body,
+#root,
+#map {
+  cursor: none !important;
+}
+
+@media (max-aspect-ratio: 10/19) {
+  .rotator {
+    max-width: min(46vw, 520px);
+  }
+
+  .clock .time {
+    font-size: clamp(20px, 2.8vw, 30px);
+  }
 }
 
 .auto-scroll {


### PR DESCRIPTION
## Summary
- restructure the dashboard page so the clock and rotating card render as absolute overlays on top of the map and add a configurable weather panel option
- compact the global styles to let the map dominate the viewport while giving the overlays translucent treatments and hiding map controls and the cursor
- tighten the MapLibre bounds fitting and component APIs so overlays can adopt the new styling hooks

## Testing
- npm --prefix dash-ui run build

------
https://chatgpt.com/codex/tasks/task_e_68fe098194e88326bc86f5ca19886c6e