### PR TITLE
Respect kiosk rotation configuration

### DIFF
--- a/dash-ui/src/components/RotatingCard.tsx
+++ b/dash-ui/src/components/RotatingCard.tsx
@@ -8,12 +8,13 @@ export type RotatingCardItem = {
 
 type RotatingCardProps = {
   cards: RotatingCardItem[];
+  rotationEnabled?: boolean;
 };
 
 const MIN_DURATION = 4000;
 const TRANSITION_DURATION = 400;
 
-export const RotatingCard = ({ cards }: RotatingCardProps): JSX.Element => {
+export const RotatingCard = ({ cards, rotationEnabled = true }: RotatingCardProps): JSX.Element => {
   const fallbackCards = useMemo<RotatingCardItem[]>(() => {
     if (cards.length > 0) {
       return cards;
@@ -38,10 +39,10 @@ export const RotatingCard = ({ cards }: RotatingCardProps): JSX.Element => {
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [fallbackCards]);
+  }, [fallbackCards, rotationEnabled]);
 
   useEffect(() => {
-    if (fallbackCards.length === 0) {
+    if (fallbackCards.length === 0 || !rotationEnabled || fallbackCards.length <= 1) {
       return undefined;
     }
 
@@ -62,7 +63,7 @@ export const RotatingCard = ({ cards }: RotatingCardProps): JSX.Element => {
         timeoutRef.current = null;
       }
     };
-  }, [activeIndex, fallbackCards]);
+  }, [activeIndex, fallbackCards, rotationEnabled]);
 
   useEffect(() => {
     return () => {

--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -7,12 +7,14 @@ import type {
 } from "../types/config";
 
 const createDefaultModules = (): DisplayModule[] => [
-  { name: "clock", enabled: true, duration_seconds: 20 },
-  { name: "weather", enabled: true, duration_seconds: 20 },
-  { name: "moon", enabled: true, duration_seconds: 20 },
+  { name: "time", enabled: true, duration_seconds: 8 },
+  { name: "weather", enabled: true, duration_seconds: 10 },
+  { name: "calendar", enabled: true, duration_seconds: 12 },
+  { name: "moon", enabled: true, duration_seconds: 10 },
+  { name: "harvest", enabled: true, duration_seconds: 12 },
+  { name: "saints", enabled: true, duration_seconds: 12 },
   { name: "news", enabled: true, duration_seconds: 20 },
-  { name: "events", enabled: true, duration_seconds: 20 },
-  { name: "calendar", enabled: true, duration_seconds: 20 }
+  { name: "ephemerides", enabled: true, duration_seconds: 20 }
 ];
 
 const createScrollDefaults = (): Record<string, UIScrollSettings> => ({
@@ -24,8 +26,8 @@ const createScrollDefaults = (): Record<string, UIScrollSettings> => ({
 export const UI_DEFAULTS: UISettings = {
   rotation: {
     enabled: true,
-    duration_sec: 10,
-    panels: ["news", "ephemerides", "moon", "forecast", "calendar"]
+    duration_sec: 12,
+    panels: ["time", "weather", "calendar", "moon", "harvest", "saints", "news", "ephemerides"]
   },
   fixed: {
     clock: { format: "HH:mm" },


### PR DESCRIPTION
## Summary
- normalize rotation panel identifiers and rebuild the dashboard rotating cards from `config.ui.rotation` and `config.display.modules`
- allow the sidebar rotator to be disabled when rotation is turned off in the configuration
- update the default module list and rotation panels to match the new kiosk cards and durations

## Testing
- not run (npm install fails: registry returns 403 for mapbox-gl)


------
https://chatgpt.com/codex/tasks/task_e_68fe257ee0548326ae30788d768b11e8