### PR TITLE
Replace MapLibre map with static tile grid

### DIFF
--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "dayjs": "^1.11.10",
-    "maplibre-gl": "^3.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3"

--- a/dash-ui/src/components/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScopeMap.tsx
@@ -1,121 +1,138 @@
-import maplibregl from "maplibre-gl";
-import "maplibre-gl/dist/maplibre-gl.css";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
-const VOYAGER = {
-  version: 8,
-  sources: {
-    carto: {
-      type: "raster" as const,
-      tiles: [
-        "https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png",
-        "https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png",
-        "https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png",
-      ],
-      tileSize: 256,
-      attribution:
-        '© OpenStreetMap contributors, © <a href="https://carto.com/attributions">CARTO</a>',
-    },
-  },
-  layers: [{ id: "carto", type: "raster" as const, source: "carto" }],
+type TileDefinition = {
+  key: string;
+  x: number;
+  y: number;
+  primaryUrl: string;
+  fallbackUrl: string;
 };
 
-const OSM_FALLBACK = {
-  version: 8,
-  sources: {
-    osm: {
-      type: "raster" as const,
-      tiles: [
-        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png",
-      ],
-      tileSize: 256,
-      attribution: "© OpenStreetMap contributors",
-    },
-  },
-  layers: [{ id: "osm", type: "raster" as const, source: "osm" }],
-};
+const TILE_SIZE = 256;
+const ZOOM_LEVEL = 2;
+const TILE_COUNT = 2 ** ZOOM_LEVEL;
+const CARTO_HOSTS = ["a", "b", "c"] as const;
+const OSM_HOSTS = ["a", "b", "c"] as const;
+
+function buildVoyagerTile(x: number, y: number, hostIndex: number): string {
+  const host = CARTO_HOSTS[hostIndex % CARTO_HOSTS.length];
+  return `https://${host}.basemaps.cartocdn.com/rastertiles/voyager/${ZOOM_LEVEL}/${x}/${y}.png`;
+}
+
+function buildOsmTile(x: number, y: number, hostIndex: number): string {
+  const host = OSM_HOSTS[hostIndex % OSM_HOSTS.length];
+  return `https://${host}.tile.openstreetmap.org/${ZOOM_LEVEL}/${x}/${y}.png`;
+}
+
+function createTileMatrix(): TileDefinition[] {
+  const tiles: TileDefinition[] = [];
+  const tileTotal = TILE_COUNT;
+
+  for (let y = 0; y < tileTotal; y += 1) {
+    for (let x = 0; x < tileTotal; x += 1) {
+      const hostIndex = (x + y) % CARTO_HOSTS.length;
+      tiles.push({
+        key: `${x}-${y}`,
+        x,
+        y,
+        primaryUrl: buildVoyagerTile(x, y, hostIndex),
+        fallbackUrl: buildOsmTile(x, y, hostIndex),
+      });
+    }
+  }
+
+  return tiles;
+}
 
 export default function GeoScopeMap(): JSX.Element {
   const hostRef = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<maplibregl.Map | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const [paddingRight, setPaddingRight] = useState(0);
+  const [zoomScale, setZoomScale] = useState(1);
+
+  const tiles = useMemo(() => createTileMatrix(), []);
 
   useEffect(() => {
-    if (!hostRef.current) {
-      return;
-    }
-
-    let fallbackApplied = false;
-    const map = new maplibregl.Map({
-      container: hostRef.current,
-      style: VOYAGER,
-      center: [0, 20],
-      zoom: 2.2,
-      bearing: 0,
-      pitch: 0,
-      interactive: false,
-      renderWorldCopies: true,
-      preserveDrawingBuffer: false,
-    });
-
-    mapRef.current = map;
-
-    map.on("error", () => {
-      if (!fallbackApplied) {
-        fallbackApplied = true;
-        map.setStyle(OSM_FALLBACK);
-      }
-    });
-
-    const updatePadding = () => {
+    const updateLayout = () => {
       const aside = document.querySelector("aside");
       const padRight = aside instanceof HTMLElement ? aside.offsetWidth : 0;
-      map.setPadding({ top: 0, left: 0, bottom: 0, right: padRight });
+      setPaddingRight(padRight);
+
+      const ratio = window.innerWidth / Math.max(window.innerHeight, 1);
+      setZoomScale(ratio > 3.5 ? 1.15 : 1);
     };
 
-    updatePadding();
-
-    map.once("load", () => {
-      const canvas = map.getCanvas();
-      canvas.style.transformOrigin = "center center";
-      canvas.style.transform = "scaleX(1.8)";
-    });
-
-    const handleResize = () => {
-      updatePadding();
-      map.resize();
-
-      const ratio = window.innerWidth / window.innerHeight;
-      if (ratio > 3.5) {
-        map.setZoom(2.3);
-      } else {
-        map.setZoom(2.0);
-      }
-    };
+    updateLayout();
 
     if (typeof ResizeObserver !== "undefined" && hostRef.current) {
-      resizeObserverRef.current = new ResizeObserver(handleResize);
+      resizeObserverRef.current = new ResizeObserver(updateLayout);
       resizeObserverRef.current.observe(hostRef.current);
     } else {
-      window.addEventListener("resize", handleResize);
+      window.addEventListener("resize", updateLayout);
     }
 
     return () => {
       resizeObserverRef.current?.disconnect();
       resizeObserverRef.current = null;
       if (typeof ResizeObserver === "undefined") {
-        window.removeEventListener("resize", handleResize);
+        window.removeEventListener("resize", updateLayout);
       }
-      map.remove();
-      mapRef.current = null;
     };
   }, []);
 
+  const baseSize = TILE_SIZE * TILE_COUNT;
+  const transform = `translate(-50%, -50%) scaleX(${(1.8 * zoomScale).toFixed(3)}) scaleY(${zoomScale.toFixed(3)})`;
+
   return (
-    <div className="absolute inset-0 overflow-hidden">
-      <div ref={hostRef} className="w-full h-full" />
+    <div
+      ref={hostRef}
+      className="absolute inset-0 overflow-hidden"
+      style={{ paddingRight: `${paddingRight}px` }}
+    >
+      <div className="w-full h-full relative">
+        <div
+          className="absolute left-1/2 top-1/2"
+          style={{
+            width: `${baseSize}px`,
+            height: `${baseSize}px`,
+            transformOrigin: "center center",
+            transform,
+          }}
+        >
+          {tiles.map((tile) => (
+            <img
+              key={tile.key}
+              src={tile.primaryUrl}
+              data-fallback={tile.fallbackUrl}
+              data-tile={`${tile.x}:${tile.y}`}
+              alt="World map tile"
+              className="absolute"
+              loading="lazy"
+              style={{
+                width: `${TILE_SIZE}px`,
+                height: `${TILE_SIZE}px`,
+                left: `${tile.x * TILE_SIZE}px`,
+                top: `${tile.y * TILE_SIZE}px`,
+                imageRendering: "crisp-edges",
+              }}
+              onError={(event) => {
+                const img = event.currentTarget;
+                if (img.dataset.fallbackApplied === "true") {
+                  img.onerror = null;
+                  return;
+                }
+
+                img.dataset.fallbackApplied = "true";
+                if (img.dataset.fallback) {
+                  img.src = img.dataset.fallback;
+                } else {
+                  img.style.visibility = "hidden";
+                }
+              }}
+            />
+          ))}
+        </div>
+      </div>
       <div className="pointer-events-none absolute bottom-1 left-2 text-[10px] text-white/50">
         © OpenStreetMap contributors · © CARTO
       </div>


### PR DESCRIPTION
## Summary
- replace the MapLibre-based implementation with a custom static tile renderer so npm lockfile stays in sync
- keep the responsive padding and zoom behaviour by adjusting layout logic around the new tile grid

## Testing
- npm ci --no-audit --no-fund *(fails: npm registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe567b27a08326aafeab25c7ea16b0