### PR TITLE
Replace MapLibre with Leaflet for static GeoScope map

### DIFF
--- a/dash-ui/package-lock.json
+++ b/dash-ui/package-lock.json
@@ -9,11 +9,13 @@
       "version": "2025.10.0",
       "dependencies": {
         "dayjs": "^1.11.10",
+        "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.9",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react": "^4.2.1",

--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "dayjs": "^1.11.10",
-    "maplibre-gl": "^3.6.2",
+    "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3"
@@ -35,6 +35,7 @@
     "earcut": "2.2.4"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.9",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^4.2.1",

--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -1,6 +1,4 @@
-import maplibregl from "maplibre-gl";
-import type { StyleSpecification } from "maplibre-gl";
-import "maplibre-gl/dist/maplibre-gl.css";
+import L from "leaflet";
 import { useEffect, useRef } from "react";
 
 import AircraftLayer from "./layers/AircraftLayer";
@@ -10,57 +8,57 @@ import LightningLayer from "./layers/LightningLayer";
 import ShipsLayer from "./layers/ShipsLayer";
 import WeatherLayer from "./layers/WeatherLayer";
 
-const VOYAGER = {
-  version: 8,
-  sources: {
-    carto: {
-      type: "raster",
-      tiles: ["https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"],
-      tileSize: 256,
-      attribution: "© OpenStreetMap contributors, © CARTO"
-    }
-  },
-  layers: [{ id: "carto", type: "raster", source: "carto" }]
-} satisfies StyleSpecification;
+const FALLBACK_CENTER: L.LatLngExpression = [0, 0];
+const FALLBACK_ZOOM = 2;
 
 export default function GeoScopeMap() {
-  const hostRef = useRef<HTMLDivElement | null>(null);
   const mapFillRef = useRef<HTMLDivElement | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const registryRef = useRef<LayerRegistry | null>(null);
-  const mapRef = useRef<maplibregl.Map | null>(null);
-  const mapReadyRef = useRef(false);
+  const mapRef = useRef<L.Map | null>(null);
 
   useEffect(() => {
-    const host = mapFillRef.current;
-    if (!host) return;
+    const container = mapFillRef.current;
+    if (!container) return;
 
-    const defaultView = { center: [0, 0] as maplibregl.LngLatLike, zoom: 2 };
-    const worldBounds: maplibregl.LngLatBoundsLike = [
-      [-180, -85],
-      [180, 85]
-    ];
+    const createMap = () => {
+      if (mapRef.current) return;
 
-    const safeFit = (map: maplibregl.Map, hostElement: HTMLDivElement | null) => {
-      if (!hostElement) return;
+      const { width, height } = container.getBoundingClientRect();
+      if (width <= 0 || height <= 0) return;
 
-      const { width, height } = hostElement.getBoundingClientRect();
-      if (width <= 0 || height <= 0) {
-        return;
-      }
+      const map = L.map(container, {
+        zoomControl: false,
+        attributionControl: true,
+        dragging: false,
+        scrollWheelZoom: false,
+        doubleClickZoom: false,
+        boxZoom: false,
+        keyboard: false,
+        touchZoom: false,
+        worldCopyJump: false
+      });
 
-      map.resize();
-      map.jumpTo(defaultView);
+      mapRef.current = map;
+
+      L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png", {
+        subdomains: ["a", "b", "c"],
+        minZoom: 0,
+        maxZoom: 19,
+        noWrap: true,
+        continuousWorld: false,
+        attribution: "© OpenStreetMap contributors, © CARTO"
+      }).addTo(map);
 
       try {
-        map.fitBounds(worldBounds, { padding: 24, animate: false });
+        map.setView(FALLBACK_CENTER, FALLBACK_ZOOM);
       } catch (error) {
-        console.warn("[map] safeFit fallback", error);
-        map.jumpTo(defaultView);
+        console.warn("[GeoScopeMap] Failed to apply initial view, falling back", error);
+        map.setView(FALLBACK_CENTER, FALLBACK_ZOOM);
       }
-    };
 
-    const initLayers = (map: maplibregl.Map) => {
+      map.invalidateSize();
+
       const registry = new LayerRegistry(map);
       registryRef.current = registry;
 
@@ -81,76 +79,39 @@ export default function GeoScopeMap() {
       }
     };
 
-    const ensureMap = () => {
-      const container = mapFillRef.current;
-      if (mapRef.current || !container) {
-        return;
-      }
-
-      const { width, height } = container.getBoundingClientRect();
-      if (width <= 0 || height <= 0) {
-        return;
-      }
-
-      const map = new maplibregl.Map({
-        container,
-        style: VOYAGER,
-        center: defaultView.center,
-        zoom: defaultView.zoom,
-        pitch: 0,
-        bearing: 0,
-        interactive: false,
-        attributionControl: false,
-        renderWorldCopies: false,
-        maxBounds: worldBounds
-      });
-
-      mapRef.current = map;
-
-      map.on("load", () => {
-        mapReadyRef.current = true;
-        map.setRenderWorldCopies(false);
-        safeFit(map, mapFillRef.current);
-        initLayers(map);
-      });
-    };
-
-    resizeObserverRef.current = new ResizeObserver((entries) => {
+    const resizeObserver = new ResizeObserver((entries) => {
       const entry = entries[0];
-      const { width, height } = entry?.contentRect ?? host.getBoundingClientRect();
+      const { width, height } = entry?.contentRect ?? container.getBoundingClientRect();
 
       if (width <= 0 || height <= 0) {
         return;
       }
 
       if (!mapRef.current) {
-        ensureMap();
+        createMap();
         return;
       }
 
-      if (mapReadyRef.current && mapFillRef.current) {
-        safeFit(mapRef.current, mapFillRef.current);
-      } else {
-        mapRef.current.resize();
-      }
+      mapRef.current.invalidateSize();
     });
 
-    resizeObserverRef.current.observe(host);
-    ensureMap();
+    resizeObserver.observe(container);
+    resizeObserverRef.current = resizeObserver;
+
+    createMap();
 
     return () => {
-      resizeObserverRef.current?.disconnect();
+      resizeObserver.disconnect();
       resizeObserverRef.current = null;
       registryRef.current?.destroy();
       registryRef.current = null;
       mapRef.current?.remove();
       mapRef.current = null;
-      mapReadyRef.current = false;
     };
   }, []);
 
   return (
-    <div ref={hostRef} className="map-host">
+    <div className="map-host">
       <div ref={mapFillRef} className="map-fill" />
     </div>
   );

--- a/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
@@ -1,4 +1,4 @@
-import maplibregl from "maplibre-gl";
+import L from "leaflet";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
@@ -14,46 +14,40 @@ export default class AircraftLayer implements Layer {
   public readonly zIndex = 40;
 
   private enabled: boolean;
-  private map?: maplibregl.Map;
-  private readonly sourceId = "geoscope-aircraft-source";
+  private map?: L.Map;
+  private layer?: L.GeoJSON;
+  private paneName?: string;
 
   constructor(options: AircraftLayerOptions = {}) {
     this.enabled = options.enabled ?? false;
   }
 
-  add(map: maplibregl.Map): void {
+  add(map: L.Map): void {
     this.map = map;
-    if (!map.getSource(this.sourceId)) {
-      map.addSource(this.sourceId, {
-        type: "geojson",
-        data: EMPTY
-      });
-    }
+    const paneName = this.ensurePane(map);
 
-    if (!map.getLayer(this.id)) {
-      map.addLayer({
-        id: this.id,
-        type: "circle",
-        source: this.sourceId,
-        paint: {
-          "circle-radius": 4,
-          "circle-color": "#f97316",
-          "circle-stroke-color": "#111827",
-          "circle-stroke-width": 1
-        }
+    if (!this.layer) {
+      this.layer = L.geoJSON(EMPTY, {
+        pane: paneName,
+        pointToLayer: (_, latlng) =>
+          L.circleMarker(latlng, {
+            radius: 4,
+            color: "#f97316",
+            weight: 1,
+            fillColor: "#f97316",
+            fillOpacity: 0.8
+          })
       });
     }
 
     this.applyVisibility();
   }
 
-  remove(map: maplibregl.Map): void {
-    if (map.getLayer(this.id)) {
-      map.removeLayer(this.id);
+  remove(map: L.Map): void {
+    if (this.layer && map.hasLayer(this.layer)) {
+      map.removeLayer(this.layer);
     }
-    if (map.getSource(this.sourceId)) {
-      map.removeSource(this.sourceId);
-    }
+    this.removePane(map);
     this.map = undefined;
   }
 
@@ -63,14 +57,38 @@ export default class AircraftLayer implements Layer {
   }
 
   destroy(): void {
+    this.layer?.remove();
+    this.layer = undefined;
     this.map = undefined;
+    this.paneName = undefined;
   }
 
   private applyVisibility() {
-    if (!this.map) return;
-    const visibility = this.enabled ? "visible" : "none";
-    if (this.map.getLayer(this.id)) {
-      this.map.setLayoutProperty(this.id, "visibility", visibility);
+    if (!this.map || !this.layer) return;
+    const shouldShow = this.enabled;
+    if (shouldShow && !this.map.hasLayer(this.layer)) {
+      this.layer.addTo(this.map);
+    } else if (!shouldShow && this.map.hasLayer(this.layer)) {
+      this.map.removeLayer(this.layer);
     }
+  }
+
+  private ensurePane(map: L.Map) {
+    if (!this.paneName) {
+      const paneName = `${this.id}-pane`;
+      const pane = map.getPane(paneName) ?? map.createPane(paneName);
+      pane.style.zIndex = String(300 + this.zIndex);
+      this.paneName = paneName;
+    }
+    return this.paneName;
+  }
+
+  private removePane(map: L.Map) {
+    if (!this.paneName) return;
+    const pane = map.getPane(this.paneName);
+    if (pane?.parentElement) {
+      pane.parentElement.removeChild(pane);
+    }
+    this.paneName = undefined;
   }
 }

--- a/dash-ui/src/components/GeoScope/layers/LayerRegistry.ts
+++ b/dash-ui/src/components/GeoScope/layers/LayerRegistry.ts
@@ -1,19 +1,19 @@
-import maplibregl from "maplibre-gl";
+import type { Map as LeafletMap } from "leaflet";
 
 export interface Layer {
   id: string;
   zIndex: number;
-  add(map: maplibregl.Map): void;
-  remove(map: maplibregl.Map): void;
+  add(map: LeafletMap): void;
+  remove(map: LeafletMap): void;
   setEnabled?(on: boolean): void;
   destroy?(): void;
 }
 
 export class LayerRegistry {
-  private map: maplibregl.Map;
+  private map: LeafletMap;
   private layers: Layer[] = [];
 
-  constructor(map: maplibregl.Map) {
+  constructor(map: LeafletMap) {
     this.map = map;
   }
 

--- a/dash-ui/src/components/GeoScope/layers/LightningLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/LightningLayer.ts
@@ -1,4 +1,4 @@
-import maplibregl from "maplibre-gl";
+import L from "leaflet";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
@@ -14,46 +14,40 @@ export default class LightningLayer implements Layer {
   public readonly zIndex = 50;
 
   private enabled: boolean;
-  private map?: maplibregl.Map;
-  private readonly sourceId = "geoscope-lightning-source";
+  private map?: L.Map;
+  private layer?: L.GeoJSON;
+  private paneName?: string;
 
   constructor(options: LightningLayerOptions = {}) {
     this.enabled = options.enabled ?? true;
   }
 
-  add(map: maplibregl.Map): void {
+  add(map: L.Map): void {
     this.map = map;
-    if (!map.getSource(this.sourceId)) {
-      map.addSource(this.sourceId, {
-        type: "geojson",
-        data: EMPTY
-      });
-    }
+    const paneName = this.ensurePane(map);
 
-    if (!map.getLayer(this.id)) {
-      map.addLayer({
-        id: this.id,
-        type: "circle",
-        source: this.sourceId,
-        paint: {
-          "circle-radius": 6,
-          "circle-color": "#fcd34d",
-          "circle-opacity": 0.65,
-          "circle-blur": 0.35
-        }
+    if (!this.layer) {
+      this.layer = L.geoJSON(EMPTY, {
+        pane: paneName,
+        pointToLayer: (_, latlng) =>
+          L.circleMarker(latlng, {
+            radius: 6,
+            color: "#facc15",
+            weight: 0,
+            fillColor: "#facc15",
+            fillOpacity: 0.7
+          })
       });
     }
 
     this.applyVisibility();
   }
 
-  remove(map: maplibregl.Map): void {
-    if (map.getLayer(this.id)) {
-      map.removeLayer(this.id);
+  remove(map: L.Map): void {
+    if (this.layer && map.hasLayer(this.layer)) {
+      map.removeLayer(this.layer);
     }
-    if (map.getSource(this.sourceId)) {
-      map.removeSource(this.sourceId);
-    }
+    this.removePane(map);
     this.map = undefined;
   }
 
@@ -63,14 +57,38 @@ export default class LightningLayer implements Layer {
   }
 
   destroy(): void {
+    this.layer?.remove();
+    this.layer = undefined;
     this.map = undefined;
+    this.paneName = undefined;
   }
 
   private applyVisibility() {
-    if (!this.map) return;
-    const visibility = this.enabled ? "visible" : "none";
-    if (this.map.getLayer(this.id)) {
-      this.map.setLayoutProperty(this.id, "visibility", visibility);
+    if (!this.map || !this.layer) return;
+    const shouldShow = this.enabled;
+    if (shouldShow && !this.map.hasLayer(this.layer)) {
+      this.layer.addTo(this.map);
+    } else if (!shouldShow && this.map.hasLayer(this.layer)) {
+      this.map.removeLayer(this.layer);
     }
+  }
+
+  private ensurePane(map: L.Map) {
+    if (!this.paneName) {
+      const paneName = `${this.id}-pane`;
+      const pane = map.getPane(paneName) ?? map.createPane(paneName);
+      pane.style.zIndex = String(300 + this.zIndex);
+      this.paneName = paneName;
+    }
+    return this.paneName;
+  }
+
+  private removePane(map: L.Map) {
+    if (!this.paneName) return;
+    const pane = map.getPane(this.paneName);
+    if (pane?.parentElement) {
+      pane.parentElement.removeChild(pane);
+    }
+    this.paneName = undefined;
   }
 }

--- a/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
@@ -1,4 +1,4 @@
-import maplibregl from "maplibre-gl";
+import L from "leaflet";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
@@ -14,46 +14,40 @@ export default class ShipsLayer implements Layer {
   public readonly zIndex = 30;
 
   private enabled: boolean;
-  private map?: maplibregl.Map;
-  private readonly sourceId = "geoscope-ships-source";
+  private map?: L.Map;
+  private layer?: L.GeoJSON;
+  private paneName?: string;
 
   constructor(options: ShipsLayerOptions = {}) {
     this.enabled = options.enabled ?? false;
   }
 
-  add(map: maplibregl.Map): void {
+  add(map: L.Map): void {
     this.map = map;
-    if (!map.getSource(this.sourceId)) {
-      map.addSource(this.sourceId, {
-        type: "geojson",
-        data: EMPTY
-      });
-    }
+    const paneName = this.ensurePane(map);
 
-    if (!map.getLayer(this.id)) {
-      map.addLayer({
-        id: this.id,
-        type: "circle",
-        source: this.sourceId,
-        paint: {
-          "circle-radius": 4,
-          "circle-color": "#38bdf8",
-          "circle-stroke-color": "#0f172a",
-          "circle-stroke-width": 1
-        }
+    if (!this.layer) {
+      this.layer = L.geoJSON(EMPTY, {
+        pane: paneName,
+        pointToLayer: (_, latlng) =>
+          L.circleMarker(latlng, {
+            radius: 4,
+            color: "#38bdf8",
+            weight: 1,
+            fillColor: "#38bdf8",
+            fillOpacity: 0.85
+          })
       });
     }
 
     this.applyVisibility();
   }
 
-  remove(map: maplibregl.Map): void {
-    if (map.getLayer(this.id)) {
-      map.removeLayer(this.id);
+  remove(map: L.Map): void {
+    if (this.layer && map.hasLayer(this.layer)) {
+      map.removeLayer(this.layer);
     }
-    if (map.getSource(this.sourceId)) {
-      map.removeSource(this.sourceId);
-    }
+    this.removePane(map);
     this.map = undefined;
   }
 
@@ -63,14 +57,38 @@ export default class ShipsLayer implements Layer {
   }
 
   destroy(): void {
+    this.layer?.remove();
+    this.layer = undefined;
     this.map = undefined;
+    this.paneName = undefined;
   }
 
   private applyVisibility() {
-    if (!this.map) return;
-    const visibility = this.enabled ? "visible" : "none";
-    if (this.map.getLayer(this.id)) {
-      this.map.setLayoutProperty(this.id, "visibility", visibility);
+    if (!this.map || !this.layer) return;
+    const shouldShow = this.enabled;
+    if (shouldShow && !this.map.hasLayer(this.layer)) {
+      this.layer.addTo(this.map);
+    } else if (!shouldShow && this.map.hasLayer(this.layer)) {
+      this.map.removeLayer(this.layer);
     }
+  }
+
+  private ensurePane(map: L.Map) {
+    if (!this.paneName) {
+      const paneName = `${this.id}-pane`;
+      const pane = map.getPane(paneName) ?? map.createPane(paneName);
+      pane.style.zIndex = String(300 + this.zIndex);
+      this.paneName = paneName;
+    }
+    return this.paneName;
+  }
+
+  private removePane(map: L.Map) {
+    if (!this.paneName) return;
+    const pane = map.getPane(this.paneName);
+    if (pane?.parentElement) {
+      pane.parentElement.removeChild(pane);
+    }
+    this.paneName = undefined;
   }
 }

--- a/dash-ui/src/main.tsx
+++ b/dash-ui/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { HashRouter } from "react-router-dom";
 
 import App from "./App";
+import "leaflet/dist/leaflet.css";
 import "./styles/global.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -77,11 +77,9 @@ body {
   height: 100%;
 }
 
-.map-host .maplibregl-canvas-container,
-.map-host .maplibregl-canvas {
-  width: 100% !important;
-  height: 100% !important;
-  display: block;
+.map-host .leaflet-container {
+  width: 100%;
+  height: 100%;
 }
 
 .side-panel {


### PR DESCRIPTION
## Summary
- replace the MapLibre implementation with a Leaflet 1.9 map using CARTO Voyager raster tiles and ResizeObserver-based sizing
- update GeoScope overlay layer scaffolding to Leaflet GeoJSON layers with pane-based z-index handling and keep the cinematic, non-interactive behavior
- add Leaflet dependencies, import the core CSS, and adjust global styles to ensure the map column fills the dashboard grid

## Testing
- not run (npm registry access for new dependencies is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ff769cfac8832694b19aaf15fb2114