### PR TITLE
feat(map-cinema): longitudinal panning with 6-band tour

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -3,6 +3,19 @@ import type { MapLibreEvent, StyleSpecification } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useRef } from "react";
 
+import { apiGet } from "../../lib/api";
+import {
+  createDefaultMapCinema,
+  createDefaultMapSettings,
+  withConfigDefaults
+} from "../../config/defaults";
+import type {
+  AppConfig,
+  UIMapCinemaBand,
+  UIMapCinemaSettings,
+  UIMapSettings
+} from "../../types/config";
+
 const VOYAGER = {
   version: 8,
   sources: {
@@ -16,17 +29,80 @@ const VOYAGER = {
   layers: [{ id: "carto", type: "raster", source: "carto" }]
 } satisfies StyleSpecification;
 
+const FALLBACK_CINEMA = createDefaultMapCinema();
 const DEFAULT_VIEW = {
   lng: 0,
-  zoom: 2.4,
+  lat: FALLBACK_CINEMA.bands[0]?.lat ?? 0,
+  zoom: FALLBACK_CINEMA.bands[0]?.zoom ?? 2.6,
   bearing: 0,
-  pitch: 12
+  pitch: FALLBACK_CINEMA.bands[0]?.pitch ?? 0
 };
-
-const MIN_ZOOM = 2.2;
-const PAN_SPEED_DEG_PER_SEC = 0.25;
+const DEFAULT_MIN_ZOOM = FALLBACK_CINEMA.bands[0]?.minZoom ?? 2.4;
+const DEFAULT_PAN_SPEED = FALLBACK_CINEMA.panLngDegPerSec;
+const FPS_LIMIT = 45;
+const FRAME_MIN_INTERVAL_MS = 1000 / FPS_LIMIT;
+const MAX_DELTA_SECONDS = 0.5;
 
 const normalizeLng = (lng: number) => ((lng + 540) % 360) - 180;
+const lerp = (start: number, end: number, t: number) => start + (end - start) * t;
+const easeInOut = (t: number) =>
+  t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+
+const cloneCinema = (cinema: UIMapCinemaSettings): UIMapCinemaSettings => ({
+  ...cinema,
+  bands: cinema.bands.map((band) => ({ ...band }))
+});
+
+type TransitionState = {
+  from: UIMapCinemaBand;
+  to: UIMapCinemaBand;
+  toIndex: number;
+  duration: number;
+  elapsed: number;
+};
+
+type RuntimePreferences = {
+  cinema: UIMapCinemaSettings;
+  renderWorldCopies: boolean;
+  initialLng: number;
+};
+
+const buildRuntimePreferences = (mapSettings?: UIMapSettings): RuntimePreferences => {
+  const defaults = createDefaultMapSettings();
+  const source = mapSettings ?? defaults;
+  const cinemaSource = source.cinema ?? defaults.cinema ?? createDefaultMapCinema();
+  const cinema = cloneCinema(cinemaSource);
+  cinema.enabled = true;
+
+  const centerLngCandidate = Array.isArray(source.center)
+    ? source.center[0]
+    : defaults.center[0];
+  const initialLng = normalizeLng(
+    Number.isFinite(Number(centerLngCandidate))
+      ? Number(centerLngCandidate)
+      : defaults.center[0]
+  );
+
+  return {
+    cinema,
+    renderWorldCopies: source.renderWorldCopies ?? defaults.renderWorldCopies ?? true,
+    initialLng
+  };
+};
+
+const loadRuntimePreferences = async (): Promise<RuntimePreferences> => {
+  try {
+    const config = await apiGet<AppConfig>("/config");
+    const merged = withConfigDefaults(config);
+    return buildRuntimePreferences(merged.ui.map);
+  } catch (error) {
+    console.warn(
+      "[GeoScopeMap] Falling back to default cinema configuration (using defaults).",
+      error
+    );
+    return buildRuntimePreferences(createDefaultMapSettings());
+  }
+};
 
 export default function GeoScopeMap() {
   const mapFillRef = useRef<HTMLDivElement | null>(null);
@@ -36,7 +112,131 @@ export default function GeoScopeMap() {
   const lastFrameTimeRef = useRef<number | null>(null);
   const dprMediaRef = useRef<MediaQueryList | null>(null);
   const viewStateRef = useRef({ ...DEFAULT_VIEW });
-  const panSpeedRef = useRef(PAN_SPEED_DEG_PER_SEC);
+  const currentMinZoomRef = useRef(DEFAULT_MIN_ZOOM);
+  const panSpeedRef = useRef(DEFAULT_PAN_SPEED);
+  const cinemaRef = useRef<UIMapCinemaSettings>(cloneCinema(FALLBACK_CINEMA));
+  const bandIndexRef = useRef(0);
+  const bandElapsedRef = useRef(0);
+  const bandTransitionRef = useRef<TransitionState | null>(null);
+
+  const applyBandInstant = (band: UIMapCinemaBand, map?: maplibregl.Map | null) => {
+    viewStateRef.current.lat = band.lat;
+    viewStateRef.current.zoom = band.zoom;
+    viewStateRef.current.pitch = band.pitch;
+    currentMinZoomRef.current = band.minZoom;
+
+    const target = map ?? mapRef.current;
+    if (target) {
+      target.setMinZoom(band.minZoom);
+    }
+  };
+
+  const finishTransition = (map: maplibregl.Map | null) => {
+    const state = bandTransitionRef.current;
+    if (!state) return;
+
+    applyBandInstant(state.to, map ?? mapRef.current);
+    bandIndexRef.current = state.toIndex;
+    bandElapsedRef.current = 0;
+    bandTransitionRef.current = null;
+  };
+
+  const startTransition = (nextIndex: number) => {
+    const cinema = cinemaRef.current;
+    if (!cinema.bands.length) return;
+
+    const totalBands = cinema.bands.length;
+    const currentIndex = ((bandIndexRef.current % totalBands) + totalBands) % totalBands;
+    const targetIndex = ((nextIndex % totalBands) + totalBands) % totalBands;
+
+    const fromBand = cinema.bands[currentIndex];
+    const toBand = cinema.bands[targetIndex];
+    if (!fromBand || !toBand) {
+      return;
+    }
+
+    const duration = Math.max(0.1, cinema.bandTransition_sec);
+    bandTransitionRef.current = {
+      from: fromBand,
+      to: toBand,
+      toIndex: targetIndex,
+      duration,
+      elapsed: 0
+    };
+
+    const minZoom = Math.min(fromBand.minZoom, toBand.minZoom);
+    currentMinZoomRef.current = minZoom;
+    const map = mapRef.current;
+    if (map) {
+      map.setMinZoom(minZoom);
+    }
+  };
+
+  const advanceTransition = (deltaSeconds: number): number => {
+    const state = bandTransitionRef.current;
+    if (!state) return deltaSeconds;
+
+    const targetElapsed = state.elapsed + deltaSeconds;
+    const clampedElapsed = Math.min(targetElapsed, state.duration);
+    state.elapsed = clampedElapsed;
+
+    const progress = state.duration > 0 ? clampedElapsed / state.duration : 1;
+    const eased = easeInOut(Math.min(progress, 1));
+
+    viewStateRef.current.lat = lerp(state.from.lat, state.to.lat, eased);
+    viewStateRef.current.zoom = lerp(state.from.zoom, state.to.zoom, eased);
+    viewStateRef.current.pitch = lerp(state.from.pitch, state.to.pitch, eased);
+
+    if (progress >= 1) {
+      finishTransition(mapRef.current);
+      const leftover = targetElapsed - state.duration;
+      return leftover > 0 ? leftover : 0;
+    }
+
+    return 0;
+  };
+
+  const updateBandState = (deltaSeconds: number) => {
+    const cinema = cinemaRef.current;
+    if (!cinema.bands.length) return;
+
+    if (bandTransitionRef.current) {
+      const leftover = advanceTransition(deltaSeconds);
+      if (leftover > 0) {
+        updateBandState(leftover);
+      }
+      return;
+    }
+
+    const totalBands = cinema.bands.length;
+    const currentIndex = ((bandIndexRef.current % totalBands) + totalBands) % totalBands;
+    const currentBand = cinema.bands[currentIndex];
+    const newElapsed = bandElapsedRef.current + deltaSeconds;
+
+    if (newElapsed >= currentBand.duration_sec) {
+      bandElapsedRef.current = currentBand.duration_sec;
+      const overshoot = newElapsed - currentBand.duration_sec;
+      const nextIndex = (currentIndex + 1) % totalBands;
+      startTransition(nextIndex);
+      const leftover = advanceTransition(overshoot);
+      if (leftover > 0) {
+        updateBandState(leftover);
+      }
+    } else {
+      bandElapsedRef.current = newElapsed;
+      applyBandInstant(currentBand);
+    }
+  };
+
+  const updateMapView = (map: maplibregl.Map) => {
+    const { lng, lat, zoom, pitch, bearing } = viewStateRef.current;
+    map.jumpTo({
+      center: [lng, lat],
+      zoom,
+      pitch,
+      bearing
+    });
+  };
 
   useEffect(() => {
     let destroyed = false;
@@ -55,13 +255,8 @@ export default function GeoScopeMap() {
       }
 
       map.resize();
-      const { lng, zoom, bearing, pitch } = viewStateRef.current;
-      map.jumpTo({
-        center: [lng, 0],
-        zoom,
-        bearing,
-        pitch
-      });
+      map.setMinZoom(currentMinZoomRef.current);
+      updateMapView(map);
     };
 
     const stopPan = () => {
@@ -79,23 +274,32 @@ export default function GeoScopeMap() {
         return;
       }
 
-      if (lastFrameTimeRef.current == null) {
+      const lastFrame = lastFrameTimeRef.current;
+      if (lastFrame == null) {
         lastFrameTimeRef.current = timestamp;
+        animationFrameRef.current = requestAnimationFrame(stepPan);
+        return;
       }
 
-      const elapsedSeconds = (timestamp - lastFrameTimeRef.current) / 1000;
+      const deltaMs = timestamp - lastFrame;
+      if (deltaMs < FRAME_MIN_INTERVAL_MS) {
+        animationFrameRef.current = requestAnimationFrame(stepPan);
+        return;
+      }
+
       lastFrameTimeRef.current = timestamp;
 
-      const deltaLng = panSpeedRef.current * elapsedSeconds;
-      const nextLng = normalizeLng(viewStateRef.current.lng + deltaLng);
-      viewStateRef.current.lng = nextLng;
+      let elapsedSeconds = deltaMs / 1000;
+      if (elapsedSeconds > MAX_DELTA_SECONDS) {
+        elapsedSeconds = MAX_DELTA_SECONDS;
+      }
 
-      map.jumpTo({
-        center: [nextLng, 0],
-        zoom: viewStateRef.current.zoom,
-        bearing: viewStateRef.current.bearing,
-        pitch: viewStateRef.current.pitch
-      });
+      updateBandState(elapsedSeconds);
+
+      const deltaLng = panSpeedRef.current * elapsedSeconds;
+      viewStateRef.current.lng = normalizeLng(viewStateRef.current.lng + deltaLng);
+
+      updateMapView(map);
 
       animationFrameRef.current = requestAnimationFrame(stepPan);
     };
@@ -174,7 +378,9 @@ export default function GeoScopeMap() {
       safeFit();
     };
 
-    const handleContextLost = (event: MapLibreEvent & { originalEvent?: WebGLContextEvent }) => {
+    const handleContextLost = (
+      event: MapLibreEvent & { originalEvent?: WebGLContextEvent }
+    ) => {
       event.originalEvent?.preventDefault();
       safeFit();
     };
@@ -193,33 +399,52 @@ export default function GeoScopeMap() {
     };
 
     const initializeMap = async () => {
-      const host = await waitForStableSize();
+      const hostPromise = waitForStableSize();
+      const runtime = await loadRuntimePreferences();
+      const host = await hostPromise;
+
       if (!host || destroyed || mapRef.current) return;
+
+      const cinemaSettings = cloneCinema(runtime.cinema);
+      const firstBand = cinemaSettings.bands[0] ?? FALLBACK_CINEMA.bands[0];
+      if (!firstBand) {
+        return;
+      }
+
+      cinemaRef.current = cinemaSettings;
+      panSpeedRef.current = cinemaSettings.panLngDegPerSec;
+      bandIndexRef.current = 0;
+      bandElapsedRef.current = 0;
+      bandTransitionRef.current = null;
+
+      viewStateRef.current.lng = runtime.initialLng;
+      applyBandInstant(firstBand, null);
+      viewStateRef.current.pitch = firstBand.pitch;
+      viewStateRef.current.bearing = 0;
 
       const map = new maplibregl.Map({
         container: host,
         style: VOYAGER,
-        center: [viewStateRef.current.lng, 0],
+        center: [viewStateRef.current.lng, viewStateRef.current.lat],
         zoom: viewStateRef.current.zoom,
-        minZoom: MIN_ZOOM,
+        minZoom: firstBand.minZoom,
         pitch: viewStateRef.current.pitch,
         bearing: viewStateRef.current.bearing,
         interactive: false,
         attributionControl: false,
-        renderWorldCopies: true,
+        renderWorldCopies: runtime.renderWorldCopies,
         trackResize: false
       });
 
       mapRef.current = map;
+      map.setMinZoom(firstBand.minZoom);
 
       map.on("load", handleLoad);
       map.on("styledata", handleStyleData);
       map.on("webglcontextlost", handleContextLost);
       map.on("webglcontextrestored", handleContextRestored);
 
-      if (host) {
-        setupResizeObserver(host);
-      }
+      setupResizeObserver(host);
 
       if (window.matchMedia) {
         const media = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
@@ -230,7 +455,7 @@ export default function GeoScopeMap() {
       document.addEventListener("visibilitychange", handleVisibilityChange);
     };
 
-    initializeMap();
+    void initializeMap();
 
     return () => {
       destroyed = true;

--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -1,10 +1,101 @@
 import type {
   AppConfig,
   DisplayModule,
+  UIMapCinemaBand,
+  UIMapCinemaSettings,
+  UIMapSettings,
   UISettings,
   UIScrollSettings,
   UIScrollSpeed,
 } from "../types/config";
+
+const sanitizeNumber = (value: unknown, fallback: number): number => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+};
+
+const sanitizePositive = (value: unknown, fallback: number, min = 0): number => {
+  const numeric = sanitizeNumber(value, fallback);
+  return numeric > min ? numeric : fallback;
+};
+
+const sanitizeNonNegative = (value: unknown, fallback: number): number => {
+  const numeric = sanitizeNumber(value, fallback);
+  return numeric >= 0 ? numeric : fallback;
+};
+
+const CINEMA_BANDS_PRESET: readonly UIMapCinemaBand[] = [
+  { lat: 0, zoom: 2.6, pitch: 10, minZoom: 2.4, duration_sec: 900 },
+  { lat: 18, zoom: 2.8, pitch: 8, minZoom: 2.6, duration_sec: 720 },
+  { lat: 32, zoom: 3.1, pitch: 6, minZoom: 2.9, duration_sec: 600 },
+  { lat: 42, zoom: 3.4, pitch: 6, minZoom: 3.2, duration_sec: 480 },
+  { lat: -18, zoom: 2.8, pitch: 8, minZoom: 2.6, duration_sec: 720 },
+  { lat: -32, zoom: 3.1, pitch: 6, minZoom: 2.9, duration_sec: 600 }
+];
+
+export const createDefaultMapCinema = (): UIMapCinemaSettings => ({
+  enabled: true,
+  panLngDegPerSec: 0.3,
+  bands: CINEMA_BANDS_PRESET.map((band) => ({ ...band })),
+  bandTransition_sec: 8
+});
+
+export const createDefaultMapSettings = (): UIMapSettings => ({
+  engine: "maplibre",
+  provider: "carto",
+  center: [0, 0],
+  zoom: 2.6,
+  interactive: false,
+  controls: false,
+  renderWorldCopies: true,
+  cinema: createDefaultMapCinema()
+});
+
+const mergeCinema = (cinema?: UIMapCinemaSettings): UIMapCinemaSettings => {
+  const defaults = createDefaultMapCinema();
+  if (!cinema) {
+    return createDefaultMapCinema();
+  }
+
+  const bands = defaults.bands.map((fallback, index) => {
+    const candidate = cinema.bands?.[index];
+    return {
+      lat: sanitizeNumber(candidate?.lat, fallback.lat),
+      zoom: sanitizeNumber(candidate?.zoom, fallback.zoom),
+      pitch: sanitizeNumber(candidate?.pitch, fallback.pitch),
+      minZoom: sanitizeNonNegative(candidate?.minZoom, fallback.minZoom),
+      duration_sec: sanitizePositive(candidate?.duration_sec, fallback.duration_sec)
+    } as UIMapCinemaBand;
+  });
+
+  return {
+    enabled: cinema.enabled ?? defaults.enabled,
+    panLngDegPerSec: sanitizePositive(cinema.panLngDegPerSec, defaults.panLngDegPerSec),
+    bands,
+    bandTransition_sec: sanitizePositive(cinema.bandTransition_sec, defaults.bandTransition_sec)
+  };
+};
+
+const mergeMapSettings = (map?: UIMapSettings): UIMapSettings => {
+  const defaults = createDefaultMapSettings();
+  const source = map ?? defaults;
+  const center = source.center ?? defaults.center;
+  const sanitizedCenter: [number, number] = [
+    sanitizeNumber(center?.[0], defaults.center[0]),
+    sanitizeNumber(center?.[1], defaults.center[1])
+  ];
+
+  return {
+    engine: source.engine ?? defaults.engine,
+    provider: source.provider ?? defaults.provider,
+    center: sanitizedCenter,
+    zoom: sanitizeNumber(source.zoom, defaults.zoom),
+    interactive: source.interactive ?? defaults.interactive,
+    controls: source.controls ?? defaults.controls,
+    renderWorldCopies: source.renderWorldCopies ?? defaults.renderWorldCopies,
+    cinema: mergeCinema(source.cinema)
+  };
+};
 
 const createDefaultModules = (): DisplayModule[] => [
   { name: "clock", enabled: true, duration_seconds: 20 },
@@ -31,13 +122,7 @@ export const UI_DEFAULTS: UISettings = {
     clock: { format: "HH:mm" },
     temperature: { unit: "C" }
   },
-  map: {
-    provider: "osm",
-    center: [0, 20],
-    zoom: 1.6,
-    interactive: false,
-    controls: false
-  },
+  map: createDefaultMapSettings(),
   text: {
     scroll: createScrollDefaults()
   }
@@ -153,10 +238,7 @@ export const withConfigDefaults = (payload?: Partial<AppConfig>): AppConfig => {
           ...(payload.ui?.fixed?.temperature ?? {})
         }
       },
-      map: {
-        ...UI_DEFAULTS.map,
-        ...(payload.ui?.map ?? {})
-      },
+      map: mergeMapSettings(payload.ui?.map),
       text: mergedScroll,
       layout: payload.ui?.layout,
       side_panel: payload.ui?.side_panel,

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -62,12 +62,30 @@ export type UIRotationSettings = {
   panels: string[];
 };
 
+export type UIMapCinemaBand = {
+  lat: number;
+  zoom: number;
+  pitch: number;
+  minZoom: number;
+  duration_sec: number;
+};
+
+export type UIMapCinemaSettings = {
+  enabled: boolean;
+  panLngDegPerSec: number;
+  bands: UIMapCinemaBand[];
+  bandTransition_sec: number;
+};
+
 export type UIMapSettings = {
+  engine?: string;
   provider: string;
   center: [number, number];
   zoom: number;
   interactive: boolean;
   controls: boolean;
+  renderWorldCopies?: boolean;
+  cinema?: UIMapCinemaSettings;
 };
 
 export type UISettings = {


### PR DESCRIPTION
## Summary
- load cinema map settings from /api/config when available and drive a six-band longitudinal tour with smooth inter-band transitions and capped frame pacing
- preserve the existing size-lock behaviour while keeping horizontal panning continuous across world copies and pausing/resuming with page visibility
- extend map configuration defaults and types with MapLibre/CARTO cinema presets, per-band minZoom, and renderWorldCopies support

## Testing
- npm run build *(fails: missing npm dependencies because the registry returned 403 during npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68ffa6333e4c83268b3f64be70322168