### PR TITLE
Refine map overlay and config API handling

### DIFF
--- a/dash-ui/src/components/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScopeMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { MapInstance, StyleSpecification } from "../types/maplibre-gl";
-import { loadMapLibre } from "../utils/loadMapLibre";
+
+import loadMapLibre, { type MapInstance, type StyleSpecification } from "maplibre-gl";
 
 type GeoScopeMapProps = {
   className?: string;

--- a/dash-ui/src/components/OverlayRotator.tsx
+++ b/dash-ui/src/components/OverlayRotator.tsx
@@ -1,0 +1,32 @@
+import React, { useMemo } from "react";
+
+import { RotatingCard, type RotatingCardItem } from "./RotatingCard";
+
+type OverlayRotatorProps = {
+  cards: RotatingCardItem[];
+  status?: string | null;
+  isLoading?: boolean;
+};
+
+export const OverlayRotator: React.FC<OverlayRotatorProps> = ({ cards, status, isLoading }) => {
+  const label = useMemo(() => {
+    if (isLoading) {
+      return "Sincronizando datos…";
+    }
+    if (status && status.trim().length > 0) {
+      return status;
+    }
+    return "datos no disponibles";
+  }, [isLoading, status]);
+
+  return (
+    <div className="overlay-rotator" role="complementary" aria-live="polite">
+      <div className="overlay-rotator__panel">
+        <RotatingCard cards={cards} />
+        <p className="overlay-rotator__status">{label}</p>
+      </div>
+    </div>
+  );
+};
+
+export default OverlayRotator;

--- a/dash-ui/src/components/RotatingCard.tsx
+++ b/dash-ui/src/components/RotatingCard.tsx
@@ -79,14 +79,6 @@ export const RotatingCard = ({ cards }: RotatingCardProps): JSX.Element => {
       <div className={`rotating-card__content${isTransitioning ? " rotating-card__content--hidden" : ""}`}>
         {CurrentCard ? <CurrentCard /> : null}
       </div>
-      <div className="rotating-card__indicators" aria-hidden="true">
-        {fallbackCards.map((card, index) => (
-          <span
-            key={`${card.id}-${index}`}
-            className={`rotating-card__indicator${index === activeIndex ? " is-active" : ""}`}
-          />
-        ))}
-      </div>
     </div>
   );
 };

--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -33,8 +33,8 @@ export const UI_DEFAULTS: UISettings = {
   },
   map: {
     provider: "osm",
-    center: [0, 0],
-    zoom: 2,
+    center: [0, 20],
+    zoom: 1.6,
     interactive: false,
     controls: false
   },

--- a/dash-ui/src/services/api.ts
+++ b/dash-ui/src/services/api.ts
@@ -1,49 +1,87 @@
 import type { AppConfig } from "../types/config";
 
-const API_BASE = import.meta.env.VITE_BACKEND_URL ?? "http://127.0.0.1:8081";
+const API_BASE = "/api";
 
-async function get<T>(path: string): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`);
-  if (!response.ok) {
-    throw new Error(`Request failed for ${path}`);
+export class ApiError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
   }
-  return response.json() as Promise<T>;
 }
 
-async function post<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body)
-  });
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Request failed for ${path}`);
-  }
-  return response.json() as Promise<T>;
-}
+type HttpMethod = "GET" | "PUT" | "POST" | "PATCH" | "DELETE";
 
