### PR TITLE
Adjust map panel layout and prevent map duplication

### DIFF
--- a/dash-ui/src/components/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScopeMap.tsx
@@ -68,6 +68,10 @@ export const GeoScopeMap = ({ className, center, zoom = 1.6 }: GeoScopeMapProps)
         });
 
         mapRef.current = map;
+        const mapWithRenderCopies = map as MapInstance & {
+          setRenderWorldCopies?: (value: boolean) => MapInstance;
+        };
+        mapWithRenderCopies.setRenderWorldCopies?.(false);
         setIsReady(true);
         setError(null);
       } catch (err) {

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -70,9 +70,9 @@ main {
 }
 
 .app-shell__aside {
-  width: 460px;
-  min-width: 400px;
-  max-width: 520px;
+  width: 520px;
+  min-width: 440px;
+  max-width: 600px;
   height: 100%;
   flex-shrink: 0;
   border-left: 1px solid rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Summary
- widen the rotating information panel to give it more room
- prevent the global map from rendering repeated world copies when initializing MapLibre

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe4702da308326b9f23c699b04100f