### PR TITLE
Replace MapLibre dependency with static map fallback

### DIFF
--- a/dash-ui/package-lock.json
+++ b/dash-ui/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2025.10.0",
       "dependencies": {
         "dayjs": "^1.11.10",
-        "maplibre-gl": "^3.6.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3"

--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "dayjs": "^1.11.10",
-    "maplibre-gl": "^3.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3"

--- a/dash-ui/src/components/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScopeMap.tsx
@@ -1,134 +1,103 @@
-import maplibregl, { type StyleSpecification } from "maplibre-gl";
-import "maplibre-gl/dist/maplibre-gl.css";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-const VOYAGER: StyleSpecification = {
-  version: 8,
-  sources: {
-    carto: {
-      type: "raster",
-      tiles: [
-        "https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png",
-        "https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png",
-        "https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
-      ],
-      tileSize: 256,
-      attribution:
-        '© OpenStreetMap contributors, © <a href="https://carto.com/attributions">CARTO</a>'
-    }
-  },
-  layers: [{ id: "carto", type: "raster", source: "carto" }]
-};
-
-const OSM_FALLBACK: StyleSpecification = {
-  version: 8,
-  sources: {
-    osm: {
-      type: "raster",
-      tiles: [
-        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      ],
-      tileSize: 256,
-      attribution: "© OpenStreetMap contributors"
-    }
-  },
-  layers: [{ id: "osm", type: "raster", source: "osm" }]
-};
-
+const VOYAGER_TILE_URL = "https://a.basemaps.cartocdn.com/rastertiles/voyager/0/0/0.png";
+const OSM_TILE_URL = "https://tile.openstreetmap.org/0/0/0.png";
 const FALLBACK_TIMEOUT = 8000;
 
 function GeoScopeMap(): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<maplibregl.Map | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const fallbackTimerRef = useRef<number | null>(null);
+  const [paddingRight, setPaddingRight] = useState(0);
+  const [imageSrc, setImageSrc] = useState<string>(VOYAGER_TILE_URL);
+
+  const clearFallbackTimer = useCallback(() => {
+    if (fallbackTimerRef.current !== null) {
+      window.clearTimeout(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
+    }
+  }, []);
+
+  const updatePadding = useCallback(() => {
+    const aside = document.querySelector("aside");
+    const padRight = aside instanceof HTMLElement ? aside.offsetWidth : 0;
+    setPaddingRight(padRight);
+  }, []);
 
   useEffect(() => {
-    if (!containerRef.current) {
-      return undefined;
-    }
-
-    let style: StyleSpecification = VOYAGER;
-
-    try {
-      // Voyager es el estilo principal; MapLibre gestionará errores de tiles automáticamente.
-      style = VOYAGER;
-    } catch {
-      style = OSM_FALLBACK;
-    }
-
-    const map = new maplibregl.Map({
-      container: containerRef.current,
-      style,
-      center: [0, 20],
-      zoom: 2.2,
-      bearing: 0,
-      pitch: 0,
-      interactive: false,
-      renderWorldCopies: true,
-      preserveDrawingBuffer: false
-    });
-
-    mapRef.current = map;
-
-    const updatePadding = () => {
-      const aside = document.querySelector("aside");
-      const padRight = aside instanceof HTMLElement ? aside.offsetWidth : 0;
-      map.setPadding({ top: 0, right: padRight, bottom: 0, left: 0 });
-    };
-
     updatePadding();
-
-    map.once("load", () => {
-      updatePadding();
-      map.resize();
-    });
 
     const handleResize = () => {
       updatePadding();
-      map.resize();
     };
 
-    if (typeof ResizeObserver !== "undefined") {
+    if (typeof ResizeObserver !== "undefined" && containerRef.current) {
       resizeObserverRef.current = new ResizeObserver(handleResize);
       resizeObserverRef.current.observe(containerRef.current);
     } else {
       window.addEventListener("resize", handleResize);
     }
 
-    fallbackTimerRef.current = window.setTimeout(() => {
-      if (mapRef.current && !map.areTilesLoaded()) {
-        mapRef.current.setStyle(OSM_FALLBACK);
-        mapRef.current.once("styledata", () => {
-          updatePadding();
-          mapRef.current?.resize();
-        });
-      }
-    }, FALLBACK_TIMEOUT);
-
     return () => {
-      if (fallbackTimerRef.current !== null) {
-        window.clearTimeout(fallbackTimerRef.current);
-        fallbackTimerRef.current = null;
-      }
-
       if (resizeObserverRef.current) {
         resizeObserverRef.current.disconnect();
         resizeObserverRef.current = null;
       } else {
         window.removeEventListener("resize", handleResize);
       }
-
-      mapRef.current = null;
-      map.remove();
     };
-  }, []);
+  }, [updatePadding]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const preload = new Image();
+    preload.onload = () => {
+      if (!cancelled) {
+        setImageSrc(VOYAGER_TILE_URL);
+        clearFallbackTimer();
+      }
+    };
+    preload.onerror = () => {
+      if (!cancelled) {
+        setImageSrc(OSM_TILE_URL);
+        clearFallbackTimer();
+      }
+    };
+    preload.src = VOYAGER_TILE_URL;
+
+    fallbackTimerRef.current = window.setTimeout(() => {
+      if (!cancelled) {
+        setImageSrc(OSM_TILE_URL);
+      }
+    }, FALLBACK_TIMEOUT);
+
+    return () => {
+      cancelled = true;
+      clearFallbackTimer();
+    };
+  }, [clearFallbackTimer]);
+
+  const handleImageError = useCallback(() => {
+    setImageSrc((current) => (current === OSM_TILE_URL ? current : OSM_TILE_URL));
+    clearFallbackTimer();
+  }, [clearFallbackTimer]);
 
   return (
     <div className="absolute inset-0">
-      <div ref={containerRef} className="w-full h-full" />
+      <div
+        ref={containerRef}
+        className="relative h-full w-full overflow-hidden"
+        style={{ paddingRight: `${paddingRight}px` }}
+      >
+        <img
+          src={imageSrc}
+          alt="Mapa mundial"
+          className="pointer-events-none h-full w-full select-none object-cover brightness-[0.75]"
+          onError={handleImageError}
+          draggable={false}
+        />
+      </div>
       <div className="pointer-events-none absolute bottom-1 left-2 text-[10px] text-white/50">
         © OpenStreetMap contributors · © CARTO
       </div>


### PR DESCRIPTION
## Summary
- remove the maplibre-gl dependency from the dashboard UI to keep the lockfile in sync
- reimplement the GeoScopeMap component with a static Voyager tile and OpenStreetMap fallback logic
- preserve responsive padding logic without relying on MapLibre APIs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fe526f5c448326ad3a0068a232568c