### PR TITLE
feat: update layout and map to maplibre

### DIFF
--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "dayjs": "^1.11.10",
+    "maplibre-gl": "^3.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3"

--- a/dash-ui/src/pages/Index.tsx
+++ b/dash-ui/src/pages/Index.tsx
@@ -3,18 +3,16 @@ import { OverlayRotator } from "../components/OverlayRotator";
 
 export default function Index(): JSX.Element {
   return (
-    <div className="w-screen h-screen overflow-hidden">
+    <div className="fixed inset-0">
       <div className="flex w-full h-full">
-        {/* Mapa (2/3) */}
-        <div id="map-column" className="h-full w-2/3 relative">
+        <div className="relative h-full w-2/3 overflow-hidden">
           <GeoScopeMap />
         </div>
 
-        {/* Panel lateral (1/3) */}
-        <aside
-          className="h-full w-1/3 min-w-[560px] max-w-[860px] border-l border-white/10 bg-black/35 backdrop-blur-sm"
-        >
-          <OverlayRotator />
+        <aside className="h-full w-1/3 shrink-0 grow-0 m-0 border-l border-white/10 bg-black/35 backdrop-blur-sm">
+          <div className="h-full w-full p-4">
+            <OverlayRotator />
+          </div>
         </aside>
       </div>
     </div>

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -71,6 +71,10 @@ body {
   position: absolute;
 }
 
+.fixed {
+  position: fixed;
+}
+
 .inset-0 {
   top: 0;
   right: 0;
@@ -88,6 +92,18 @@ body {
 
 .w-1\/3 {
   width: 33.3333%;
+}
+
+.shrink-0 {
+  flex-shrink: 0;
+}
+
+.grow-0 {
+  flex-grow: 0;
+}
+
+.m-0 {
+  margin: 0;
 }
 
 .min-w-\[560px\] {
@@ -114,6 +130,10 @@ body {
 
 .backdrop-blur-sm {
   backdrop-filter: blur(8px);
+}
+
+.p-4 {
+  padding: 1rem;
 }
 
 .pointer-events-none {


### PR DESCRIPTION
## Summary
- switch the dashboard layout to a fixed 2/3 map and 1/3 overlay panel without exterior gaps
- replace the static map image with a non-interactive MapLibre instance using the CARTO Voyager tiles and panoramic stretch
- extend the utility styles to support the new fixed layout spacing helpers

## Testing
- `npm install --no-audit --no-fund` *(fails: registry returns 403 for maplibre-gl)*
- `npm run build` *(fails: TypeScript cannot resolve maplibre-gl because install above failed)*

------
https://chatgpt.com/codex/tasks/task_e_68fe552990448326a46d42e2dfc161a7