### PR TITLE
feat: add MapFrame wrapper for map view

### DIFF
--- a/dash-ui/src/App.tsx
+++ b/dash-ui/src/App.tsx
@@ -2,15 +2,16 @@ import React from "react";
 import { Route, Routes } from "react-router-dom";
 
 import GeoScopeMap from "./components/GeoScope/GeoScopeMap";
+import MapFrame from "./components/MapFrame";
 import { RightPanel } from "./components/RightPanel";
 import { ConfigPage } from "./pages/ConfigPage";
 
 const DashboardShell: React.FC = () => {
   return (
     <div className="app-shell">
-      <div className="map-area">
+      <MapFrame className="map-area">
         <GeoScopeMap />
-      </div>
+      </MapFrame>
       <aside className="side-panel">
         <RightPanel />
       </aside>

--- a/dash-ui/src/components/MapFrame.tsx
+++ b/dash-ui/src/components/MapFrame.tsx
@@ -1,0 +1,23 @@
+import type { PropsWithChildren } from "react";
+
+import "../styles/map-frame.css";
+
+type MapFrameProps = PropsWithChildren<{
+  className?: string;
+}>;
+
+/**
+ * TODO: Explore alternate clipping strategies (e.g., SVG clipPath or CSS mask-image)
+ * if we ever need a more advanced pill shape or feathered edge treatment.
+ */
+export function MapFrame({ className, children }: MapFrameProps) {
+  const outerClassName = className ? `map-frame ${className}` : "map-frame";
+
+  return (
+    <div className={outerClassName}>
+      <div className="map-frame-inner">{children}</div>
+    </div>
+  );
+}
+
+export default MapFrame;

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -29,6 +29,8 @@
   --chip-shadow: 0 18px 42px rgba(0, 0, 0, 0.5);
   --success: #7dd3fc;
   --danger: #fca5a5;
+  --map-radius: 28px;
+  --map-frame-bg: #000000;
 }
 
 

--- a/dash-ui/src/styles/map-frame.css
+++ b/dash-ui/src/styles/map-frame.css
@@ -1,0 +1,14 @@
+.map-frame {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.map-frame-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border-radius: var(--map-radius);
+  background-color: var(--map-frame-bg);
+}


### PR DESCRIPTION
## Summary
- add a reusable MapFrame wrapper that applies the pill-style border radius while keeping the map canvas untouched
- expose theme variables `--map-radius` and `--map-frame-bg` in the global stylesheet for easy tuning
- wrap the dashboard map column with MapFrame without altering the existing MapLibre host elements

## Testing
- `npm install` *(fails: registry access to maplibre-gl is forbidden in this environment)*
- `npm run build` *(fails: TypeScript compile stops because dependencies like maplibre-gl/dayjs are unavailable without npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68ff9fc081308326bef991de497a8463