### PR TITLE
Restore MapLibre GeoScope map implementation

### DIFF
--- a/dash-ui/package-lock.json
+++ b/dash-ui/package-lock.json
@@ -9,13 +9,11 @@
       "version": "2025.10.0",
       "dependencies": {
         "dayjs": "^1.11.10",
-        "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
-        "@types/leaflet": "^1.9.9",
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@vitejs/plugin-react": "^4.2.1",

--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "dayjs": "^1.11.10",
-    "leaflet": "^1.9.4",
+    "maplibre-gl": "^3.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.22.3"
@@ -35,7 +35,6 @@
     "earcut": "2.2.4"
   },
   "devDependencies": {
-    "@types/leaflet": "^1.9.9",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^4.2.1",

--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -1,4 +1,6 @@
-import L from "leaflet";
+import maplibregl from "maplibre-gl";
+import type { StyleSpecification } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useRef } from "react";
 
 import AircraftLayer from "./layers/AircraftLayer";
@@ -8,57 +10,57 @@ import LightningLayer from "./layers/LightningLayer";
 import ShipsLayer from "./layers/ShipsLayer";
 import WeatherLayer from "./layers/WeatherLayer";
 
-const FALLBACK_CENTER: L.LatLngExpression = [0, 0];
-const FALLBACK_ZOOM = 2;
+const VOYAGER = {
+  version: 8,
+  sources: {
+    carto: {
+      type: "raster",
+      tiles: ["https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"],
+      tileSize: 256,
+      attribution: "© OpenStreetMap contributors, © CARTO"
+    }
+  },
+  layers: [{ id: "carto", type: "raster", source: "carto" }]
+} satisfies StyleSpecification;
 
 export default function GeoScopeMap() {
+  const hostRef = useRef<HTMLDivElement | null>(null);
   const mapFillRef = useRef<HTMLDivElement | null>(null);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const registryRef = useRef<LayerRegistry | null>(null);
-  const mapRef = useRef<L.Map | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const mapReadyRef = useRef(false);
 
   useEffect(() => {
-    const container = mapFillRef.current;
-    if (!container) return;
+    const host = mapFillRef.current;
+    if (!host) return;
 
-    const createMap = () => {
-      if (mapRef.current) return;
+    const defaultView = { center: [0, 0] as maplibregl.LngLatLike, zoom: 2 };
+    const worldBounds: maplibregl.LngLatBoundsLike = [
+      [-180, -85],
+      [180, 85]
+    ];
 
-      const { width, height } = container.getBoundingClientRect();
-      if (width <= 0 || height <= 0) return;
+    const safeFit = (map: maplibregl.Map, hostElement: HTMLDivElement | null) => {
+      if (!hostElement) return;
 
-      const map = L.map(container, {
-        zoomControl: false,
-        attributionControl: true,
-        dragging: false,
-        scrollWheelZoom: false,
-        doubleClickZoom: false,
-        boxZoom: false,
-        keyboard: false,
-        touchZoom: false,
-        worldCopyJump: false
-      });
-
-      mapRef.current = map;
-
-      L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png", {
-        subdomains: ["a", "b", "c"],
-        minZoom: 0,
-        maxZoom: 19,
-        noWrap: true,
-        continuousWorld: false,
-        attribution: "© OpenStreetMap contributors, © CARTO"
-      }).addTo(map);
-
-      try {
-        map.setView(FALLBACK_CENTER, FALLBACK_ZOOM);
-      } catch (error) {
-        console.warn("[GeoScopeMap] Failed to apply initial view, falling back", error);
-        map.setView(FALLBACK_CENTER, FALLBACK_ZOOM);
+      const { width, height } = hostElement.getBoundingClientRect();
+      if (width <= 0 || height <= 0) {
+        return;
       }
 
-      map.invalidateSize();
+      map.resize();
+      map.jumpTo(defaultView);
 
+      try {
+        map.fitBounds(worldBounds, { padding: 24, animate: false });
+      } catch (error) {
+        console.warn("[map] safeFit fallback", error);
+        map.jumpTo(defaultView);
+      }
+    };
+
+    const initLayers = (map: maplibregl.Map) => {
       const registry = new LayerRegistry(map);
       registryRef.current = registry;
 
@@ -79,39 +81,76 @@ export default function GeoScopeMap() {
       }
     };
 
-    const resizeObserver = new ResizeObserver((entries) => {
+    const ensureMap = () => {
+      const container = mapFillRef.current;
+      if (mapRef.current || !container) {
+        return;
+      }
+
+      const { width, height } = container.getBoundingClientRect();
+      if (width <= 0 || height <= 0) {
+        return;
+      }
+
+      const map = new maplibregl.Map({
+        container,
+        style: VOYAGER,
+        center: defaultView.center,
+        zoom: defaultView.zoom,
+        pitch: 0,
+        bearing: 0,
+        interactive: false,
+        attributionControl: false,
+        renderWorldCopies: false,
+        maxBounds: worldBounds
+      });
+
+      mapRef.current = map;
+
+      map.on("load", () => {
+        mapReadyRef.current = true;
+        map.setRenderWorldCopies(false);
+        safeFit(map, mapFillRef.current);
+        initLayers(map);
+      });
+    };
+
+    resizeObserverRef.current = new ResizeObserver((entries) => {
       const entry = entries[0];
-      const { width, height } = entry?.contentRect ?? container.getBoundingClientRect();
+      const { width, height } = entry?.contentRect ?? host.getBoundingClientRect();
 
       if (width <= 0 || height <= 0) {
         return;
       }
 
       if (!mapRef.current) {
-        createMap();
+        ensureMap();
         return;
       }
 
-      mapRef.current.invalidateSize();
+      if (mapReadyRef.current && mapFillRef.current) {
+        safeFit(mapRef.current, mapFillRef.current);
+      } else {
+        mapRef.current.resize();
+      }
     });
 
-    resizeObserver.observe(container);
-    resizeObserverRef.current = resizeObserver;
-
-    createMap();
+    resizeObserverRef.current.observe(host);
+    ensureMap();
 
     return () => {
-      resizeObserver.disconnect();
+      resizeObserverRef.current?.disconnect();
       resizeObserverRef.current = null;
       registryRef.current?.destroy();
       registryRef.current = null;
       mapRef.current?.remove();
       mapRef.current = null;
+      mapReadyRef.current = false;
     };
   }, []);
 
   return (
-    <div className="map-host">
+    <div ref={hostRef} className="map-host">
       <div ref={mapFillRef} className="map-fill" />
     </div>
   );

--- a/dash-ui/src/components/GeoScope/layers/CyclonesLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/CyclonesLayer.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import maplibregl from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
@@ -14,25 +14,31 @@ export default class CyclonesLayer implements Layer {
   public readonly zIndex = 20;
 
   private enabled: boolean;
-  private map?: L.Map;
-  private layer?: L.GeoJSON;
-  private paneName?: string;
+  private map?: maplibregl.Map;
+  private readonly sourceId = "geoscope-cyclones-source";
 
   constructor(options: CyclonesLayerOptions = {}) {
     this.enabled = options.enabled ?? false;
   }
 
-  add(map: L.Map): void {
+  add(map: maplibregl.Map): void {
     this.map = map;
-    const paneName = this.ensurePane(map);
+    if (!map.getSource(this.sourceId)) {
+      map.addSource(this.sourceId, {
+        type: "geojson",
+        data: EMPTY
+      });
+    }
 
-    if (!this.layer) {
-      this.layer = L.geoJSON(EMPTY, {
-        pane: paneName,
-        style: {
-          color: "#34d399",
-          weight: 2,
-          dashArray: "4 4"
+    if (!map.getLayer(this.id)) {
+      map.addLayer({
+        id: this.id,
+        type: "line",
+        source: this.sourceId,
+        paint: {
+          "line-color": "#34d399",
+          "line-width": 2,
+          "line-dasharray": [2, 2]
         }
       });
     }
@@ -40,11 +46,13 @@ export default class CyclonesLayer implements Layer {
     this.applyVisibility();
   }
 
-  remove(map: L.Map): void {
-    if (this.layer && map.hasLayer(this.layer)) {
-      map.removeLayer(this.layer);
+  remove(map: maplibregl.Map): void {
+    if (map.getLayer(this.id)) {
+      map.removeLayer(this.id);
     }
-    this.removePane(map);
+    if (map.getSource(this.sourceId)) {
+      map.removeSource(this.sourceId);
+    }
     this.map = undefined;
   }
 
@@ -54,38 +62,14 @@ export default class CyclonesLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
-    this.layer = undefined;
     this.map = undefined;
-    this.paneName = undefined;
   }
 
   private applyVisibility() {
-    if (!this.map || !this.layer) return;
-    const shouldShow = this.enabled;
-    if (shouldShow && !this.map.hasLayer(this.layer)) {
-      this.layer.addTo(this.map);
-    } else if (!shouldShow && this.map.hasLayer(this.layer)) {
-      this.map.removeLayer(this.layer);
+    if (!this.map) return;
+    const visibility = this.enabled ? "visible" : "none";
+    if (this.map.getLayer(this.id)) {
+      this.map.setLayoutProperty(this.id, "visibility", visibility);
     }
-  }
-
-  private ensurePane(map: L.Map) {
-    if (!this.paneName) {
-      const paneName = `${this.id}-pane`;
-      const pane = map.getPane(paneName) ?? map.createPane(paneName);
-      pane.style.zIndex = String(300 + this.zIndex);
-      this.paneName = paneName;
-    }
-    return this.paneName;
-  }
-
-  private removePane(map: L.Map) {
-    if (!this.paneName) return;
-    const pane = map.getPane(this.paneName);
-    if (pane?.parentElement) {
-      pane.parentElement.removeChild(pane);
-    }
-    this.paneName = undefined;
   }
 }

--- a/dash-ui/src/components/GeoScope/layers/LayerRegistry.ts
+++ b/dash-ui/src/components/GeoScope/layers/LayerRegistry.ts
@@ -1,19 +1,19 @@
-import type { Map as LeafletMap } from "leaflet";
+import maplibregl from "maplibre-gl";
 
 export interface Layer {
   id: string;
   zIndex: number;
-  add(map: LeafletMap): void;
-  remove(map: LeafletMap): void;
+  add(map: maplibregl.Map): void;
+  remove(map: maplibregl.Map): void;
   setEnabled?(on: boolean): void;
   destroy?(): void;
 }
 
 export class LayerRegistry {
-  private map: LeafletMap;
+  private map: maplibregl.Map;
   private layers: Layer[] = [];
 
-  constructor(map: LeafletMap) {
+  constructor(map: maplibregl.Map) {
     this.map = map;
   }
 

--- a/dash-ui/src/components/GeoScope/layers/LightningLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/LightningLayer.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import maplibregl from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
@@ -14,40 +14,46 @@ export default class LightningLayer implements Layer {
   public readonly zIndex = 50;
 
   private enabled: boolean;
-  private map?: L.Map;
-  private layer?: L.GeoJSON;
-  private paneName?: string;
+  private map?: maplibregl.Map;
+  private readonly sourceId = "geoscope-lightning-source";
 
   constructor(options: LightningLayerOptions = {}) {
     this.enabled = options.enabled ?? true;
   }
 
-  add(map: L.Map): void {
+  add(map: maplibregl.Map): void {
     this.map = map;
-    const paneName = this.ensurePane(map);
+    if (!map.getSource(this.sourceId)) {
+      map.addSource(this.sourceId, {
+        type: "geojson",
+        data: EMPTY
+      });
+    }
 
-    if (!this.layer) {
-      this.layer = L.geoJSON(EMPTY, {
-        pane: paneName,
-        pointToLayer: (_, latlng) =>
-          L.circleMarker(latlng, {
-            radius: 6,
-            color: "#facc15",
-            weight: 0,
-            fillColor: "#facc15",
-            fillOpacity: 0.7
-          })
+    if (!map.getLayer(this.id)) {
+      map.addLayer({
+        id: this.id,
+        type: "circle",
+        source: this.sourceId,
+        paint: {
+          "circle-radius": 6,
+          "circle-color": "#fcd34d",
+          "circle-opacity": 0.65,
+          "circle-blur": 0.35
+        }
       });
     }
 
     this.applyVisibility();
   }
 
-  remove(map: L.Map): void {
-    if (this.layer && map.hasLayer(this.layer)) {
-      map.removeLayer(this.layer);
+  remove(map: maplibregl.Map): void {
+    if (map.getLayer(this.id)) {
+      map.removeLayer(this.id);
     }
-    this.removePane(map);
+    if (map.getSource(this.sourceId)) {
+      map.removeSource(this.sourceId);
+    }
     this.map = undefined;
   }
 
@@ -57,38 +63,14 @@ export default class LightningLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
-    this.layer = undefined;
     this.map = undefined;
-    this.paneName = undefined;
   }
 
   private applyVisibility() {
-    if (!this.map || !this.layer) return;
-    const shouldShow = this.enabled;
-    if (shouldShow && !this.map.hasLayer(this.layer)) {
-      this.layer.addTo(this.map);
-    } else if (!shouldShow && this.map.hasLayer(this.layer)) {
-      this.map.removeLayer(this.layer);
+    if (!this.map) return;
+    const visibility = this.enabled ? "visible" : "none";
+    if (this.map.getLayer(this.id)) {
+      this.map.setLayoutProperty(this.id, "visibility", visibility);
     }
-  }
-
-  private ensurePane(map: L.Map) {
-    if (!this.paneName) {
-      const paneName = `${this.id}-pane`;
-      const pane = map.getPane(paneName) ?? map.createPane(paneName);
-      pane.style.zIndex = String(300 + this.zIndex);
-      this.paneName = paneName;
-    }
-    return this.paneName;
-  }
-
-  private removePane(map: L.Map) {
-    if (!this.paneName) return;
-    const pane = map.getPane(this.paneName);
-    if (pane?.parentElement) {
-      pane.parentElement.removeChild(pane);
-    }
-    this.paneName = undefined;
   }
 }

--- a/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import maplibregl from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
@@ -14,40 +14,46 @@ export default class ShipsLayer implements Layer {
   public readonly zIndex = 30;
 
   private enabled: boolean;
-  private map?: L.Map;
-  private layer?: L.GeoJSON;
-  private paneName?: string;
+  private map?: maplibregl.Map;
+  private readonly sourceId = "geoscope-ships-source";
 
   constructor(options: ShipsLayerOptions = {}) {
     this.enabled = options.enabled ?? false;
   }
 
-  add(map: L.Map): void {
+  add(map: maplibregl.Map): void {
     this.map = map;
-    const paneName = this.ensurePane(map);
+    if (!map.getSource(this.sourceId)) {
+      map.addSource(this.sourceId, {
+        type: "geojson",
+        data: EMPTY
+      });
+    }
 
-    if (!this.layer) {
-      this.layer = L.geoJSON(EMPTY, {
-        pane: paneName,
-        pointToLayer: (_, latlng) =>
-          L.circleMarker(latlng, {
-            radius: 4,
-            color: "#38bdf8",
-            weight: 1,
-            fillColor: "#38bdf8",
-            fillOpacity: 0.85
-          })
+    if (!map.getLayer(this.id)) {
+      map.addLayer({
+        id: this.id,
+        type: "circle",
+        source: this.sourceId,
+        paint: {
+          "circle-radius": 4,
+          "circle-color": "#38bdf8",
+          "circle-stroke-color": "#0f172a",
+          "circle-stroke-width": 1
+        }
       });
     }
 
     this.applyVisibility();
   }
 
-  remove(map: L.Map): void {
-    if (this.layer && map.hasLayer(this.layer)) {
-      map.removeLayer(this.layer);
+  remove(map: maplibregl.Map): void {
+    if (map.getLayer(this.id)) {
+      map.removeLayer(this.id);
     }
-    this.removePane(map);
+    if (map.getSource(this.sourceId)) {
+      map.removeSource(this.sourceId);
+    }
     this.map = undefined;
   }
 
@@ -57,38 +63,14 @@ export default class ShipsLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
-    this.layer = undefined;
     this.map = undefined;
-    this.paneName = undefined;
   }
 
   private applyVisibility() {
-    if (!this.map || !this.layer) return;
-    const shouldShow = this.enabled;
-    if (shouldShow && !this.map.hasLayer(this.layer)) {
-      this.layer.addTo(this.map);
-    } else if (!shouldShow && this.map.hasLayer(this.layer)) {
-      this.map.removeLayer(this.layer);
+    if (!this.map) return;
+    const visibility = this.enabled ? "visible" : "none";
+    if (this.map.getLayer(this.id)) {
+      this.map.setLayoutProperty(this.id, "visibility", visibility);
     }
-  }
-
-  private ensurePane(map: L.Map) {
-    if (!this.paneName) {
-      const paneName = `${this.id}-pane`;
-      const pane = map.getPane(paneName) ?? map.createPane(paneName);
-      pane.style.zIndex = String(300 + this.zIndex);
-      this.paneName = paneName;
-    }
-    return this.paneName;
-  }
-
-  private removePane(map: L.Map) {
-    if (!this.paneName) return;
-    const pane = map.getPane(this.paneName);
-    if (pane?.parentElement) {
-      pane.parentElement.removeChild(pane);
-    }
-    this.paneName = undefined;
   }
 }

--- a/dash-ui/src/components/GeoScope/layers/WeatherLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/WeatherLayer.ts
@@ -1,4 +1,4 @@
-import L from "leaflet";
+import maplibregl from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
@@ -14,26 +14,30 @@ export default class WeatherLayer implements Layer {
   public readonly zIndex = 10;
 
   private enabled: boolean;
-  private map?: L.Map;
-  private layer?: L.GeoJSON;
-  private paneName?: string;
+  private map?: maplibregl.Map;
+  private readonly sourceId = "geoscope-weather-source";
 
   constructor(options: WeatherLayerOptions = {}) {
     this.enabled = options.enabled ?? false;
   }
 
-  add(map: L.Map): void {
+  add(map: maplibregl.Map): void {
     this.map = map;
-    const paneName = this.ensurePane(map);
+    if (!map.getSource(this.sourceId)) {
+      map.addSource(this.sourceId, {
+        type: "geojson",
+        data: EMPTY
+      });
+    }
 
-    if (!this.layer) {
-      this.layer = L.geoJSON(EMPTY, {
-        pane: paneName,
-        style: {
-          color: "#60a5fa",
-          weight: 0,
-          fillColor: "#60a5fa",
-          fillOpacity: 0.25
+    if (!map.getLayer(this.id)) {
+      map.addLayer({
+        id: this.id,
+        type: "fill",
+        source: this.sourceId,
+        paint: {
+          "fill-color": "#60a5fa",
+          "fill-opacity": 0.25
         }
       });
     }
@@ -41,11 +45,13 @@ export default class WeatherLayer implements Layer {
     this.applyVisibility();
   }
 
-  remove(map: L.Map): void {
-    if (this.layer && map.hasLayer(this.layer)) {
-      map.removeLayer(this.layer);
+  remove(map: maplibregl.Map): void {
+    if (map.getLayer(this.id)) {
+      map.removeLayer(this.id);
     }
-    this.removePane(map);
+    if (map.getSource(this.sourceId)) {
+      map.removeSource(this.sourceId);
+    }
     this.map = undefined;
   }
 
@@ -55,38 +61,14 @@ export default class WeatherLayer implements Layer {
   }
 
   destroy(): void {
-    this.layer?.remove();
-    this.layer = undefined;
     this.map = undefined;
-    this.paneName = undefined;
   }
 
   private applyVisibility() {
-    if (!this.map || !this.layer) return;
-    const shouldShow = this.enabled;
-    if (shouldShow && !this.map.hasLayer(this.layer)) {
-      this.layer.addTo(this.map);
-    } else if (!shouldShow && this.map.hasLayer(this.layer)) {
-      this.map.removeLayer(this.layer);
+    if (!this.map) return;
+    const visibility = this.enabled ? "visible" : "none";
+    if (this.map.getLayer(this.id)) {
+      this.map.setLayoutProperty(this.id, "visibility", visibility);
     }
-  }
-
-  private ensurePane(map: L.Map) {
-    if (!this.paneName) {
-      const paneName = `${this.id}-pane`;
-      const pane = map.getPane(paneName) ?? map.createPane(paneName);
-      pane.style.zIndex = String(300 + this.zIndex);
-      this.paneName = paneName;
-    }
-    return this.paneName;
-  }
-
-  private removePane(map: L.Map) {
-    if (!this.paneName) return;
-    const pane = map.getPane(this.paneName);
-    if (pane?.parentElement) {
-      pane.parentElement.removeChild(pane);
-    }
-    this.paneName = undefined;
   }
 }

--- a/dash-ui/src/main.tsx
+++ b/dash-ui/src/main.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom/client";
 import { HashRouter } from "react-router-dom";
 
 import App from "./App";
-import "leaflet/dist/leaflet.css";
 import "./styles/global.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -77,9 +77,11 @@ body {
   height: 100%;
 }
 
-.map-host .leaflet-container {
-  width: 100%;
-  height: 100%;
+.map-host .maplibregl-canvas-container,
+.map-host .maplibregl-canvas {
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
 }
 
 .side-panel {


### PR DESCRIPTION
## Summary
- restore the GeoScope map component to use MapLibre with the Voyager basemap and constrained world bounds
- revert GeoScope overlay layers and registry helpers to their MapLibre-based implementations
- remove Leaflet dependencies and related styles from the dashboard bundle

## Testing
- npm install *(fails: npm not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ff8c7ea770832688fb792bdb886f13