### PR TITLE
Implement MapLibre-based map layout and sidebar

### DIFF
--- a/dash-ui/package-lock.json
+++ b/dash-ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2025.10.0",
       "dependencies": {
         "dayjs": "^1.11.10",
+        "maplibre-gl": "^3.6.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3"

--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "dayjs": "^1.11.10",
+    "maplibre-gl": "^3.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3"

--- a/dash-ui/src/pages/Index.tsx
+++ b/dash-ui/src/pages/Index.tsx
@@ -1,17 +1,22 @@
-import React from "react";
-
-import { GeoScopeMap } from "../components/GeoScopeMap";
+import GeoScopeMap from "../components/GeoScopeMap";
 import { OverlayRotator } from "../components/OverlayRotator";
 
 export default function Index(): JSX.Element {
   return (
-    <div className="layout-root w-screen h-screen flex overflow-hidden bg-black text-white">
-      <div className="layout-map flex-1 h-full">
-        <GeoScopeMap />
+    <div className="w-screen h-screen overflow-hidden">
+      <div className="flex w-full h-full">
+        {/* Mapa (2/3) */}
+        <div id="map-column" className="h-full w-2/3 relative">
+          <GeoScopeMap />
+        </div>
+
+        {/* Panel lateral (1/3) */}
+        <aside
+          className="h-full w-1/3 min-w-[560px] max-w-[860px] border-l border-white/10 bg-black/35 backdrop-blur-sm"
+        >
+          <OverlayRotator />
+        </aside>
       </div>
-      <aside className="layout-aside h-full w-[460px] max-w-[520px] min-w-[400px] border-l border-white/10 bg-black/35 backdrop-blur-sm">
-        <OverlayRotator />
-      </aside>
     </div>
   );
 }

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -43,6 +43,103 @@ body {
   overflow: hidden;
 }
 
+.w-screen {
+  width: 100vw;
+}
+
+.h-screen {
+  height: 100vh;
+}
+
+.w-full {
+  width: 100%;
+}
+
+.h-full {
+  height: 100%;
+}
+
+.flex {
+  display: flex;
+}
+
+.relative {
+  position: relative;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.inset-0 {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.overflow-hidden {
+  overflow: hidden;
+}
+
+.w-2\/3 {
+  width: 66.6667%;
+}
+
+.w-1\/3 {
+  width: 33.3333%;
+}
+
+.min-w-\[560px\] {
+  min-width: 560px;
+}
+
+.max-w-\[860px\] {
+  max-width: 860px;
+}
+
+.border-l {
+  border-left-width: 1px;
+  border-left-style: solid;
+  border-left-color: currentColor;
+}
+
+.border-white\/10 {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.bg-black\/35 {
+  background-color: rgba(0, 0, 0, 0.35);
+}
+
+.backdrop-blur-sm {
+  backdrop-filter: blur(8px);
+}
+
+.pointer-events-none {
+  pointer-events: none;
+}
+
+.bottom-1 {
+  bottom: 0.25rem;
+}
+
+.left-2 {
+  left: 0.5rem;
+}
+
+.text-\[10px\] {
+  font-size: 10px;
+}
+
+.text-white\/50 {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+#map-column {
+  min-width: 0;
+}
+
 #root {
   display: flex;
 }


### PR DESCRIPTION
## Summary
- adjust the root page layout so the map fills two-thirds of the screen and the sidebar occupies the remaining third
- replace the static map component with a MapLibre-driven implementation using CARTO Voyager tiles and responsive padding
- add utility styles and declare the MapLibre dependency required for the updated map rendering

## Testing
- npm run build *(fails: maplibre-gl package download blocked by registry access restrictions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5023a70883269338703b4f33fddd