### PR TITLE
fix: remove unsupported jumpTo option

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -60,8 +60,7 @@ export default function GeoScopeMap() {
         center: [lng, 0],
         zoom,
         bearing,
-        pitch,
-        animate: false
+        pitch
       });
     };
 
@@ -95,8 +94,7 @@ export default function GeoScopeMap() {
         center: [nextLng, 0],
         zoom: viewStateRef.current.zoom,
         bearing: viewStateRef.current.bearing,
-        pitch: viewStateRef.current.pitch,
-        animate: false
+        pitch: viewStateRef.current.pitch
       });
 
       animationFrameRef.current = requestAnimationFrame(stepPan);


### PR DESCRIPTION
## Summary
- remove the unsupported `animate` flag from `jumpTo` calls so the maplibre typings are satisfied

## Testing
- npm run build *(fails: missing local dependencies in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ff9da44b5883268db43a577b1002d0