### PR TITLE
feat: enforce band zoom and refresh vivid map theming

### DIFF
--- a/dash-ui/src/components/GeoScope/mapStyle.ts
+++ b/dash-ui/src/components/GeoScope/mapStyle.ts
@@ -3,8 +3,10 @@ import type { StyleSpecification } from "maplibre-gl";
 import type { UIMapSettings } from "../../types/config";
 
 const CARTO_ATTRIBUTION = "© OpenStreetMap contributors, © CARTO";
-const CARTO_DARK_TILES = "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png";
-const CARTO_LIGHT_TILES = "https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png";
+const CARTO_DARK_TILES =
+  "https://basemaps.cartocdn.com/rastertiles/dark_all/{z}/{x}/{y}.png";
+const CARTO_LIGHT_TILES =
+  "https://basemaps.cartocdn.com/rastertiles/light_all/{z}/{x}/{y}.png";
 
 export type MapStyleVariant = "dark" | "light" | "bright";
 

--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -40,11 +40,11 @@ const CINEMA_BANDS_PRESET: readonly UIMapCinemaBand[] = [
 ];
 
 const DEFAULT_MAP_THEME: UIMapThemeSettings = {
-  sea: "#0b2a3a",
-  land: "#202327",
-  label: "#aeb8c2",
+  sea: "#0b3756",
+  land: "#20262c",
+  label: "#d6e7ff",
   contrast: 0.15,
-  tint: null,
+  tint: "rgba(0,170,255,0.06)",
 };
 
 const DEFAULT_MAPTILER: UIMapProviderMapTiler = {


### PR DESCRIPTION
## Summary
- ensure cinema bands drive the live camera state, preserve zoom across resize, and clamp each band’s minimum zoom
- prefer MapTiler vector styles when a key is configured with CARTO raster tiles as a resilient fallback
- apply configurable vivid sea/land/label colours, raster enhancements, and an optional tint overlay based on UI defaults

## Testing
- npm run build *(fails: missing project dependencies such as dayjs in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ffb5e886208326b0b01071a66b1992