### PR TITLE
Replace MapLibre map with static map rendering

### DIFF
--- a/dash-ui/package-lock.json
+++ b/dash-ui/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2025.10.0",
       "dependencies": {
         "dayjs": "^1.11.10",
-        "maplibre-gl": "^3.6.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3"

--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "dayjs": "^1.11.10",
-    "maplibre-gl": "^3.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3"

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -86,9 +86,12 @@ main {
   align-items: stretch;
 }
 
-.geo-scope-map__canvas {
+.geo-scope-map__image {
   width: 100%;
   height: 100%;
+  object-fit: cover;
+  border-radius: 16px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
 }
 
 .geo-scope-map__attribution {


### PR DESCRIPTION
## Summary
- remove the MapLibre dependency from the dashboard UI
- replace the map component with a static OpenStreetMap image renderer that resizes with its container
- refresh the dashboard styling to match the new static map element

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe4eb62c808326a028d6af7eca192e