-async function patch<T>(path: string, body: unknown): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body)
-  });
-  if (!response.ok) {
-    const message = await response.text();
-    throw new Error(message || `Request failed for ${path}`);
+type RequestOptions = {
+  method?: HttpMethod;
+  body?: unknown;
+};
+
+const toJson = async (response: Response) => {
+  if (response.status === 204) {
+    return {};
   }
-  return response.json() as Promise<T>;
-}
+
+  const text = await response.text();
+  if (!text) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new ApiError("La respuesta del servidor no es JSON válido", response.status);
+  }
+};
+
+const request = async <T>(path: string, options: RequestOptions = {}): Promise<T> => {
+  const { method = "GET", body } = options;
+
+  let response: Response;
+  try {
+    const headers: HeadersInit | undefined =
+      body === undefined ? undefined : { "Content-Type": "application/json" };
+    response = await fetch(`${API_BASE}${path}`, {
+      method,
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body)
+    });
+  } catch (error) {
+    throw new ApiError("No se pudo conectar con el servicio", undefined);
+  }
+
+  if (response.status === 404 || response.status === 501) {
+    throw new ApiError("No disponible / no configurado", response.status);
+  }
+
+  if (!response.ok) {
+    let detail: string | null = null;
+    try {
+      const payload = (await toJson(response)) as { detail?: string };
+      detail = typeof payload?.detail === "string" ? payload.detail : null;
+    } catch (parseError) {
+      detail = null;
+    }
+
+    const message = detail || `Error ${response.status} en la solicitud`;
+    throw new ApiError(message, response.status);
+  }
+
+  return toJson(response) as Promise<T>;
+};
 
 export const api = {
-  fetchHealth: () => get<{ status: string; uptime_seconds: number; timestamp: string }>("/api/health"),
-  fetchConfig: () => get<AppConfig>("/api/config"),
-  updateConfig: (payload: Partial<AppConfig>) => patch<AppConfig>("/api/config", payload),
-  fetchWeather: () => get<Record<string, unknown>>("/api/weather"),
-  fetchNews: () => get<Record<string, unknown>>("/api/news"),
-  fetchAstronomy: () => get<Record<string, unknown>>("/api/astronomy"),
-  fetchCalendar: () => get<Record<string, unknown>>("/api/calendar"),
-  fetchStormMode: () => get<Record<string, unknown>>("/api/storm_mode"),
-  updateStormMode: (payload: { enabled: boolean }) => post<Record<string, unknown>>("/api/storm_mode", payload)
+  fetchHealth: () => request<{ status: string; uptime_seconds: number; timestamp: string }>("/health"),
+  fetchConfig: () => request<AppConfig>("/config"),
+  updateConfig: (payload: AppConfig) => request<AppConfig>("/config", { method: "PUT", body: payload }),
+  fetchWeather: () => request<Record<string, unknown>>("/weather"),
+  fetchNews: () => request<Record<string, unknown>>("/news"),
+  fetchAstronomy: () => request<Record<string, unknown>>("/astronomy"),
+  fetchCalendar: () => request<Record<string, unknown>>("/calendar"),
+  fetchStormMode: () => request<Record<string, unknown>>("/storm_mode"),
+  updateStormMode: (payload: { enabled: boolean }) => request<Record<string, unknown>>("/storm_mode", { method: "POST", body: payload })
 };
