### PR TITLE
Improve map initialization stability

### DIFF
--- a/dash-ui/src/pages/ConfigPage.tsx
+++ b/dash-ui/src/pages/ConfigPage.tsx
@@ -612,7 +612,7 @@ export const ConfigPage: React.FC = () => {
   };
 
   const apiStatusLabel =
-    apiOnline === null ? "API CHECKING" : apiOnline ? "API ONLINE" : "API OFFLINE";
+    apiOnline === null ? "API checking" : apiOnline ? "API online" : "API offline";
   const apiStatusClass =
     apiOnline === null ? " is-pending" : apiOnline ? " is-online" : " is-offline";
   const apiHint =
@@ -620,7 +620,7 @@ export const ConfigPage: React.FC = () => {
       ? "Comprobando el estado del backend…"
       : apiOnline
       ? "Conectado al backend."
-      : "No se pudo contactar con el backend. Revisa el proxy /api.";
+      : "API offline. No se pudo contactar con el backend (/api).";
 
   return (
     <div className="config-page">


### PR DESCRIPTION
## Summary
- tighten the MapLibre initialization to guard against oversized padding, observe container changes, and wait for the style before touching layers
- safely register the GeoScope overlay layers after the style loads and tear them down during cleanup
- surface an "API offline" status message when the backend health check fails on the config page

## Testing
- npm run build *(fails: missing `maplibre-gl`/`geojson` packages because the npm registry returned 403 in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fe6ed306188326a70f3fcec09a9a50