### PR TITLE
fix(nginx): correct /api proxy trailing slash

### DIFF
--- a/etc/nginx/sites-available/pantalla-reloj.conf
+++ b/etc/nginx/sites-available/pantalla-reloj.conf
@@ -6,7 +6,7 @@ server {
   root /var/www/html;
   index index.html;
 
-  location /api/ {
+  location /api {
     proxy_pass         http://127.0.0.1:8081;
     proxy_http_version 1.1;
     proxy_set_header   Host $host;


### PR DESCRIPTION
## Summary
- update the Nginx site configuration to proxy /api without an extra trailing slash so FastAPI paths remain intact

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ffbbd7fc908326b3cdd242ce7e344b