+
+export type ApiClient = typeof api;

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -52,9 +52,10 @@ main {
 }
 
 .dashboard-alt {
-  display: grid;
-  grid-template-columns: minmax(0, 4fr) minmax(320px, 1fr);
-  gap: clamp(18px, 3vw, 32px);
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
   width: 100%;
   height: 100%;
   padding: clamp(16px, 2.8vw, 32px);
@@ -62,64 +63,14 @@ main {
 
 .dashboard-alt__map {
   position: relative;
+  flex: 1;
   border-radius: clamp(20px, 3vw, 36px);
   overflow: hidden;
   background: var(--panel-bg);
   border: 1px solid var(--panel-border);
   box-shadow: var(--panel-glow);
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
-.dashboard-alt__map-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: clamp(12px, 1.8vw, 24px);
-  padding: clamp(16px, 2vw, 28px);
-  position: relative;
-  z-index: 2;
-}
-
-.dashboard-alt__chips {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  min-width: 240px;
-}
-
-.dashboard-alt__map-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  padding: clamp(16px, 2vw, 24px);
-  font-size: 0.95rem;
-  color: var(--text-muted);
-  backdrop-filter: blur(12px);
-  background: linear-gradient(180deg, rgba(3, 6, 15, 0.4), rgba(3, 6, 15, 0.75));
-  border-top: 1px solid rgba(109, 182, 255, 0.18);
-}
-
-.dashboard-alt__sidebar {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
   min-height: 0;
-}
-
-.dashboard-alt__sidebar-footer {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 16px 20px;
-  border-radius: 20px;
-  background: var(--surface);
-  border: 1px solid var(--border-color);
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.35);
+  height: 100%;
 }
 
 .world-map {
@@ -164,53 +115,49 @@ main {
   font-weight: 600;
 }
 
-.map-chip {
+.overlay-rotator {
+  position: absolute;
+  inset: clamp(24px, 4vw, 48px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.overlay-rotator__panel {
+  width: min(720px, 85%);
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 12px 18px;
-  border-radius: 18px;
-  background: var(--chip-bg);
-  border: 1px solid var(--chip-border);
-  box-shadow: var(--chip-shadow);
-  min-width: 180px;
+  gap: 18px;
 }
 
-.map-chip--title {
-  min-width: 220px;
-  background: linear-gradient(140deg, rgba(79, 173, 255, 0.25), rgba(54, 90, 255, 0.18));
-}
-
-.map-chip__label {
-  text-transform: uppercase;
-  font-size: 0.7rem;
-  letter-spacing: 0.16em;
-  color: rgba(199, 218, 255, 0.75);
-}
-
-.map-chip__value {
-  font-size: clamp(1.1rem, 1.6vw, 1.6rem);
-  font-weight: 600;
-  color: #e8f1ff;
-}
-
-.map-chip__hint {
-  font-size: 0.85rem;
+.overlay-rotator__status {
+  margin: 0 auto;
+  padding: 8px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(109, 182, 255, 0.28);
+  background: rgba(5, 11, 24, 0.68);
   color: var(--text-muted);
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  backdrop-filter: blur(6px);
 }
 
 .rotating-card {
   flex: 1;
   position: relative;
-  border-radius: 24px;
-  background: var(--card-gradient);
+  border-radius: 28px;
+  background: rgba(7, 12, 26, 0.74);
   border: 1px solid var(--card-border);
   box-shadow: var(--card-shadow);
   overflow: hidden;
-  padding: clamp(20px, 2vw, 28px);
+  padding: clamp(24px, 2.6vw, 32px);
   display: flex;
   align-items: stretch;
   justify-content: center;
+  backdrop-filter: blur(18px);
+  pointer-events: none;
 }
 
 .rotating-card__content {
@@ -222,28 +169,6 @@ main {
 .rotating-card__content--hidden {
   opacity: 0;
   transform: scale(0.96);
-}
-
-.rotating-card__indicators {
-  position: absolute;
-  bottom: 18px;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  gap: 8px;
-}
-
-.rotating-card__indicator {
-  width: 12px;
-  height: 12px;
-  border-radius: 999px;
-  background: var(--indicator-idle);
-  transition: all 0.3s ease;
-}
-
-.rotating-card__indicator.is-active {
-  background: var(--indicator-active);
-  width: 32px;
 }
 
 .card {

--- a/dash-ui/src/types/maplibre-gl.d.ts
+++ b/dash-ui/src/types/maplibre-gl.d.ts
@@ -1,29 +1,36 @@
-export type LngLatLike = [number, number];
+declare module "maplibre-gl" {
+  export type LngLatLike = [number, number];
 
-export interface MapOptions {
-  container: string | HTMLElement;
-  style: StyleSpecification;
-  center?: LngLatLike;
-  zoom?: number;
-  bearing?: number;
-  pitch?: number;
-  interactive?: boolean;
-  attributionControl?: boolean;
-}
+  export interface MapOptions {
+    container: string | HTMLElement;
+    style: StyleSpecification;
+    center?: LngLatLike;
+    zoom?: number;
+    bearing?: number;
+    pitch?: number;
+    interactive?: boolean;
+    attributionControl?: boolean;
+  }
 
-export interface MapInstance {
-  resize(): void;
-  remove(): void;
-}
+  export interface MapInstance {
+    resize(): void;
+    remove(): void;
+  }
 
-export interface MapLibreGL {
-  Map: new (options: MapOptions) => MapInstance;
+  export interface MapLibreGL {
+    Map: new (options: MapOptions) => MapInstance;
+  }
+
+  export type StyleSpecification = Record<string, unknown>;
+
+  const loadMapLibre: () => Promise<MapLibreGL>;
+  export default loadMapLibre;
 }
 
 declare global {
   interface Window {
-    maplibregl?: MapLibreGL;
+    maplibregl?: import("maplibre-gl").MapLibreGL;
   }
 }
 
-export type StyleSpecification = Record<string, unknown>;
+export {};

--- a/dash-ui/src/vendor/maplibre-gl.ts
+++ b/dash-ui/src/vendor/maplibre-gl.ts
@@ -10,10 +10,7 @@ const ensureStylesheet = () => {
     return;
   }
 
-  const existingLink = document.querySelector<HTMLLinkElement>(
-    'link[data-maplibre-stylesheet="true"]'
-  );
-
+  const existingLink = document.querySelector<HTMLLinkElement>('link[data-maplibre-stylesheet="true"]');
   if (existingLink) {
     return;
   }
@@ -25,9 +22,9 @@ const ensureStylesheet = () => {
   document.head.appendChild(link);
 };
 
-export const loadMapLibre = (): Promise<MapLibreGL> => {
+const loadMapLibre = (): Promise<MapLibreGL> => {
   if (typeof window === "undefined") {
-    return Promise.reject(new Error("MapLibre can only be loaded in a browser environment"));
+    return Promise.reject(new Error("MapLibre solo está disponible en navegadores"));
   }
 
   if (window.maplibregl) {
@@ -49,11 +46,11 @@ export const loadMapLibre = (): Promise<MapLibreGL> => {
           return;
         }
 
-        reject(new Error("MapLibre script loaded but window.maplibregl is undefined"));
+        reject(new Error("MapLibre se cargó pero no está disponible en ventana"));
       });
 
       script.addEventListener("error", () => {
-        reject(new Error("No se pudo cargar la librería de mapas (MapLibre)"));
+        reject(new Error("No se pudo cargar la librería de MapLibre"));
       });
 
       document.head.appendChild(script);
@@ -63,6 +60,4 @@ export const loadMapLibre = (): Promise<MapLibreGL> => {
   return loaderPromise;
 };
 
-export const resetMapLibreLoaderForTests = () => {
-  loaderPromise = null;
-};
+export default loadMapLibre;

--- a/dash-ui/tsconfig.json
+++ b/dash-ui/tsconfig.json
@@ -11,6 +11,10 @@
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
     "moduleResolution": "Node",
+    "baseUrl": "./",
+    "paths": {
+      "maplibre-gl": ["src/vendor/maplibre-gl"]
+    },
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/dash-ui/vite.config.ts
+++ b/dash-ui/vite.config.ts
@@ -1,8 +1,15 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const maplibreEntry = new URL("./src/vendor/maplibre-gl.ts", import.meta.url).pathname;
+
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      "maplibre-gl": maplibreEntry
+    }
+  },
   server: {
     host: "0.0.0.0",
     port: 5173

--- a/etc/nginx/sites-available/pantalla-reloj.conf
+++ b/etc/nginx/sites-available/pantalla-reloj.conf
@@ -1,16 +1,22 @@
 server {
-  listen 80 default_server;
+  listen 80;
+  listen [::]:80;
   server_name _;
+
   root /var/www/html;
   index index.html;
 
   location /api/ {
-    proxy_pass http://127.0.0.1:8081/;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
+    proxy_pass         http://127.0.0.1:8081;
+    proxy_http_version 1.1;
+    proxy_set_header   Host $host;
+    proxy_set_header   X-Real-IP $remote_addr;
+    proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_read_timeout 60s;
   }
 
   location / {
-    try_files $uri $uri/ /index.html;
+    try_files $uri /index.html;
   }
 }


### PR DESCRIPTION
## Summary
- simplify the dashboard layout so the world map fills the card and a new OverlayRotator cycles the information cards while removing on-map HUD elements
- switch the map loader to the local MapLibre helper with updated defaults and styles for the overlay presentation
- harden configuration requests and UI messaging around the /api proxy and update the nginx site configuration accordingly

## Testing
- npm install --prefer-offline --loglevel info *(fails: npm error ENOTCACHED because the registry blocks new downloads in this environment)*
- npm run build *(fails: missing cached packages after install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68fe3897df2c83269c5e25165feccada