### PR TITLE
Load MapLibre from CDN during dashboard render

### DIFF
--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "dayjs": "^1.11.10",
-    "maplibre-gl": "^3.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3"

--- a/dash-ui/src/components/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScopeMap.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from "react";
-import maplibregl from "maplibre-gl";
-import "maplibre-gl/dist/maplibre-gl.css";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { MapInstance, StyleSpecification } from "../types/maplibre-gl";
+import { loadMapLibre } from "../utils/loadMapLibre";
 
 type GeoScopeMapProps = {
   className?: string;
@@ -8,7 +8,7 @@ type GeoScopeMapProps = {
   zoom?: number;
 };
 
-const style: maplibregl.StyleSpecification = {
+const CDN_STYLE: StyleSpecification = {
   version: 8,
   sources: {
     osm: {
@@ -29,46 +29,95 @@ const style: maplibregl.StyleSpecification = {
 
 export const GeoScopeMap = ({ className, center, zoom = 1.6 }: GeoScopeMapProps): JSX.Element => {
   const mapContainer = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<maplibregl.Map | null>(null);
-  const [lng, lat] = center ?? [0, 20];
+  const mapRef = useRef<MapInstance | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  const [lng, lat] = useMemo(() => center ?? [0, 20], [center]);
 
   useEffect(() => {
-    if (!mapContainer.current) {
-      return undefined;
+    const container = mapContainer.current;
+    if (!container) {
+      return () => {
+        /* noop */
+      };
     }
 
-    const map = new maplibregl.Map({
-      container: mapContainer.current,
-      style,
-      center: [lng, lat],
-      zoom,
-      bearing: 0,
-      pitch: 0,
-      interactive: false,
-      attributionControl: false
-    });
+    let disposed = false;
+    let map: MapInstance | null = null;
 
-    mapRef.current = map;
+    setIsReady(false);
+    setError(null);
 
-    const onResize = () => {
-      map.resize();
+    const initialize = async () => {
+      try {
+        const maplibre = await loadMapLibre();
+        if (disposed || !mapContainer.current) {
+          return;
+        }
+
+        map = new maplibre.Map({
+          container: mapContainer.current,
+          style: CDN_STYLE,
+          center: [lng, lat],
+          zoom,
+          bearing: 0,
+          pitch: 0,
+          interactive: false,
+          attributionControl: false
+        });
+
+        mapRef.current = map;
+        setIsReady(true);
+        setError(null);
+      } catch (err) {
+        console.error(err);
+        if (!disposed) {
+          setError(err instanceof Error ? err.message : "No se pudo cargar el mapa");
+        }
+      }
     };
 
-    window.addEventListener("resize", onResize);
+    initialize();
+
+    const handleResize = () => {
+      mapRef.current?.resize();
+    };
+
+    window.addEventListener("resize", handleResize);
 
     return () => {
-      window.removeEventListener("resize", onResize);
+      disposed = true;
+      window.removeEventListener("resize", handleResize);
       mapRef.current?.remove();
       mapRef.current = null;
+      map?.remove();
+      map = null;
     };
   }, [lat, lng, zoom]);
 
   return (
-    <div className={["world-map", className].filter(Boolean).join(" ")}>
+    <div className={["world-map", className].filter(Boolean).join(" ")}> 
       <div ref={mapContainer} className="world-map__canvas" aria-hidden="true" />
       <div className="absolute bottom-1 right-2 text-[10px] text-white/50">
         © OpenStreetMap contributors
       </div>
+      {error ? (
+        <div className="world-map__overlay" role="alert">
+          <div className="world-map__overlay-card">
+            <p>No se pudo cargar el mapa global.</p>
+            <p className="world-map__overlay-hint">{error}</p>
+          </div>
+        </div>
+      ) : null}
+      {!error && !isReady ? (
+        <div className="world-map__overlay" aria-live="polite">
+          <div className="world-map__overlay-card">
+            <p>Cargando el mapa global…</p>
+            <p className="world-map__overlay-hint">Conectando con MapLibre</p>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/dash-ui/src/types/maplibre-gl.d.ts
+++ b/dash-ui/src/types/maplibre-gl.d.ts
@@ -1,0 +1,29 @@
+export type LngLatLike = [number, number];
+
+export interface MapOptions {
+  container: string | HTMLElement;
+  style: StyleSpecification;
+  center?: LngLatLike;
+  zoom?: number;
+  bearing?: number;
+  pitch?: number;
+  interactive?: boolean;
+  attributionControl?: boolean;
+}
+
+export interface MapInstance {
+  resize(): void;
+  remove(): void;
+}
+
+export interface MapLibreGL {
+  Map: new (options: MapOptions) => MapInstance;
+}
+
+declare global {
+  interface Window {
+    maplibregl?: MapLibreGL;
+  }
+}
+
+export type StyleSpecification = Record<string, unknown>;

--- a/dash-ui/src/utils/loadMapLibre.ts
+++ b/dash-ui/src/utils/loadMapLibre.ts
@@ -1,0 +1,68 @@
+import type { MapLibreGL } from "../types/maplibre-gl";
+
+const SCRIPT_URL = "https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.js";
+const STYLESHEET_URL = "https://unpkg.com/maplibre-gl@3.6.2/dist/maplibre-gl.css";
+
+let loaderPromise: Promise<MapLibreGL> | null = null;
+
+const ensureStylesheet = () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const existingLink = document.querySelector<HTMLLinkElement>(
+    'link[data-maplibre-stylesheet="true"]'
+  );
+
+  if (existingLink) {
+    return;
+  }
+
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.href = STYLESHEET_URL;
+  link.setAttribute("data-maplibre-stylesheet", "true");
+  document.head.appendChild(link);
+};
+
+export const loadMapLibre = (): Promise<MapLibreGL> => {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("MapLibre can only be loaded in a browser environment"));
+  }
+
+  if (window.maplibregl) {
+    ensureStylesheet();
+    return Promise.resolve(window.maplibregl);
+  }
+
+  if (!loaderPromise) {
+    loaderPromise = new Promise<MapLibreGL>((resolve, reject) => {
+      ensureStylesheet();
+
+      const script = document.createElement("script");
+      script.src = SCRIPT_URL;
+      script.async = true;
+
+      script.addEventListener("load", () => {
+        if (window.maplibregl) {
+          resolve(window.maplibregl);
+          return;
+        }
+
+        reject(new Error("MapLibre script loaded but window.maplibregl is undefined"));
+      });
+
+      script.addEventListener("error", () => {
+        reject(new Error("No se pudo cargar la librería de mapas (MapLibre)"));
+      });
+
+      document.head.appendChild(script);
+    });
+  }
+
+  return loaderPromise;
+};
+
+export const resetMapLibreLoaderForTests = () => {
+  loaderPromise = null;
+};


### PR DESCRIPTION
## Summary
- load MapLibre dynamically from the official CDN instead of the npm package so the installer no longer needs a lockfile update
- add a reusable loader utility and minimal type definitions to handle the CDN module and display user-friendly status overlays while the map initializes
- update the GeoScopeMap component to use the loader, show progress or error overlays, and keep the dashboard map rendering unchanged when the CDN script loads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe325171288326968dc77eb1c24a99