### PR TITLE
Refactor dashboard layout into map and sidebar

### DIFF
--- a/dash-ui/src/App.tsx
+++ b/dash-ui/src/App.tsx
@@ -3,13 +3,13 @@ import { Route, Routes } from "react-router-dom";
 
 import { ConfigProvider } from "./context/ConfigContext";
 import { ConfigPage } from "./pages/ConfigPage";
-import { DashboardPage } from "./pages/DashboardPage";
+import Index from "./pages/Index";
 
 const App: React.FC = () => {
   return (
     <ConfigProvider>
       <Routes>
-        <Route path="/" element={<DashboardPage />} />
+        <Route path="/" element={<Index />} />
         <Route path="/config" element={<ConfigPage />} />
       </Routes>
     </ConfigProvider>

--- a/dash-ui/src/components/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScopeMap.tsx
@@ -96,28 +96,25 @@ export const GeoScopeMap = ({ className, center, zoom = 1.6 }: GeoScopeMapProps)
     };
   }, [lat, lng, zoom]);
 
+  const classes = useMemo(() => {
+    return ["geo-scope-map", className].filter(Boolean).join(" ");
+  }, [className]);
+
   return (
-    <div className={["world-map", className].filter(Boolean).join(" ")}> 
-      <div ref={mapContainer} className="world-map__canvas" aria-hidden="true" />
-      <div className="absolute bottom-1 right-2 text-[10px] text-white/50">
-        © OpenStreetMap contributors
-      </div>
+    <div className={classes}>
       {error ? (
-        <div className="world-map__overlay" role="alert">
-          <div className="world-map__overlay-card">
-            <p>No se pudo cargar el mapa global.</p>
-            <p className="world-map__overlay-hint">{error}</p>
-          </div>
+        <div className="geo-scope-map__fallback" role="alert">
+          <p>No se pudo cargar el mapa global.</p>
+          <p className="geo-scope-map__hint">{error}</p>
         </div>
-      ) : null}
-      {!error && !isReady ? (
-        <div className="world-map__overlay" aria-live="polite">
-          <div className="world-map__overlay-card">
-            <p>Cargando el mapa global…</p>
-            <p className="world-map__overlay-hint">Conectando con MapLibre</p>
-          </div>
-        </div>
-      ) : null}
+      ) : (
+        <div
+          ref={mapContainer}
+          className="geo-scope-map__canvas"
+          aria-hidden={!isReady}
+          data-ready={isReady}
+        />
+      )}
     </div>
   );
 };

--- a/dash-ui/src/components/OverlayRotator.tsx
+++ b/dash-ui/src/components/OverlayRotator.tsx
@@ -19,10 +19,18 @@ export const OverlayRotator: React.FC<OverlayRotatorProps> = ({ cards, status, i
     return "datos no disponibles";
   }, [isLoading, status]);
 
