### PR TITLE
Address review feedback for map attribution and weather panel

### DIFF
--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -25,7 +25,7 @@ export const UI_DEFAULTS: UISettings = {
   rotation: {
     enabled: true,
     duration_sec: 10,
-    panels: ["news", "ephemerides", "moon", "forecast", "calendar"]
+    panels: ["news", "weather", "ephemerides", "moon", "forecast", "calendar"]
   },
   fixed: {
     clock: { format: "HH:mm" },

--- a/dash-ui/src/pages/DashboardPage.tsx
+++ b/dash-ui/src/pages/DashboardPage.tsx
@@ -394,6 +394,16 @@ export const DashboardPage: React.FC = () => {
             titleClassName="title"
             bodyClassName="card-body"
           />
+          <div className="overlay map-attribution">
+            Map data ©{" "}
+            <a
+              href="https://www.openstreetmap.org/copyright"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              OpenStreetMap contributors
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -207,6 +207,32 @@ body {
   z-index: 11;
 }
 
+.map-attribution {
+  right: 14px;
+  bottom: 12px;
+  padding: 4px 8px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.4);
+  font-size: clamp(10px, 1.2vw, 13px);
+  line-height: 1.2;
+  color: rgba(245, 248, 255, 0.8);
+  pointer-events: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.map-attribution a {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.map-attribution a:hover,
+.map-attribution a:focus {
+  text-decoration: underline;
+}
+
 .mapboxgl-ctrl,
 .maplibregl-ctrl,
 .mapboxgl-ctrl-logo,


### PR DESCRIPTION
## Summary
- add an on-screen OpenStreetMap attribution overlay so credit remains visible while controls stay hidden
- include the weather panel in the default rotating card configuration and surface the attribution overlay in the dashboard page markup
- style the attribution overlay to match the updated dashboard overlays and allow the link to be clickable

## Testing
- npm --prefix dash-ui run build

------
https://chatgpt.com/codex/tasks/task_e_68fe0e268e2c83268f5c314800760618