### PR TITLE
Avoid double-removing Leaflet layers during teardown

### DIFF
--- a/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
@@ -57,7 +57,6 @@ export default class AircraftLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
     this.layer = undefined;
     this.map = undefined;
     this.paneName = undefined;

--- a/dash-ui/src/components/GeoScope/layers/CyclonesLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/CyclonesLayer.ts
@@ -54,7 +54,6 @@ export default class CyclonesLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
     this.layer = undefined;
     this.map = undefined;
     this.paneName = undefined;

--- a/dash-ui/src/components/GeoScope/layers/LightningLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/LightningLayer.ts
@@ -57,7 +57,6 @@ export default class LightningLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
     this.layer = undefined;
     this.map = undefined;
     this.paneName = undefined;

--- a/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
@@ -57,7 +57,6 @@ export default class ShipsLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
     this.layer = undefined;
     this.map = undefined;
     this.paneName = undefined;

--- a/dash-ui/src/components/GeoScope/layers/WeatherLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/WeatherLayer.ts
@@ -55,7 +55,6 @@ export default class WeatherLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
     this.layer = undefined;
     this.map = undefined;
     this.paneName = undefined;


### PR DESCRIPTION
## Summary
- prevent GeoScope layer destroy methods from calling `remove()` after the layer registry has already detached them
- keep teardown limited to clearing references to avoid Leaflet runtime errors when the component unmounts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff7e8248b88326b123bfdec0499cdc