+  const hasCards = cards.length > 0;
+
   return (
     <div className="overlay-rotator" role="complementary" aria-live="polite">
-      <div className="overlay-rotator__panel">
-        <RotatingCard cards={cards} />
+      <div className="overlay-rotator__content">
+        {hasCards ? (
+          <RotatingCard cards={cards} />
+        ) : (
+          <div className="overlay-rotator__fallback" role="status">
+            <p>Datos no disponibles</p>
+          </div>
+        )}
         <p className="overlay-rotator__status">{label}</p>
       </div>
     </div>

--- a/dash-ui/src/pages/Index.tsx
+++ b/dash-ui/src/pages/Index.tsx
@@ -99,7 +99,7 @@ const extractStrings = (value: unknown): string[] => {
   return [];
 };
 
-export const DashboardPage: React.FC = () => {
+export default function Index(): JSX.Element {
   const { config, loading } = useConfig();
   const [payload, setPayload] = useState<DashboardPayload>({});
   const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
@@ -277,13 +277,13 @@ export const DashboardPage: React.FC = () => {
   const overlayStatus = lastUpdatedLabel ? `Actualizado ${lastUpdatedLabel}` : "datos no disponibles";
 
   return (
-    <main className="dashboard-alt" aria-busy={loading}>
-      <section className="dashboard-alt__map" aria-label="Mapa global">
+    <div className="app-shell" aria-busy={loading}>
+      <div className="app-shell__map" aria-label="Mapa global">
         <GeoScopeMap />
+      </div>
+      <aside className="app-shell__aside" aria-label="Información rotatoria">
         <OverlayRotator cards={rotatingCards} status={overlayStatus} isLoading={loading && !lastUpdatedAt} />
-      </section>
-    </main>
+      </aside>
+    </div>
   );
-};
-
-export default DashboardPage;
+}

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -51,50 +51,52 @@ main {
   flex: 1;
 }
 
-.dashboard-alt {
-  position: relative;
+.app-shell {
   display: flex;
-  align-items: stretch;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  padding: clamp(16px, 2.8vw, 32px);
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
 }
 
-.dashboard-alt__map {
-  position: relative;
+
+.app-shell__map {
   flex: 1;
-  border-radius: clamp(20px, 3vw, 36px);
-  overflow: hidden;
-  background: var(--panel-bg);
-  border: 1px solid var(--panel-border);
-  box-shadow: var(--panel-glow);
+  min-width: 0;
   min-height: 0;
   height: 100%;
-}
-
-.world-map {
-  position: absolute;
-  inset: 0;
-}
-
-.world-map__canvas {
-  position: absolute;
-  inset: 0;
-}
-
-.world-map__overlay {
-  position: absolute;
-  inset: 0;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  backdrop-filter: blur(12px);
-  background: rgba(3, 6, 15, 0.65);
-  z-index: 1;
+  background: var(--panel-bg);
+  border-right: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-.world-map__overlay-card {
+.app-shell__aside {
+  width: 460px;
+  min-width: 400px;
+  max-width: 520px;
+  height: 100%;
+  flex-shrink: 0;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(14px);
+  pointer-events: none;
+  display: flex;
+}
+
+.geo-scope-map {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+}
+
+.geo-scope-map__canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.geo-scope-map__fallback {
+  margin: auto;
   padding: 24px 32px;
   border-radius: 20px;
   background: rgba(7, 12, 26, 0.9);
@@ -106,42 +108,68 @@ main {
   line-height: 1.5;
 }
 
-.world-map__overlay-card p {
+.geo-scope-map__fallback p {
   margin: 0 0 8px 0;
 }
 
-.world-map__overlay-hint {
+.geo-scope-map__hint {
   color: var(--accent);
   font-weight: 600;
 }
 
 .overlay-rotator {
-  position: absolute;
-  inset: clamp(24px, 4vw, 48px);
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.overlay-rotator__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.overlay-rotator__fallback {
+  flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
-  pointer-events: none;
-  z-index: 2;
+  border-radius: 28px;
+  border: 1px solid var(--card-border);
+  background: rgba(7, 12, 26, 0.74);
+  box-shadow: var(--card-shadow);
+  padding: 32px;
+  color: var(--text-muted);
+  text-align: center;
 }
 
-.overlay-rotator__panel {
-  width: min(720px, 85%);
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
+.overlay-rotator__fallback p {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .overlay-rotator__status {
-  margin: 0 auto;
-  padding: 8px 18px;
+  margin: 0;
+  padding: 10px 18px;
   border-radius: 999px;
   border: 1px solid rgba(109, 182, 255, 0.28);
   background: rgba(5, 11, 24, 0.68);
   color: var(--text-muted);
   font-size: 0.95rem;
   letter-spacing: 0.02em;
-  backdrop-filter: blur(6px);
+  align-self: flex-start;
+  margin-top: auto;
 }
 
 .rotating-card {
@@ -158,12 +186,14 @@ main {
   justify-content: center;
   backdrop-filter: blur(18px);
   pointer-events: none;
+  min-height: 0;
 }
 
 .rotating-card__content {
   flex: 1;
   transition: opacity 0.4s ease, transform 0.4s ease;
   display: flex;
+  min-height: 0;
 }
 
 .rotating-card__content--hidden {


### PR DESCRIPTION
## Summary
- refactor the main dashboard page to expose the map and rotating overlay as sibling columns with an aside container
- simplify the GeoScopeMap component to fill its column without additional overlays
- restyle the overlay rotator and supporting styles to occupy the fixed-width sidebar and provide a data fallback

## Testing
- npm run build *(fails: missing React/Day.js type declarations in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe43d433f8832682897db99e319f8e