### PR TITLE
Expand map layout and enhance dashboard cards

### DIFF
--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -52,6 +52,7 @@ main {
 }
 
 .app-shell {
+  position: relative;
   display: flex;
   width: 100vw;
   height: 100vh;
@@ -64,22 +65,29 @@ main {
   min-width: 0;
   min-height: 0;
   height: 100%;
+  width: 100%;
   display: flex;
   background: var(--panel-bg);
   border-right: 1px solid rgba(255, 255, 255, 0.04);
+  position: relative;
+  z-index: 0;
 }
 
 .app-shell__aside {
-  width: 520px;
-  min-width: 440px;
-  max-width: 600px;
-  height: 100%;
-  flex-shrink: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: clamp(520px, 34vw, 680px);
+  max-width: 100%;
   border-left: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(0, 0, 0, 0.35);
   backdrop-filter: blur(14px);
   pointer-events: none;
   display: flex;
+  padding: clamp(16px, 2.4vw, 32px);
+  box-sizing: border-box;
+  z-index: 1;
 }
 
 .geo-scope-map {
@@ -121,10 +129,10 @@ main {
   flex: 1;
   width: 100%;
   height: 100%;
-  padding: 24px;
+  padding: clamp(20px, 3vw, 40px);
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: clamp(20px, 2.6vw, 36px);
   pointer-events: none;
   overflow: hidden;
 }
@@ -133,7 +141,7 @@ main {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: clamp(20px, 2.2vw, 32px);
   min-height: 0;
   overflow: hidden;
 }
@@ -176,11 +184,11 @@ main {
   flex: 1;
   position: relative;
   border-radius: 28px;
-  background: rgba(7, 12, 26, 0.74);
+  background: rgba(7, 12, 26, 0.78);
   border: 1px solid var(--card-border);
   box-shadow: var(--card-shadow);
   overflow: hidden;
-  padding: clamp(24px, 2.6vw, 32px);
+  padding: clamp(28px, 3vw, 44px);
   display: flex;
   align-items: stretch;
   justify-content: center;
@@ -207,14 +215,14 @@ main {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
+  gap: clamp(18px, 2vw, 28px);
   color: var(--text-primary);
   text-align: center;
 }
 
 .card-icon {
-  width: clamp(44px, 4vw, 64px);
-  height: clamp(44px, 4vw, 64px);
+  width: clamp(56px, 5vw, 88px);
+  height: clamp(56px, 5vw, 88px);
   color: var(--accent);
 }
 
@@ -235,15 +243,15 @@ main {
 }
 
 .time-card__time {
-  font-size: clamp(2.2rem, 4.2vw, 3.6rem);
+  font-size: clamp(2.8rem, 5.6vw, 4.6rem);
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   margin: 0;
 }
 
 .time-card__date {
   margin: 0;
-  font-size: clamp(1rem, 1.6vw, 1.2rem);
+  font-size: clamp(1.1rem, 2vw, 1.5rem);
   color: var(--text-muted);
   text-transform: capitalize;
 }
@@ -386,7 +394,7 @@ main {
 
 .ephemerides-card {
   align-items: stretch;
-  gap: 20px;
+  gap: clamp(22px, 2vw, 32px);
 }
 
 .ephemerides-card__header {
@@ -397,31 +405,31 @@ main {
 
 .ephemerides-card__header h2 {
   margin: 0;
-  font-size: 1.6rem;
+  font-size: clamp(1.8rem, 2.8vw, 2.4rem);
 }
 
 .ephemerides-card__meta {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  gap: clamp(12px, 1.6vw, 20px);
   width: 100%;
-  font-size: 0.95rem;
+  font-size: clamp(1rem, 1.4vw, 1.25rem);
 }
 
 .ephemerides-card__meta div {
-  background: rgba(12, 18, 34, 0.7);
-  border-radius: 14px;
-  padding: 12px;
-  border: 1px solid rgba(104, 162, 255, 0.16);
+  background: rgba(12, 18, 34, 0.74);
+  border-radius: 16px;
+  padding: clamp(14px, 1.8vw, 24px);
+  border: 1px solid rgba(104, 162, 255, 0.18);
 }
 
 .ephemerides-card__label {
   display: block;
-  font-size: 0.75rem;
+  font-size: clamp(0.82rem, 1.1vw, 1rem);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--text-muted);
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 }
 
 .ephemerides-card__events {

--- a/dash-ui/src/vendor/maplibre-gl.ts
+++ b/dash-ui/src/vendor/maplibre-gl.ts
@@ -17,6 +17,9 @@ export interface MapOptions {
 export interface MapInstance {
   resize(): void;
   remove(): void;
+  once?(event: string, handler: (...args: unknown[]) => void): void;
+  on?(event: string, handler: (...args: unknown[]) => void): void;
+  off?(event: string, handler: (...args: unknown[]) => void): void;
 }
 
 export interface MapLibreGL {


### PR DESCRIPTION
## Summary
- overlay the sidebar so the global map spans the full viewport width
- keep world copies disabled even after style reloads to avoid duplicated globes
- scale up the time and ephemerides cards for better legibility on the landscape display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe48df502c8326a7d7ba3364e6c935