### PR TITLE
Fix MapLibre cleanup double remove

### DIFF
--- a/dash-ui/src/components/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScopeMap.tsx
@@ -91,7 +91,6 @@ export const GeoScopeMap = ({ className, center, zoom = 1.6 }: GeoScopeMapProps)
       window.removeEventListener("resize", handleResize);
       mapRef.current?.remove();
       mapRef.current = null;
-      map?.remove();
       map = null;
     };
   }, [lat, lng, zoom]);


### PR DESCRIPTION
## Summary
- avoid calling MapLibre's remove twice during GeoScopeMap cleanup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe344708548326be9729c3e7d086dc