### PR TITLE
Fix GeoScope map sizing and initialization

### DIFF
--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -49,8 +49,10 @@ body {
   display: grid;
   grid-template-columns: 2fr 1fr;
   grid-template-rows: 100%;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
+  min-height: 100svh;
+  gap: 0;
 }
 
 .map-area {
@@ -59,6 +61,19 @@ body {
   min-height: 240px;
   position: relative;
   overflow: hidden;
+}
+
+.map-host {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+.map-area .maplibregl-map,
+.map-area .maplibregl-canvas,
+.map-area .maplibregl-canvas-container {
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .side-panel {


### PR DESCRIPTION
## Summary
- wait for the map host to report dimensions before creating the MapLibre instance and keep renderWorldCopies disabled with a safeFit fallback
- ensure safeFit always resizes/jumps to the cinematic view, logging a warning when fitBounds cannot run, and re-run it on load, idle, and resize events
- adjust the global layout styles so the map column fills 2/3 width at full height while MapLibre canvases stretch to their container and controls stay hidden

## Testing
- npm run build *(fails: existing project dependencies are unavailable because npm install is blocked with 403 Forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68ff71fd05048326a70050fb4995f9f5