### PR TITLE
Fix map style typing in GeoScope map

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -1,4 +1,5 @@
 import maplibregl from "maplibre-gl";
+import type { StyleSpecification } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useRef } from "react";
 
@@ -24,7 +25,7 @@ const VOYAGER = {
     }
   },
   layers: [{ id: "carto", type: "raster", source: "carto" }]
-} as const;
+} satisfies StyleSpecification;
 
 export default function GeoScopeMap() {
   const hostRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
## Summary
- type the Voyager style definition against MapLibre's StyleSpecification
- remove readonly assertions that caused compatibility issues with the map style option

## Testing
- npm run build *(fails: missing maplibre-gl dependency in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fe5e6ba4708326a4e1f1a345a766e9