### PR TITLE
fix(config): robust fetch to window.location.origin + retry banner with origin; remove hardcoded API URLs

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -235,7 +235,7 @@ const buildRuntimePreferences = (
 
 const loadRuntimePreferences = async (): Promise<RuntimePreferences> => {
   try {
-    const config = await apiGet<AppConfig>("/config");
+    const config = await apiGet<AppConfig | undefined>("/api/config");
     const merged = withConfigDefaults(config);
     const mapSettings = merged.ui.map;
     const styleResult = await loadMapStyle(mapSettings);

--- a/dash-ui/src/components/OverlayRotator.tsx
+++ b/dash-ui/src/components/OverlayRotator.tsx
@@ -111,10 +111,10 @@ export const OverlayRotator: React.FC = () => {
     const fetchAll = async () => {
       try {
         const [weather, news, astronomy, calendar] = await Promise.all([
-          apiGet<Record<string, unknown>>("/weather").catch(() => ({})),
-          apiGet<Record<string, unknown>>("/news").catch(() => ({})),
-          apiGet<Record<string, unknown>>("/astronomy").catch(() => ({})),
-          apiGet<Record<string, unknown>>("/calendar").catch(() => ({}))
+          apiGet<Record<string, unknown>>("/api/weather").catch(() => ({})),
+          apiGet<Record<string, unknown>>("/api/news").catch(() => ({})),
+          apiGet<Record<string, unknown>>("/api/astronomy").catch(() => ({})),
+          apiGet<Record<string, unknown>>("/api/calendar").catch(() => ({}))
         ]);
 
         if (mounted) {

--- a/dash-ui/src/lib/api.ts
+++ b/dash-ui/src/lib/api.ts
@@ -1,36 +1,56 @@
-export const API_BASE = `${window.location.origin}/api`;
+import type { AppConfig } from "../types/config";
+
+const BASE = window.location.origin;
 
 const withBase = (path: string) => {
   const suffix = path.startsWith("/") ? path : `/${path}`;
-  return `${API_BASE}${suffix}`;
+  return `${BASE}${suffix}`;
 };
+
+const readJson = async <T>(response: Response): Promise<T> => {
+  const text = await response.text();
+  if (!text) {
+    return undefined as T;
+  }
+  try {
+    return JSON.parse(text) as T;
+  } catch (error) {
+    console.warn("Failed to parse API response as JSON", error);
+    return undefined as T;
+  }
+};
+
+export const API_ORIGIN = BASE;
 
 export async function apiGet<T = unknown>(path: string): Promise<T> {
   const response = await fetch(withBase(path), {
     headers: { Accept: "application/json" }
   });
-  if (!response.ok) throw new Error(`GET ${path} ${response.status}`);
-  return (await response.json()) as T;
+  if (!response.ok) throw new Error(`API:${response.status}`);
+  return await readJson<T>(response);
 }
 
-export async function apiPut<T = unknown>(path: string, body: unknown): Promise<T> {
+export async function apiPost<T = unknown>(path: string, body: unknown): Promise<T> {
   const response = await fetch(withBase(path), {
-    method: "PUT",
+    method: "POST",
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json"
     },
     body: JSON.stringify(body ?? {})
   });
-  if (!response.ok) throw new Error(`PUT ${path} ${response.status}`);
-  return (await response.json()) as T;
+  if (!response.ok) throw new Error(`API:${response.status}`);
+  return await readJson<T>(response);
 }
 
-export async function apiPing(): Promise<boolean> {
-  try {
-    const response = await fetch(withBase("/health"), { cache: "no-store" });
-    return response.ok;
-  } catch {
-    return false;
-  }
+export async function getHealth() {
+  return apiGet<Record<string, unknown> | undefined>("/api/health");
+}
+
+export async function getConfig() {
+  return apiGet<AppConfig | undefined>("/api/config");
+}
+
+export async function saveConfig(data: AppConfig) {
+  return apiPost<unknown>("/api/config", data);
 }

--- a/dash-ui/src/lib/useConfig.ts
+++ b/dash-ui/src/lib/useConfig.ts
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useState } from "react";
 
 import { withConfigDefaults } from "../config/defaults";
 import type { AppConfig } from "../types/config";
-import { API_BASE, apiGet } from "./api";
+import { API_ORIGIN, getConfig } from "./api";
 
-const API_UNREACHABLE = `No se pudo contactar con /api en ${API_BASE}`;
+const API_UNREACHABLE = `No se pudo conectar con el backend en ${API_ORIGIN}`;
 
 export function useConfig() {
   const [data, setData] = useState<AppConfig | null>(null);
@@ -14,8 +14,8 @@ export function useConfig() {
   const load = useCallback(async () => {
     try {
       setLoading(true);
-      const cfg = await apiGet<AppConfig>("/config");
-      setData(withConfigDefaults(cfg));
+      const cfg = await getConfig();
+      setData(withConfigDefaults((cfg ?? {}) as AppConfig));
       setError(null);
     } catch (e) {
       setError(API_UNREACHABLE);

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -787,6 +787,16 @@ main {
   gap: 12px;
 }
 
+.config-form-fields {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  min-inline-size: 0;
+}
+
 .config-tab {
   padding: 14px 18px;
   border-radius: 16px;
@@ -951,6 +961,47 @@ main {
   background: rgba(148, 163, 184, 0.08);
   border-color: rgba(148, 163, 184, 0.35);
   color: rgba(226, 232, 240, 0.85);
+}
+
+.config-skeleton {
+  display: grid;
+  gap: 18px;
+}
+
+.config-skeleton__block {
+  height: 160px;
+  border-radius: 24px;
+  background: linear-gradient(140deg, rgba(10, 18, 38, 0.9), rgba(8, 14, 32, 0.75));
+  position: relative;
+  overflow: hidden;
+}
+
+.config-skeleton__block::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 0%, rgba(109, 182, 255, 0.2) 45%, transparent 90%);
+  transform: translateX(-60%);
+  animation: configSkeletonPulse 1.6s ease-in-out infinite;
+}
+
+@keyframes configSkeletonPulse {
+  0% {
+    transform: translateX(-60%);
+  }
+  50% {
+    transform: translateX(60%);
+  }
+  100% {
+    transform: translateX(160%);
+  }
+}
+
+.config-page__footer {
+  margin-top: 8px;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 0.85rem;
 }
 
 @media (max-width: 1200px) {


### PR DESCRIPTION
## Summary
- add an API helper that builds requests from window.location.origin and exposes health/config helpers
- harden the config screen with loading/error states, retry banner that shows the detected backend origin, and skeleton placeholders while disabling inputs when offline
- route dashboard data fetches through the helper so empty API responses are tolerated without crashing

## Testing
- npm run build *(fails: registry access forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_68ffafbb5a0083269bb26ac63428e76a