### PR TITLE
Run API verifier after backend startup

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -395,12 +395,6 @@ configure_nginx() {
     log_info "Backend OK (HTTP 200)"
   fi
 
-  log_info "Ejecutando verificador post-deploy"
-  if ! "$REPO_ROOT/scripts/verify_api.sh"; then
-    log_error "La verificación de Nginx/API falló"
-    exit 1
-  fi
-  log_info "Verificador post-deploy completado"
 }
 
 configure_nginx
@@ -541,6 +535,13 @@ else
   log_warn "Backend /api/health not responding yet"
   SUMMARY+=('[install] backend /api/health no responde')
 fi
+
+log_info "Ejecutando verificador post-deploy"
+if ! "$REPO_ROOT/scripts/verify_api.sh"; then
+  log_error "La verificación de Nginx/API falló"
+  exit 1
+fi
+log_info "Verificador post-deploy completado"
 
 if DISPLAY=:0 XAUTHORITY=/home/${USER_NAME}/.Xauthority wmctrl -lx | grep -q 'chromium-browser\.pantalla-kiosk'; then
   log_ok "Ventana de Chromium detectada"


### PR DESCRIPTION
## Summary
- move the API verification step out of the nginx configuration helper
- invoke the verifier after systemd has started and restarted the backend service

## Testing
- bash -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_68ffc251e7048326b84d4d922375dded