### PR TITLE
Fix ConfigPage loading state comparison

### DIFF
--- a/dash-ui/src/pages/ConfigPage.tsx
+++ b/dash-ui/src/pages/ConfigPage.tsx
@@ -140,8 +140,9 @@ export const ConfigPage: React.FC = () => {
   };
 
   const isReady = status === "ready";
+  const isLoading = status === "loading";
   const disableInputs = !isReady || saving;
-  const showSkeleton = status === "loading";
+  const showSkeleton = isLoading;
 
   const renderWiFiTab = () => (
     <div className="config-card">
@@ -638,7 +639,7 @@ export const ConfigPage: React.FC = () => {
               onClick={() => {
                 void initialize();
               }}
-              disabled={status === "loading"}
+              disabled={isLoading}
             >
               Reintentar
             </button>


### PR DESCRIPTION
## Summary
- add an `isLoading` flag derived from the status
- reuse the flag to avoid comparing mutually exclusive status values

## Testing
- `npm run build` *(fails: missing vite/dayjs dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffb652f69483269eb00a292f27d35f