### PR TITLE
feat(map-style): vector tiles with JSON style + raster fallback; theming tokens and band zoom upgrades (future-proof)

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -1,7 +1,7 @@
 import maplibregl from "maplibre-gl";
-import type { MapLibreEvent, StyleSpecification } from "maplibre-gl";
+import type { MapLibreEvent } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { apiGet } from "../../lib/api";
 import {
@@ -13,21 +13,14 @@ import type {
   AppConfig,
   UIMapCinemaBand,
   UIMapCinemaSettings,
-  UIMapSettings
+  UIMapSettings,
+  UIMapThemeSettings
 } from "../../types/config";
-
-const VOYAGER = {
-  version: 8,
-  sources: {
-    carto: {
-      type: "raster",
-      tiles: ["https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"],
-      tileSize: 256,
-      attribution: "© OpenStreetMap contributors, © CARTO"
-    }
-  },
-  layers: [{ id: "carto", type: "raster", source: "carto" }]
-} satisfies StyleSpecification;
+import {
+  loadMapStyle,
+  type MapStyleDefinition,
+  type MapStyleResult
+} from "./mapStyle";
 
 const FALLBACK_CINEMA = createDefaultMapCinema();
 const DEFAULT_VIEW = {
@@ -42,6 +35,145 @@ const DEFAULT_PAN_SPEED = FALLBACK_CINEMA.panLngDegPerSec;
 const FPS_LIMIT = 45;
 const FRAME_MIN_INTERVAL_MS = 1000 / FPS_LIMIT;
 const MAX_DELTA_SECONDS = 0.5;
+
+const FALLBACK_THEME = createDefaultMapSettings().theme ?? {};
+
+const cloneTheme = (theme?: UIMapThemeSettings | null): UIMapThemeSettings => ({
+  ...FALLBACK_THEME,
+  ...(theme ?? {})
+});
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const setPaintProperty = (
+  map: maplibregl.Map,
+  layerId: string,
+  property: string,
+  value: unknown
+) => {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!map.getLayer(layerId)) {
+    return;
+  }
+  try {
+    map.setPaintProperty(layerId, property, value);
+  } catch {
+    // TODO: The active style may not expose this property; ignore silently.
+  }
+};
+
+const applyVectorTheme = (map: maplibregl.Map, theme: UIMapThemeSettings) => {
+  const sea = theme.sea ?? undefined;
+  const land = theme.land ?? undefined;
+  const label = theme.label ?? undefined;
+  const contrast = typeof theme.contrast === "number" ? theme.contrast : undefined;
+
+  if (sea) {
+    const waterFillLayers = [
+      "water",
+      "water-depth",
+      "water-pattern",
+      "water-shadow",
+      "ocean",
+      "sea",
+      "lake",
+      "reservoir",
+      "river",
+      "river-canal"
+    ];
+    const waterLineLayers = ["waterway", "waterway-other", "water-boundary"];
+
+    // TODO: extend this list if the upstream style adds or renames hydro layers.
+    for (const layerId of waterFillLayers) {
+      setPaintProperty(map, layerId, "fill-color", sea);
+    }
+    for (const layerId of waterLineLayers) {
+      setPaintProperty(map, layerId, "line-color", sea);
+    }
+  }
+
+  if (land) {
+    const landFillLayers = [
+      "background",
+      "land",
+      "landcover",
+      "landcover-ice",
+      "landcover-wood",
+      "landuse",
+      "landuse-residential",
+      "park",
+      "park-outline",
+      "national-park"
+    ];
+
+    // TODO: keep layer mappings in sync with the active base style revisions.
+    for (const layerId of landFillLayers) {
+      setPaintProperty(map, layerId, layerId === "background" ? "background-color" : "fill-color", land);
+    }
+  }
+
+  if (label) {
+    const labelLayers = [
+      "place-label",
+      "settlement-major-label",
+      "settlement-minor-label",
+      "state-label",
+      "country-label",
+      "marine-label",
+      "airport-label",
+      "road-label",
+      "road-number-shield",
+      "poi-label",
+      "natural-point-label",
+      "water-label"
+    ];
+
+    // TODO: widen coverage for specialised label layers when styles evolve.
+    for (const layerId of labelLayers) {
+      setPaintProperty(map, layerId, "text-color", label);
+      setPaintProperty(map, layerId, "icon-color", label);
+    }
+  }
+
+  if (contrast !== undefined) {
+    const opacity = clamp(0.7 + contrast * 0.6, 0.2, 1);
+    const landOpacityLayers = [
+      "landcover",
+      "landcover-wood",
+      "landuse",
+      "park",
+      "national-park"
+    ];
+    for (const layerId of landOpacityLayers) {
+      setPaintProperty(map, layerId, "fill-opacity", opacity);
+    }
+  }
+};
+
+const applyRasterTheme = (map: maplibregl.Map, theme: UIMapThemeSettings) => {
+  const contrast = typeof theme.contrast === "number" ? clamp(theme.contrast, -0.5, 0.5) : 0;
+
+  setPaintProperty(map, "carto", "raster-contrast", contrast);
+  setPaintProperty(map, "carto", "raster-saturation", 0);
+  setPaintProperty(map, "carto", "raster-brightness-min", clamp(0.6 - contrast * 0.4, 0, 1.5));
+  setPaintProperty(map, "carto", "raster-brightness-max", clamp(1.3 + contrast * 0.4, 0.5, 2));
+};
+
+const applyThemeToMap = (
+  map: maplibregl.Map,
+  styleType: MapStyleDefinition["type"],
+  theme: UIMapThemeSettings
+) => {
+  if (styleType === "vector") {
+    applyVectorTheme(map, theme);
+    return;
+  }
+
+  applyRasterTheme(map, theme);
+};
 
 const normalizeLng = (lng: number) => ((lng + 540) % 360) - 180;
 const lerp = (start: number, end: number, t: number) => start + (end - start) * t;
@@ -65,9 +197,16 @@ type RuntimePreferences = {
   cinema: UIMapCinemaSettings;
   renderWorldCopies: boolean;
   initialLng: number;
+  style: MapStyleDefinition;
+  fallbackStyle: MapStyleDefinition;
+  styleWasFallback: boolean;
+  theme: UIMapThemeSettings;
 };
 
-const buildRuntimePreferences = (mapSettings?: UIMapSettings): RuntimePreferences => {
+const buildRuntimePreferences = (
+  mapSettings: UIMapSettings,
+  styleResult: MapStyleResult
+): RuntimePreferences => {
   const defaults = createDefaultMapSettings();
   const source = mapSettings ?? defaults;
   const cinemaSource = source.cinema ?? defaults.cinema ?? createDefaultMapCinema();
@@ -86,7 +225,11 @@ const buildRuntimePreferences = (mapSettings?: UIMapSettings): RuntimePreference
   return {
     cinema,
     renderWorldCopies: source.renderWorldCopies ?? defaults.renderWorldCopies ?? true,
-    initialLng
+    initialLng,
+    style: styleResult.resolved,
+    fallbackStyle: styleResult.fallback,
+    styleWasFallback: styleResult.usedFallback,
+    theme: cloneTheme(source.theme)
   };
 };
 
@@ -94,13 +237,17 @@ const loadRuntimePreferences = async (): Promise<RuntimePreferences> => {
   try {
     const config = await apiGet<AppConfig>("/config");
     const merged = withConfigDefaults(config);
-    return buildRuntimePreferences(merged.ui.map);
+    const mapSettings = merged.ui.map;
+    const styleResult = await loadMapStyle(mapSettings);
+    return buildRuntimePreferences(mapSettings, styleResult);
   } catch (error) {
     console.warn(
       "[GeoScopeMap] Falling back to default cinema configuration (using defaults).",
       error
     );
-    return buildRuntimePreferences(createDefaultMapSettings());
+    const fallbackSettings = createDefaultMapSettings();
+    const styleResult = await loadMapStyle(fallbackSettings);
+    return buildRuntimePreferences(fallbackSettings, styleResult);
   }
 };
 
@@ -118,6 +265,11 @@ export default function GeoScopeMap() {
   const bandIndexRef = useRef(0);
   const bandElapsedRef = useRef(0);
   const bandTransitionRef = useRef<TransitionState | null>(null);
+  const themeRef = useRef<UIMapThemeSettings>(cloneTheme(null));
+  const styleTypeRef = useRef<MapStyleDefinition["type"]>("raster");
+  const fallbackStyleRef = useRef<MapStyleDefinition | null>(null);
+  const fallbackAppliedRef = useRef(false);
+  const [tintColor, setTintColor] = useState<string | null>(null);
 
   const applyBandInstant = (band: UIMapCinemaBand, map?: maplibregl.Map | null) => {
     viewStateRef.current.lat = band.lat;
@@ -241,6 +393,8 @@ export default function GeoScopeMap() {
   useEffect(() => {
     let destroyed = false;
     let sizeCheckFrame: number | null = null;
+    let styleErrorHandler: ((event: MapLibreEvent & { error?: unknown }) => void) | null =
+      null;
 
     const safeFit = () => {
       const map = mapRef.current;
@@ -368,6 +522,10 @@ export default function GeoScopeMap() {
     };
 
     const handleLoad = () => {
+      const map = mapRef.current;
+      if (map) {
+        applyThemeToMap(map, styleTypeRef.current, themeRef.current);
+      }
       safeFit();
       if (document.visibilityState === "visible") {
         startPan();
@@ -375,6 +533,10 @@ export default function GeoScopeMap() {
     };
 
     const handleStyleData = () => {
+      const map = mapRef.current;
+      if (map) {
+        applyThemeToMap(map, styleTypeRef.current, themeRef.current);
+      }
       safeFit();
     };
 
@@ -401,6 +563,11 @@ export default function GeoScopeMap() {
     const initializeMap = async () => {
       const hostPromise = waitForStableSize();
       const runtime = await loadRuntimePreferences();
+
+      if (destroyed) {
+        return;
+      }
+
       const host = await hostPromise;
 
       if (!host || destroyed || mapRef.current) return;
@@ -422,9 +589,24 @@ export default function GeoScopeMap() {
       viewStateRef.current.pitch = firstBand.pitch;
       viewStateRef.current.bearing = 0;
 
+      themeRef.current = cloneTheme(runtime.theme);
+      styleTypeRef.current = runtime.style.type;
+      fallbackStyleRef.current = runtime.fallbackStyle;
+      fallbackAppliedRef.current =
+        runtime.styleWasFallback || runtime.style.type !== "vector";
+
+      if (!destroyed) {
+        const tintCandidate = runtime.theme?.tint ?? null;
+        if (typeof tintCandidate === "string" && tintCandidate.trim().length > 0) {
+          setTintColor(tintCandidate);
+        } else {
+          setTintColor(null);
+        }
+      }
+
       const map = new maplibregl.Map({
         container: host,
-        style: VOYAGER,
+        style: runtime.style.style,
         center: [viewStateRef.current.lng, viewStateRef.current.lat],
         zoom: viewStateRef.current.zoom,
         minZoom: firstBand.minZoom,
@@ -439,10 +621,64 @@ export default function GeoScopeMap() {
       mapRef.current = map;
       map.setMinZoom(firstBand.minZoom);
 
+      const applyFallbackStyle = (reason?: unknown) => {
+        if (fallbackAppliedRef.current) {
+          return;
+        }
+        const fallbackStyle = fallbackStyleRef.current;
+        if (!fallbackStyle) {
+          return;
+        }
+        fallbackAppliedRef.current = true;
+        styleTypeRef.current = fallbackStyle.type;
+        console.warn("[map] vector style failed, using raster fallback", reason);
+        map.setStyle(fallbackStyle.style);
+      };
+
+      styleErrorHandler = (event: MapLibreEvent & { error?: unknown }) => {
+        if (styleTypeRef.current !== "vector" || fallbackAppliedRef.current) {
+          return;
+        }
+        const error = event.error as
+          | {
+              status?: number;
+              message?: string;
+              error?: unknown;
+            }
+          | undefined;
+        const innerError = (error?.error as { status?: number; message?: string }) ?? undefined;
+        const statusCandidate =
+          typeof error?.status === "number"
+            ? error.status
+            : typeof innerError?.status === "number"
+            ? innerError.status
+            : undefined;
+        const messageCandidate =
+          typeof error?.message === "string"
+            ? error.message
+            : typeof innerError?.message === "string"
+            ? innerError.message
+            : "";
+        if (typeof statusCandidate === "number" && statusCandidate >= 400) {
+          applyFallbackStyle(error);
+          return;
+        }
+        if (
+          messageCandidate &&
+          /style/i.test(messageCandidate) &&
+          /fail|unauthorized|forbidden|error/i.test(messageCandidate)
+        ) {
+          applyFallbackStyle(error);
+        }
+      };
+
       map.on("load", handleLoad);
       map.on("styledata", handleStyleData);
       map.on("webglcontextlost", handleContextLost);
       map.on("webglcontextrestored", handleContextRestored);
+      if (styleErrorHandler) {
+        map.on("error", styleErrorHandler);
+      }
 
       setupResizeObserver(host);
 
@@ -484,6 +720,10 @@ export default function GeoScopeMap() {
         map.off("styledata", handleStyleData);
         map.off("webglcontextlost", handleContextLost);
         map.off("webglcontextrestored", handleContextRestored);
+        if (styleErrorHandler) {
+          map.off("error", styleErrorHandler);
+          styleErrorHandler = null;
+        }
         map.remove();
         mapRef.current = null;
       }
@@ -493,6 +733,9 @@ export default function GeoScopeMap() {
   return (
     <div className="map-host">
       <div ref={mapFillRef} className="map-fill" />
+      {tintColor ? (
+        <div className="map-tint" style={{ background: tintColor }} aria-hidden="true" />
+      ) : null}
     </div>
   );
 }

--- a/dash-ui/src/components/GeoScope/mapStyle.ts
+++ b/dash-ui/src/components/GeoScope/mapStyle.ts
@@ -1,0 +1,162 @@
+import type { StyleSpecification } from "maplibre-gl";
+
+import type { UIMapSettings } from "../../types/config";
+
+const CARTO_ATTRIBUTION = "© OpenStreetMap contributors, © CARTO";
+const CARTO_DARK_TILES = "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png";
+const CARTO_LIGHT_TILES = "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
+
+export type MapStyleVariant = "dark" | "light" | "bright";
+
+export type MapStyleDefinition = {
+  type: "vector" | "raster";
+  style: StyleSpecification;
+  variant: MapStyleVariant;
+  name: string;
+};
+
+export type MapStyleResult = {
+  resolved: MapStyleDefinition;
+  fallback: MapStyleDefinition;
+  usedFallback: boolean;
+};
+
+const determineVariant = (styleName: string): MapStyleVariant => {
+  const normalized = styleName.toLowerCase();
+  if (normalized.includes("bright")) {
+    return "bright";
+  }
+  if (normalized.includes("light")) {
+    return "light";
+  }
+  return "dark";
+};
+
+const getFallbackTiles = (variant: MapStyleVariant): string => {
+  if (variant === "dark") {
+    return CARTO_DARK_TILES;
+  }
+  return CARTO_LIGHT_TILES;
+};
+
+const createCartoStyle = (tilesUrl: string): StyleSpecification => ({
+  version: 8,
+  sources: {
+    carto: {
+      type: "raster",
+      tiles: [tilesUrl],
+      tileSize: 256,
+      attribution: CARTO_ATTRIBUTION
+    }
+  },
+  layers: [{ id: "carto", type: "raster", source: "carto" }]
+});
+
+const ensureStyleName = (mapSettings: UIMapSettings): string => {
+  const candidate = mapSettings.style;
+  if (typeof candidate === "string" && candidate.trim().length > 0) {
+    return candidate;
+  }
+  return "raster-carto-dark";
+};
+
+const sanitizeOptionalString = (value?: string | null): string | null => {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+};
+
+const selectMaptilerUrl = (
+  mapSettings: UIMapSettings,
+  variant: MapStyleVariant
+): string | null => {
+  const config = mapSettings.maptiler;
+  if (!config) {
+    return null;
+  }
+
+  if (variant === "dark") {
+    return sanitizeOptionalString(config.styleUrlDark) ?? sanitizeOptionalString(config.styleUrlLight);
+  }
+
+  if (variant === "bright") {
+    return (
+      sanitizeOptionalString(config.styleUrlBright) ??
+      sanitizeOptionalString(config.styleUrlLight) ??
+      sanitizeOptionalString(config.styleUrlDark)
+    );
+  }
+
+  return sanitizeOptionalString(config.styleUrlLight) ?? sanitizeOptionalString(config.styleUrlDark);
+};
+
+const injectKeyIntoUrl = (baseUrl: string, key: string): string => {
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set("key", key);
+    return url.toString();
+  } catch {
+    const delimiter = baseUrl.includes("?") ? "&" : "?";
+    return `${baseUrl}${delimiter}key=${encodeURIComponent(key)}`;
+  }
+};
+
+const injectKeyPlaceholders = (payload: string, key: string): string => {
+  if (!key) {
+    return payload;
+  }
+  return payload.replace(/{key}/g, key);
+};
+
+export const loadMapStyle = async (mapSettings: UIMapSettings): Promise<MapStyleResult> => {
+  const styleName = ensureStyleName(mapSettings);
+  const variant = determineVariant(styleName);
+  const fallbackStyle: MapStyleDefinition = {
+    type: "raster",
+    style: createCartoStyle(getFallbackTiles(variant === "bright" ? "light" : variant)),
+    variant,
+    name: styleName
+  };
+
+  let resolvedStyle = fallbackStyle;
+  let usedFallback = false;
+
+  if (styleName.startsWith("vector-")) {
+    const key = sanitizeOptionalString(mapSettings.maptiler?.key) ?? "";
+    const baseUrl = selectMaptilerUrl(mapSettings, variant);
+
+    if (key && baseUrl) {
+      const styleUrl = injectKeyIntoUrl(baseUrl, key);
+      try {
+        const response = await fetch(styleUrl);
+        if (!response.ok) {
+          throw new Error(`Failed to load style: HTTP ${response.status}`);
+        }
+        const styleText = await response.text();
+        const parsed = JSON.parse(injectKeyPlaceholders(styleText, key)) as StyleSpecification;
+        resolvedStyle = {
+          type: "vector",
+          style: parsed,
+          variant,
+          name: styleName
+        };
+      } catch (error) {
+        console.warn("[map] vector style failed, using raster fallback", error);
+        usedFallback = true;
+      }
+    } else {
+      console.warn("[map] vector style failed, using raster fallback");
+      usedFallback = true;
+    }
+  }
+
+  return {
+    resolved: resolvedStyle,
+    fallback: fallbackStyle,
+    usedFallback
+  };
+};
+
+export default loadMapStyle;

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -79,6 +79,13 @@ body {
   height: 100%;
 }
 
+.map-tint {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: normal;
+}
+
 .maplibregl-canvas-container,
 .maplibregl-canvas {
   width: 100% !important;

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -77,6 +77,21 @@ export type UIMapCinemaSettings = {
   bandTransition_sec: number;
 };
 
+export type UIMapThemeSettings = {
+  sea?: string | null;
+  land?: string | null;
+  label?: string | null;
+  contrast?: number | null;
+  tint?: string | null;
+};
+
+export type UIMapProviderMapTiler = {
+  key?: string | null;
+  styleUrlDark?: string | null;
+  styleUrlLight?: string | null;
+  styleUrlBright?: string | null;
+};
+
 export type UIMapSettings = {
   engine?: string;
   provider: string;
@@ -86,6 +101,9 @@ export type UIMapSettings = {
   controls: boolean;
   renderWorldCopies?: boolean;
   cinema?: UIMapCinemaSettings;
+  style?: string;
+  theme?: UIMapThemeSettings;
+  maptiler?: UIMapProviderMapTiler;
 };
 
 export type UISettings = {


### PR DESCRIPTION
## Summary
- introduce a configurable MapTiler vector style loader with automatic CARTO raster fallback
- apply config-driven theming, tint overlay, and runtime fallback handling to the GeoScope MapLibre view
- extend map defaults/types for vector styles, MapTiler credentials, and higher-zoom cinema band presets

## Testing
- npm run build *(fails: missing registry access for maplibre/dayjs packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ffaca02bd483269dcd2c40693ad552