### PR TITLE
feat: implement configuration schema v1.5

### DIFF
--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -1,63 +1,54 @@
 {
   "display": {
     "timezone": "Europe/Madrid",
-    "rotation": "left",
-    "module_cycle_seconds": 20,
-    "modules": [
-      { "name": "clock", "enabled": true, "duration_seconds": 20 },
-      { "name": "weather", "enabled": true, "duration_seconds": 20 },
-      { "name": "moon", "enabled": true, "duration_seconds": 20 },
-      { "name": "news", "enabled": true, "duration_seconds": 20 },
-      { "name": "events", "enabled": true, "duration_seconds": 20 },
-      { "name": "calendar", "enabled": true, "duration_seconds": 20 }
-    ]
-  },
-  "api_keys": {
-    "weather": null,
-    "news": null,
-    "astronomy": null,
-    "calendar": null
-  },
-  "mqtt": {
-    "enabled": false,
-    "host": "localhost",
-    "port": 1883,
-    "topic": "pantalla/reloj",
-    "username": null,
-    "password": null
-  },
-  "wifi": {
-    "interface": "wlan2",
-    "ssid": null,
-    "psk": null
-  },
-  "storm_mode": {
-    "enabled": false,
-    "last_triggered": null
+    "module_cycle_seconds": 20
   },
   "ui": {
+    "layout": "grid-2-1",
+    "map": {
+      "engine": "maplibre",
+      "style": "vector-dark",
+      "provider": "maptiler",
+      "maptiler": {
+        "key": null,
+        "styleUrlDark": "https://api.maptiler.com/maps/dark/style.json",
+        "styleUrlLight": "https://api.maptiler.com/maps/streets/style.json",
+        "styleUrlBright": "https://api.maptiler.com/maps/bright/style.json"
+      },
+      "renderWorldCopies": true,
+      "interactive": false,
+      "controls": false,
+      "cinema": {
+        "enabled": true,
+        "panLngDegPerSec": 0.3,
+        "bandTransition_sec": 8,
+        "bands": [
+          { "lat": 0.0, "zoom": 2.8, "pitch": 10.0, "minZoom": 2.6, "duration_sec": 900 },
+          { "lat": 18.0, "zoom": 3.0, "pitch": 8.0, "minZoom": 2.8, "duration_sec": 720 },
+          { "lat": 32.0, "zoom": 3.3, "pitch": 6.0, "minZoom": 3.0, "duration_sec": 600 },
+          { "lat": 42.0, "zoom": 3.6, "pitch": 6.0, "minZoom": 3.2, "duration_sec": 480 },
+          { "lat": -18.0, "zoom": 3.0, "pitch": 8.0, "minZoom": 2.8, "duration_sec": 720 },
+          { "lat": -32.0, "zoom": 3.3, "pitch": 6.0, "minZoom": 3.0, "duration_sec": 600 }
+        ]
+      },
+      "theme": {
+        "sea": "#0b3756",
+        "land": "#20262c",
+        "label": "#d6e7ff",
+        "contrast": 0.15,
+        "tint": "rgba(0,170,255,0.06)"
+      }
+    },
     "rotation": {
       "enabled": true,
       "duration_sec": 10,
       "panels": ["news", "ephemerides", "moon", "forecast", "calendar"]
-    },
-    "fixed": {
-      "clock": { "format": "HH:mm" },
-      "temperature": { "unit": "C" }
-    },
-    "map": {
-      "provider": "osm",
-      "center": [0, 0],
-      "zoom": 2,
-      "interactive": false,
-      "controls": false
-    },
-    "text": {
-      "scroll": {
-        "news": { "enabled": true, "direction": "left", "speed": "normal", "gap_px": 48 },
-        "ephemerides": { "enabled": true, "direction": "up", "speed": "slow", "gap_px": 24 },
-        "forecast": { "enabled": true, "direction": "up", "speed": "slow", "gap_px": 24 }
-      }
     }
+  },
+  "news": {
+    "enabled": true
+  },
+  "ai": {
+    "enabled": false
   }
 }

--- a/dash-ui/src/components/OverlayRotator.tsx
+++ b/dash-ui/src/components/OverlayRotator.tsx
@@ -142,7 +142,7 @@ export const OverlayRotator: React.FC = () => {
   const news = (payload.news ?? {}) as Record<string, unknown>;
   const calendar = (payload.calendar ?? {}) as Record<string, unknown>;
 
-  const targetUnit = config.ui.fixed.temperature.unit || "C";
+  const targetUnit = "C";
   const rawTemperature = typeof weather.temperature === "number" ? weather.temperature : null;
   const rawUnit = ensurePlainText(weather.unit) || "C";
   const temperature = formatTemperature(rawTemperature, rawUnit, targetUnit);

--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -1,107 +1,39 @@
 import type {
   AppConfig,
-  DisplayModule,
-  UIMapCinemaBand,
-  UIMapCinemaSettings,
-  UIMapProviderMapTiler,
-  UIMapSettings,
-  UIMapThemeSettings,
-  UISettings,
-  UIScrollSettings,
-  UIScrollSpeed,
+  MapCinemaBand,
+  MapCinemaConfig,
+  MapConfig,
+  MapThemeConfig,
+  MaptilerConfig,
 } from "../types/config";
 
-const sanitizeString = (value: unknown, fallback: string): string => {
-  return typeof value === "string" && value.trim().length > 0 ? value : fallback;
+const clampNumber = (value: number, min: number, max: number): number => {
+  return Math.min(Math.max(value, min), max);
 };
 
-const sanitizeNumber = (value: unknown, fallback: number): number => {
+const toNumber = (value: unknown, fallback: number): number => {
   const numeric = Number(value);
   return Number.isFinite(numeric) ? numeric : fallback;
 };
 
-const sanitizePositive = (value: unknown, fallback: number, min = 0): number => {
-  const numeric = sanitizeNumber(value, fallback);
-  return numeric > min ? numeric : fallback;
-};
-
-const sanitizeNonNegative = (value: unknown, fallback: number): number => {
-  const numeric = sanitizeNumber(value, fallback);
-  return numeric >= 0 ? numeric : fallback;
-};
-
-const CINEMA_BANDS_PRESET: readonly UIMapCinemaBand[] = [
-  { lat: 0, zoom: 2.8, pitch: 10, minZoom: 2.6, duration_sec: 900 },
-  { lat: 18, zoom: 3.0, pitch: 8, minZoom: 2.8, duration_sec: 720 },
-  { lat: 32, zoom: 3.3, pitch: 6, minZoom: 3.0, duration_sec: 600 },
-  { lat: 42, zoom: 3.6, pitch: 6, minZoom: 3.2, duration_sec: 480 },
-  { lat: -18, zoom: 3.0, pitch: 8, minZoom: 2.8, duration_sec: 720 },
-  { lat: -32, zoom: 3.3, pitch: 6, minZoom: 3.0, duration_sec: 600 }
-];
-
-const DEFAULT_MAP_THEME: UIMapThemeSettings = {
-  sea: "#0b3756",
-  land: "#20262c",
-  label: "#d6e7ff",
-  contrast: 0.15,
-  tint: "rgba(0,170,255,0.06)",
-};
-
-const DEFAULT_MAPTILER: UIMapProviderMapTiler = {
-  key: null,
-  styleUrlDark: "https://api.maptiler.com/maps/dark/style.json",
-  styleUrlLight: "https://api.maptiler.com/maps/streets/style.json",
-  styleUrlBright: "https://api.maptiler.com/maps/bright/style.json",
-};
-
-const createDefaultMapTheme = (): UIMapThemeSettings => ({ ...DEFAULT_MAP_THEME });
-
-const createDefaultMaptiler = (): UIMapProviderMapTiler => ({ ...DEFAULT_MAPTILER });
-
-export const createDefaultMapCinema = (): UIMapCinemaSettings => ({
-  enabled: true,
-  panLngDegPerSec: 0.3,
-  bands: CINEMA_BANDS_PRESET.map((band) => ({ ...band })),
-  bandTransition_sec: 8
-});
-
-export const createDefaultMapSettings = (): UIMapSettings => ({
-  engine: "maplibre",
-  provider: "carto",
-  center: [0, 0],
-  zoom: 2.6,
-  interactive: false,
-  controls: false,
-  renderWorldCopies: true,
-  cinema: createDefaultMapCinema(),
-  style: "raster-carto-dark",
-  theme: createDefaultMapTheme(),
-  maptiler: createDefaultMaptiler()
-});
-
-const mergeCinema = (cinema?: UIMapCinemaSettings): UIMapCinemaSettings => {
-  const defaults = createDefaultMapCinema();
-  if (!cinema) {
-    return createDefaultMapCinema();
+const toBoolean = (value: unknown, fallback: boolean): boolean => {
+  if (typeof value === "boolean") {
+    return value;
   }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "1", "yes", "on"].includes(normalized)) {
+      return true;
+    }
+    if (["false", "0", "no", "off"].includes(normalized)) {
+      return false;
+    }
+  }
+  return fallback;
+};
 
-  const bands = defaults.bands.map((fallback, index) => {
-    const candidate = cinema.bands?.[index];
-    return {
-      lat: sanitizeNumber(candidate?.lat, fallback.lat),
-      zoom: sanitizeNumber(candidate?.zoom, fallback.zoom),
-      pitch: sanitizeNumber(candidate?.pitch, fallback.pitch),
-      minZoom: sanitizeNonNegative(candidate?.minZoom, fallback.minZoom),
-      duration_sec: sanitizePositive(candidate?.duration_sec, fallback.duration_sec)
-    } as UIMapCinemaBand;
-  });
-
-  return {
-    enabled: cinema.enabled ?? defaults.enabled,
-    panLngDegPerSec: sanitizePositive(cinema.panLngDegPerSec, defaults.panLngDegPerSec),
-    bands,
-    bandTransition_sec: sanitizePositive(cinema.bandTransition_sec, defaults.bandTransition_sec)
-  };
+const sanitizeString = (value: unknown, fallback: string): string => {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : fallback;
 };
 
 const sanitizeNullableString = (value: unknown, fallback: string | null): string | null => {
@@ -115,121 +47,161 @@ const sanitizeNullableString = (value: unknown, fallback: string | null): string
   return fallback;
 };
 
-const mergeTheme = (theme?: UIMapThemeSettings): UIMapThemeSettings => {
-  const defaults = createDefaultMapTheme();
-  if (!theme) {
-    return createDefaultMapTheme();
-  }
-
-  return {
-    sea: sanitizeNullableString(theme.sea, defaults.sea ?? null),
-    land: sanitizeNullableString(theme.land, defaults.land ?? null),
-    label: sanitizeNullableString(theme.label, defaults.label ?? null),
-    contrast: theme.contrast ?? defaults.contrast ?? 0,
-    tint: sanitizeNullableString(theme.tint, defaults.tint ?? null)
-  };
-};
-
-const mergeMaptiler = (maptiler?: UIMapProviderMapTiler): UIMapProviderMapTiler => {
-  const defaults = createDefaultMaptiler();
-  if (!maptiler) {
-    return createDefaultMaptiler();
-  }
-
-  return {
-    key: sanitizeNullableString(maptiler.key, defaults.key ?? null),
-    styleUrlDark: sanitizeNullableString(maptiler.styleUrlDark, defaults.styleUrlDark ?? null),
-    styleUrlLight: sanitizeNullableString(maptiler.styleUrlLight, defaults.styleUrlLight ?? null),
-    styleUrlBright: sanitizeNullableString(maptiler.styleUrlBright, defaults.styleUrlBright ?? null)
-  };
-};
-
-const mergeMapSettings = (map?: UIMapSettings): UIMapSettings => {
-  const defaults = createDefaultMapSettings();
-  const source = map ?? defaults;
-  const center = source.center ?? defaults.center;
-  const sanitizedCenter: [number, number] = [
-    sanitizeNumber(center?.[0], defaults.center[0]),
-    sanitizeNumber(center?.[1], defaults.center[1])
-  ];
-
-  return {
-    engine: source.engine ?? defaults.engine,
-    provider: sanitizeString(source.provider, defaults.provider),
-    center: sanitizedCenter,
-    zoom: sanitizeNumber(source.zoom, defaults.zoom),
-    interactive: source.interactive ?? defaults.interactive,
-    controls: source.controls ?? defaults.controls,
-    renderWorldCopies: source.renderWorldCopies ?? defaults.renderWorldCopies,
-    cinema: mergeCinema(source.cinema),
-    style: sanitizeString(source.style ?? defaults.style ?? "raster-carto-dark", "raster-carto-dark"),
-    theme: mergeTheme(source.theme),
-    maptiler: mergeMaptiler(source.maptiler)
-  };
-};
-
-const createDefaultModules = (): DisplayModule[] => [
-  { name: "clock", enabled: true, duration_seconds: 20 },
-  { name: "weather", enabled: true, duration_seconds: 20 },
-  { name: "moon", enabled: true, duration_seconds: 20 },
-  { name: "news", enabled: true, duration_seconds: 20 },
-  { name: "events", enabled: true, duration_seconds: 20 },
-  { name: "calendar", enabled: true, duration_seconds: 20 }
+const DEFAULT_CINEMA_BANDS: readonly MapCinemaBand[] = [
+  { lat: 0, zoom: 2.8, pitch: 10, minZoom: 2.6, duration_sec: 900 },
+  { lat: 18, zoom: 3.0, pitch: 8, minZoom: 2.8, duration_sec: 720 },
+  { lat: 32, zoom: 3.3, pitch: 6, minZoom: 3.0, duration_sec: 600 },
+  { lat: 42, zoom: 3.6, pitch: 6, minZoom: 3.2, duration_sec: 480 },
+  { lat: -18, zoom: 3.0, pitch: 8, minZoom: 2.8, duration_sec: 720 },
+  { lat: -32, zoom: 3.3, pitch: 6, minZoom: 3.0, duration_sec: 600 },
 ];
 
-const createScrollDefaults = (): Record<string, UIScrollSettings> => ({
-  news: { enabled: true, direction: "left", speed: "normal", gap_px: 48 },
-  ephemerides: { enabled: true, direction: "up", speed: "slow", gap_px: 24 },
-  forecast: { enabled: true, direction: "up", speed: "slow", gap_px: 24 }
+const DEFAULT_THEME: MapThemeConfig = {
+  sea: "#0b3756",
+  land: "#20262c",
+  label: "#d6e7ff",
+  contrast: 0.15,
+  tint: "rgba(0,170,255,0.06)",
+};
+
+const DEFAULT_MAPTILER: MaptilerConfig = {
+  key: null,
+  styleUrlDark: "https://api.maptiler.com/maps/dark/style.json",
+  styleUrlLight: "https://api.maptiler.com/maps/streets/style.json",
+  styleUrlBright: "https://api.maptiler.com/maps/bright/style.json",
+};
+
+export const createDefaultMapCinema = (): MapCinemaConfig => ({
+  enabled: true,
+  panLngDegPerSec: 0.3,
+  bandTransition_sec: 8,
+  bands: DEFAULT_CINEMA_BANDS.map((band) => ({ ...band })),
 });
 
-export const UI_DEFAULTS: UISettings = {
-  rotation: {
+export const createDefaultMapSettings = (): MapConfig => ({
+  engine: "maplibre",
+  style: "vector-dark",
+  provider: "maptiler",
+  maptiler: { ...DEFAULT_MAPTILER },
+  renderWorldCopies: true,
+  interactive: false,
+  controls: false,
+  cinema: createDefaultMapCinema(),
+  theme: { ...DEFAULT_THEME },
+});
+
+const mergeCinemaBand = (candidate: unknown, fallback: MapCinemaBand): MapCinemaBand => {
+  const source = (candidate as Partial<MapCinemaBand>) ?? {};
+  const zoom = toNumber(source.zoom, fallback.zoom);
+  const minZoom = Math.min(toNumber(source.minZoom, fallback.minZoom), zoom);
+  return {
+    lat: toNumber(source.lat, fallback.lat),
+    zoom,
+    pitch: toNumber(source.pitch, fallback.pitch),
+    minZoom,
+    duration_sec: Math.max(1, Math.round(toNumber(source.duration_sec, fallback.duration_sec))),
+  };
+};
+
+const mergeCinema = (candidate: unknown): MapCinemaConfig => {
+  const fallback = createDefaultMapCinema();
+  const source = (candidate as Partial<MapCinemaConfig>) ?? {};
+  const bandsSource = Array.isArray(source.bands) ? source.bands : [];
+  const bands = DEFAULT_CINEMA_BANDS.map((band, index) => mergeCinemaBand(bandsSource[index], band));
+  return {
+    enabled: toBoolean(source.enabled, fallback.enabled),
+    panLngDegPerSec: Math.max(0, toNumber(source.panLngDegPerSec, fallback.panLngDegPerSec)),
+    bandTransition_sec: Math.max(1, Math.round(toNumber(source.bandTransition_sec, fallback.bandTransition_sec))),
+    bands,
+  };
+};
+
+const mergeTheme = (candidate: unknown): MapThemeConfig => {
+  const fallback = { ...DEFAULT_THEME };
+  const source = (candidate as Partial<MapThemeConfig>) ?? {};
+  return {
+    sea: sanitizeString(source.sea, fallback.sea),
+    land: sanitizeString(source.land, fallback.land),
+    label: sanitizeString(source.label, fallback.label),
+    contrast: toNumber(source.contrast, fallback.contrast),
+    tint: sanitizeString(source.tint, fallback.tint),
+  };
+};
+
+const mergeMaptiler = (candidate: unknown): MaptilerConfig => {
+  const fallback = { ...DEFAULT_MAPTILER };
+  const source = (candidate as Partial<MaptilerConfig>) ?? {};
+  return {
+    key: sanitizeNullableString(source.key, fallback.key),
+    styleUrlDark: sanitizeNullableString(source.styleUrlDark, fallback.styleUrlDark),
+    styleUrlLight: sanitizeNullableString(source.styleUrlLight, fallback.styleUrlLight),
+    styleUrlBright: sanitizeNullableString(source.styleUrlBright, fallback.styleUrlBright),
+  };
+};
+
+const mergeMap = (candidate: unknown): MapConfig => {
+  const fallback = createDefaultMapSettings();
+  const source = (candidate as Partial<MapConfig>) ?? {};
+  const allowedStyles: MapConfig["style"][] = [
+    "vector-dark",
+    "vector-light",
+    "vector-bright",
+    "raster-carto-dark",
+    "raster-carto-light",
+  ];
+  const allowedProviders: MapConfig["provider"][] = ["maptiler", "carto"];
+  const style = allowedStyles.includes(source.style ?? fallback.style)
+    ? (source.style as MapConfig["style"])
+    : fallback.style;
+  const provider = allowedProviders.includes(source.provider ?? fallback.provider)
+    ? (source.provider as MapConfig["provider"])
+    : fallback.provider;
+  return {
+    engine: "maplibre",
+    style,
+    provider,
+    maptiler: mergeMaptiler(source.maptiler),
+    renderWorldCopies: toBoolean(source.renderWorldCopies, fallback.renderWorldCopies),
+    interactive: toBoolean(source.interactive, fallback.interactive),
+    controls: toBoolean(source.controls, fallback.controls),
+    cinema: mergeCinema(source.cinema),
+    theme: mergeTheme(source.theme),
+  };
+};
+
+const mergeRotation = (candidate: unknown) => {
+  const fallback = {
     enabled: true,
     duration_sec: 10,
-    panels: ["news", "ephemerides", "moon", "forecast", "calendar"]
-  },
-  fixed: {
-    clock: { format: "HH:mm" },
-    temperature: { unit: "C" }
-  },
-  map: createDefaultMapSettings(),
-  text: {
-    scroll: createScrollDefaults()
-  }
+    panels: ["news", "ephemerides", "moon", "forecast", "calendar"],
+  };
+  const source = (candidate as Partial<AppConfig["ui"]["rotation"]>) ?? {};
+  const panels = Array.isArray(source.panels)
+    ? source.panels.filter((panel): panel is string => typeof panel === "string" && panel.trim().length > 0)
+    : fallback.panels;
+  return {
+    enabled: toBoolean(source.enabled, fallback.enabled),
+    duration_sec: clampNumber(Math.round(toNumber(source.duration_sec, fallback.duration_sec)), 3, 3600),
+    panels: panels.length > 0 ? panels : fallback.panels,
+  };
 };
 
 export const DEFAULT_CONFIG: AppConfig = {
   display: {
     timezone: "Europe/Madrid",
-    rotation: "left",
     module_cycle_seconds: 20,
-    modules: createDefaultModules()
   },
-  api_keys: {
-    weather: null,
-    news: null,
-    astronomy: null,
-    calendar: null
+  ui: {
+    layout: "grid-2-1",
+    map: createDefaultMapSettings(),
+    rotation: mergeRotation(undefined),
   },
-  mqtt: {
+  news: {
+    enabled: true,
+  },
+  ai: {
     enabled: false,
-    host: "localhost",
-    port: 1883,
-    topic: "pantalla/reloj",
-    username: null,
-    password: null
   },
-  wifi: {
-    interface: "wlan2",
-    ssid: null,
-    psk: null
-  },
-  storm_mode: {
-    enabled: false,
-    last_triggered: null
-  },
-  ui: UI_DEFAULTS
 };
 
 export const withConfigDefaults = (payload?: Partial<AppConfig>): AppConfig => {
@@ -237,85 +209,30 @@ export const withConfigDefaults = (payload?: Partial<AppConfig>): AppConfig => {
     return JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as AppConfig;
   }
 
-  const displayModules = payload.display?.modules ?? DEFAULT_CONFIG.display.modules;
-
-  const mergeScroll = (scroll?: UISettings["text"]["scroll"]): UISettings["text"] => {
-    const defaults = createScrollDefaults();
-    if (!scroll) {
-      return { scroll: defaults };
-    }
-    const result: Record<string, UIScrollSettings> = { ...defaults };
-    for (const [key, value] of Object.entries(scroll)) {
-      result[key] = { ...defaults[key], ...value };
-    }
-    return { scroll: result };
-  };
-
-  const mergeSpeed = (speed: UIScrollSpeed | undefined): UIScrollSpeed => {
-    if (speed === undefined || speed === null) {
-      return "normal";
-    }
-    if (typeof speed === "string" && ["slow", "normal", "fast"].includes(speed)) {
-      return speed;
-    }
-    if (Number.isFinite(Number(speed))) {
-      return Number(speed);
-    }
-    return "normal";
-  };
-
-  const mergedScroll = mergeScroll(payload.ui?.text?.scroll);
-  for (const [key, value] of Object.entries(mergedScroll.scroll)) {
-    value.speed = mergeSpeed(value.speed);
-    const gap = Number(value.gap_px);
-    const fallback = createScrollDefaults()[key]?.gap_px ?? 48;
-    value.gap_px = Number.isFinite(gap) && gap >= 0 ? gap : fallback;
-  }
+  const display = payload.display ?? {};
+  const ui = payload.ui ?? {};
+  const news = payload.news ?? {};
+  const ai = payload.ai ?? {};
 
   return {
     display: {
-      ...DEFAULT_CONFIG.display,
-      ...payload.display,
-      modules: displayModules.map((module) => ({ ...module }))
-    },
-    api_keys: {
-      ...DEFAULT_CONFIG.api_keys,
-      ...payload.api_keys
-    },
-    mqtt: {
-      ...DEFAULT_CONFIG.mqtt,
-      ...payload.mqtt
-    },
-    wifi: {
-      ...DEFAULT_CONFIG.wifi,
-      ...payload.wifi
-    },
-    storm_mode: {
-      ...DEFAULT_CONFIG.storm_mode,
-      ...payload.storm_mode
+      timezone: sanitizeString(display.timezone, DEFAULT_CONFIG.display.timezone),
+      module_cycle_seconds: clampNumber(
+        Math.round(toNumber(display.module_cycle_seconds, DEFAULT_CONFIG.display.module_cycle_seconds)),
+        5,
+        600,
+      ),
     },
     ui: {
-      rotation: {
-        ...UI_DEFAULTS.rotation,
-        ...(payload.ui?.rotation ?? {})
-      },
-      fixed: {
-        clock: {
-          ...UI_DEFAULTS.fixed.clock,
-          ...(payload.ui?.fixed?.clock ?? {})
-        },
-        temperature: {
-          ...UI_DEFAULTS.fixed.temperature,
-          ...(payload.ui?.fixed?.temperature ?? {})
-        }
-      },
-      map: mergeMapSettings(payload.ui?.map),
-      text: mergedScroll,
-      layout: payload.ui?.layout,
-      side_panel: payload.ui?.side_panel,
-      show_config: payload.ui?.show_config,
-      enable_demo: payload.ui?.enable_demo,
-      carousel: payload.ui?.carousel
-    }
+      layout: "grid-2-1",
+      map: mergeMap(ui.map),
+      rotation: mergeRotation(ui.rotation),
+    },
+    news: {
+      enabled: toBoolean(news.enabled, DEFAULT_CONFIG.news.enabled),
+    },
+    ai: {
+      enabled: toBoolean(ai.enabled, DEFAULT_CONFIG.ai.enabled),
+    },
   };
 };

--- a/dash-ui/src/pages/ConfigPage.tsx
+++ b/dash-ui/src/pages/ConfigPage.tsx
@@ -1,86 +1,343 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 
-import { UI_DEFAULTS, withConfigDefaults } from "../config/defaults";
-import { API_ORIGIN, getConfig, getHealth, saveConfig } from "../lib/api";
-import type { AppConfig, UIScrollSettings } from "../types/config";
+import { DEFAULT_CONFIG, withConfigDefaults } from "../config/defaults";
+import {
+  API_ORIGIN,
+  ApiError,
+  getConfig,
+  getHealth,
+  getSchema,
+  saveConfig,
+} from "../lib/api";
+import type { AppConfig, MapCinemaBand } from "../types/config";
 
-const booleanOptions = [
-  { value: "true", label: "Sí" },
-  { value: "false", label: "No" }
-];
+type LoadStatus = "loading" | "ready" | "error";
+type Banner = { kind: "success" | "error"; text: string } | null;
+type FieldErrors = Record<string, string>;
 
-const directionOptions = [
-  { value: "left", label: "Horizontal" },
-  { value: "up", label: "Vertical" }
-];
+type JsonSchema = {
+  $ref?: string;
+  type?: string | string[];
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+  allOf?: JsonSchema[];
+  anyOf?: JsonSchema[];
+  oneOf?: JsonSchema[];
+};
 
-const speedPlaceholders = "slow / normal / fast o px/s";
+type SchemaInspector = {
+  has(path: string | string[]): boolean;
+};
 
 const API_ERROR_MESSAGE = `No se pudo conectar con el backend en ${API_ORIGIN}`;
-
-const defaultScroll = (panel: string): UIScrollSettings => {
-  return UI_DEFAULTS.text.scroll[panel] ?? { enabled: true, direction: "left", speed: "normal", gap_px: 48 };
-};
-
-const parseSpeedInput = (value: string, current: UIScrollSettings["speed"]): UIScrollSettings["speed"] => {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return current;
-  }
-  if (["slow", "normal", "fast"].includes(trimmed)) {
-    return trimmed as UIScrollSettings["speed"];
-  }
-  const numeric = Number(trimmed);
-  if (Number.isFinite(numeric) && numeric > 0) {
-    return numeric;
-  }
-  return current;
-};
-
-const parsePanelsInput = (value: string): string[] => {
-  return value
-    .split(/[\n,]+/)
-    .map((entry) => entry.trim())
-    .filter(Boolean);
-};
-
-type ConfigTab = "wifi" | "api" | "ui" | "system";
-
-const tabs: { id: ConfigTab; label: string }[] = [
-  { id: "wifi", label: "Wi-Fi" },
-  { id: "api", label: "APIs" },
-  { id: "ui", label: "Interfaz" },
-  { id: "system", label: "Sistema" }
+const MAP_STYLE_OPTIONS: AppConfig["ui"]["map"]["style"][] = [
+  "vector-dark",
+  "vector-light",
+  "vector-bright",
+  "raster-carto-dark",
+  "raster-carto-light",
 ];
+const MAP_PROVIDER_OPTIONS: AppConfig["ui"]["map"]["provider"][] = ["maptiler", "carto"];
+const DEFAULT_PANELS = DEFAULT_CONFIG.ui.rotation.panels;
+const CINEMA_BAND_COUNT = DEFAULT_CONFIG.ui.map.cinema.bands.length;
 
-export const ConfigPage: React.FC = () => {
-  const navigate = useNavigate();
+const DEFAULT_SCHEMA_PATHS: Set<string> = (() => {
+  const paths = new Set<string>();
+  const walk = (value: unknown, prefix: string[]) => {
+    if (!value || typeof value !== "object") {
+      return;
+    }
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        walk(value[0], prefix);
+      }
+      return;
+    }
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      const nextPath = [...prefix, key];
+      paths.add(nextPath.join("."));
+      walk(child, nextPath);
+    }
+  };
+  walk(DEFAULT_CONFIG, []);
+  return paths;
+})();
 
+const joinPath = (path: string | string[]): string => {
+  if (Array.isArray(path)) {
+    return path.join(".");
+  }
+  return path;
+};
+
+const decodeJsonPointer = (token: string): string => {
+  return token.replace(/~1/g, "/").replace(/~0/g, "~");
+};
+
+const createSchemaInspector = (schema: Record<string, unknown> | undefined): SchemaInspector => {
+  if (!schema || typeof schema !== "object") {
+    return { has: (path: string | string[]) => DEFAULT_SCHEMA_PATHS.has(joinPath(path)) };
+  }
+
+  const root = schema as JsonSchema & { [key: string]: unknown };
+  const pathSet = new Set<string>();
+  const visited = new WeakMap<object, Set<string>>();
+
+  const resolveRef = (ref: string | undefined): JsonSchema | undefined => {
+    if (!ref || typeof ref !== "string" || !ref.startsWith("#/")) {
+      return undefined;
+    }
+    const segments = ref
+      .slice(2)
+      .split("/")
+      .map(decodeJsonPointer);
+    let current: unknown = root;
+    for (const segment of segments) {
+      if (!current || typeof current !== "object" || !(segment in current)) {
+        return undefined;
+      }
+      current = (current as Record<string, unknown>)[segment];
+    }
+    return current as JsonSchema;
+  };
+
+  const deref = (node: JsonSchema | undefined): JsonSchema | undefined => {
+    if (!node || typeof node !== "object") {
+      return node;
+    }
+    if (node.$ref) {
+      const target = resolveRef(node.$ref);
+      if (target) {
+        return deref(target);
+      }
+    }
+    return node;
+  };
+
+  const visit = (node: JsonSchema | undefined, prefix: string[]) => {
+    const resolved = deref(node);
+    if (!resolved || typeof resolved !== "object") {
+      return;
+    }
+    const key = prefix.join(".");
+    const marker = visited.get(resolved);
+    if (marker?.has(key)) {
+      return;
+    }
+    if (marker) {
+      marker.add(key);
+    } else {
+      visited.set(resolved, new Set(key ? [key] : []));
+    }
+
+    const composites = [resolved, ...(resolved.allOf ?? []), ...(resolved.anyOf ?? []), ...(resolved.oneOf ?? [])];
+    for (const composite of composites) {
+      const concrete = deref(composite);
+      if (!concrete || typeof concrete !== "object") {
+        continue;
+      }
+      if (concrete.properties) {
+        for (const [name, child] of Object.entries(concrete.properties)) {
+          const childPath = [...prefix, name];
+          pathSet.add(childPath.join("."));
+          visit(child, childPath);
+        }
+      }
+      if (concrete.items) {
+        visit(concrete.items, prefix);
+      }
+    }
+  };
+
+  visit(root, []);
+
+  return {
+    has: (path: string | string[]) => pathSet.has(joinPath(path)),
+  };
+};
+
+const extractBackendErrors = (detail: unknown): FieldErrors => {
+  if (Array.isArray(detail)) {
+    return detail.reduce<FieldErrors>((acc, entry) => {
+      if (!entry || typeof entry !== "object") {
+        return acc;
+      }
+      const loc = Array.isArray((entry as Record<string, unknown>).loc)
+        ? ((entry as Record<string, unknown>).loc as (string | number)[])
+        : [];
+      const path = loc.length ? loc.map(String).join(".") : "__root__";
+      const message = typeof (entry as Record<string, unknown>).msg === "string"
+        ? (entry as Record<string, unknown>).msg
+        : "Dato inválido";
+      acc[path] = message;
+      return acc;
+    }, {});
+  }
+
+  if (detail && typeof detail === "object" && "detail" in detail) {
+    const inner = (detail as Record<string, unknown>).detail;
+    if (typeof inner === "string") {
+      return { __root__: inner };
+    }
+    return extractBackendErrors(inner);
+  }
+
+  if (typeof detail === "string") {
+    return { __root__: detail };
+  }
+
+  return {};
+};
+
+const validateConfig = (config: AppConfig, supports: SchemaInspector["has"]): FieldErrors => {
+  const errors: FieldErrors = {};
+
+  if (supports("display.timezone")) {
+    if (!config.display.timezone || !config.display.timezone.trim()) {
+      errors["display.timezone"] = "Introduce una zona horaria válida";
+    }
+  }
+
+  if (supports("display.module_cycle_seconds")) {
+    const value = config.display.module_cycle_seconds;
+    if (!Number.isFinite(value) || value < 5 || value > 600) {
+      errors["display.module_cycle_seconds"] = "Debe estar entre 5 y 600";
+    }
+  }
+
+  if (supports("ui.map.style")) {
+    if (!MAP_STYLE_OPTIONS.includes(config.ui.map.style)) {
+      errors["ui.map.style"] = "Selecciona un estilo compatible";
+    }
+  }
+
+  if (supports("ui.map.provider")) {
+    if (!MAP_PROVIDER_OPTIONS.includes(config.ui.map.provider)) {
+      errors["ui.map.provider"] = "Selecciona un proveedor soportado";
+    }
+  }
+
+  if (supports("ui.map.cinema.panLngDegPerSec")) {
+    if (!Number.isFinite(config.ui.map.cinema.panLngDegPerSec) || config.ui.map.cinema.panLngDegPerSec < 0) {
+      errors["ui.map.cinema.panLngDegPerSec"] = "Introduce una velocidad positiva";
+    }
+  }
+
+  if (supports("ui.map.cinema.bandTransition_sec")) {
+    if (!Number.isFinite(config.ui.map.cinema.bandTransition_sec) || config.ui.map.cinema.bandTransition_sec < 1) {
+      errors["ui.map.cinema.bandTransition_sec"] = "Debe ser mayor o igual a 1";
+    }
+  }
+
+  if (supports("ui.map.cinema.bands")) {
+    if (config.ui.map.cinema.bands.length !== CINEMA_BAND_COUNT) {
+      errors["ui.map.cinema.bands"] = `Configura exactamente ${CINEMA_BAND_COUNT} bandas`;
+    }
+    config.ui.map.cinema.bands.forEach((band, index) => {
+      const basePath = `ui.map.cinema.bands.${index}`;
+      if (!Number.isFinite(band.lat)) {
+        errors[`${basePath}.lat`] = "Latitud inválida";
+      }
+      if (!Number.isFinite(band.zoom)) {
+        errors[`${basePath}.zoom`] = "Zoom inválido";
+      }
+      if (!Number.isFinite(band.pitch)) {
+        errors[`${basePath}.pitch`] = "Pitch inválido";
+      }
+      if (!Number.isFinite(band.minZoom)) {
+        errors[`${basePath}.minZoom`] = "minZoom inválido";
+      }
+      if (!Number.isFinite(band.duration_sec) || band.duration_sec < 1) {
+        errors[`${basePath}.duration_sec`] = "Duración inválida";
+      }
+      if (Number.isFinite(band.minZoom) && Number.isFinite(band.zoom) && band.minZoom > band.zoom) {
+        errors[`${basePath}.minZoom`] = "minZoom debe ser menor o igual a zoom";
+      }
+    });
+  }
+
+  if (supports("ui.map.theme.contrast")) {
+    if (!Number.isFinite(config.ui.map.theme.contrast)) {
+      errors["ui.map.theme.contrast"] = "Introduce un número";
+    }
+  }
+
+  if (supports("ui.rotation.duration_sec")) {
+    const value = config.ui.rotation.duration_sec;
+    if (!Number.isFinite(value) || value < 3 || value > 3600) {
+      errors["ui.rotation.duration_sec"] = "Debe estar entre 3 y 3600";
+    }
+  }
+
+  if (supports("ui.rotation.panels")) {
+    const panels = config.ui.rotation.panels.filter((panel) => panel.trim().length > 0);
+    if (!panels.length) {
+      errors["ui.rotation.panels"] = "Selecciona al menos un panel";
+    }
+    const unique = new Set(panels.map((panel) => panel.toLowerCase()))
+      .size;
+    if (unique !== panels.length) {
+      errors["ui.rotation.panels"] = "Los paneles no pueden repetirse";
+    }
+  }
+
+  return errors;
+};
+
+const ConfigPage: React.FC = () => {
   const [form, setForm] = useState<AppConfig>(withConfigDefaults());
-  const [activeTab, setActiveTab] = useState<ConfigTab>("wifi");
+  const [schema, setSchema] = useState<Record<string, unknown> | null>(null);
+  const [status, setStatus] = useState<LoadStatus>("loading");
   const [saving, setSaving] = useState(false);
-  const [banner, setBanner] = useState<{ kind: "success" | "error"; text: string } | null>(null);
-  const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
+  const [banner, setBanner] = useState<Banner>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [newPanel, setNewPanel] = useState("");
+
+  const schemaInspector = useMemo(() => createSchemaInspector(schema ?? undefined), [schema]);
+  const supports = useCallback((path: string) => schemaInspector.has(path), [schemaInspector]);
+
+  const panelOptions = useMemo(() => {
+    const base = new Set<string>([...DEFAULT_PANELS, ...form.ui.rotation.panels]);
+    return Array.from(base);
+  }, [form.ui.rotation.panels]);
+
+  const resetErrorsFor = useCallback((pathPrefix: string) => {
+    setFieldErrors((prev) => {
+      const next: FieldErrors = {};
+      const prefix = `${pathPrefix}`;
+      for (const [key, value] of Object.entries(prev)) {
+        if (prefix) {
+          if (key === prefix || key.startsWith(`${prefix}.`)) {
+            continue;
+          }
+        }
+        next[key] = value;
+      }
+      return next;
+    });
+  }, []);
 
   const refreshConfig = useCallback(async () => {
     const cfg = await getConfig();
-    setForm(withConfigDefaults((cfg ?? {}) as AppConfig));
+    setForm(withConfigDefaults(cfg ?? undefined));
   }, []);
 
   const initialize = useCallback(async () => {
     setStatus("loading");
     setErrorMessage(null);
     setBanner(null);
+    setFieldErrors({});
     try {
       await getHealth();
+      const schemaPayload = await getSchema();
+      setSchema(schemaPayload ?? {});
       await refreshConfig();
       setStatus("ready");
     } catch (error) {
       console.error("[ConfigPage] Backend unreachable", error);
-      setErrorMessage(API_ERROR_MESSAGE);
       setStatus("error");
+      setErrorMessage(API_ERROR_MESSAGE);
       setBanner({ kind: "error", text: API_ERROR_MESSAGE });
     }
   }, [refreshConfig]);
@@ -89,599 +346,703 @@ export const ConfigPage: React.FC = () => {
     void initialize();
   }, [initialize]);
 
-  const update = useCallback(<K extends keyof AppConfig>(section: K, value: AppConfig[K]) => {
-    setForm((prev) => ({ ...prev, [section]: value }));
+  const updateForm = useCallback(<K extends keyof AppConfig>(key: K, value: AppConfig[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
   }, []);
 
-  const scrollPanels = useMemo(() => {
-    const keys = new Set<string>([...Object.keys(UI_DEFAULTS.text.scroll), ...Object.keys(form.ui.text.scroll)]);
-    return Array.from(keys);
-  }, [form.ui.text.scroll]);
+  const handleBandChange = (index: number, patch: Partial<MapCinemaBand>) => {
+    setForm((prev) => {
+      const nextBands = prev.ui.map.cinema.bands.map((band, bandIndex) =>
+        bandIndex === index ? { ...band, ...patch } : band,
+      );
+      return {
+        ...prev,
+        ui: {
+          ...prev.ui,
+          map: {
+            ...prev.ui.map,
+            cinema: {
+              ...prev.ui.map.cinema,
+              bands: nextBands,
+            },
+          },
+        },
+      };
+    });
+  };
 
-  const handleScrollChange = useCallback(
-    (panel: string, partial: Partial<UIScrollSettings>) => {
-      const current = form.ui.text.scroll[panel] ?? defaultScroll(panel);
-      update("ui", {
-        ...form.ui,
-        text: {
-          ...form.ui.text,
-          scroll: {
-            ...form.ui.text.scroll,
-            [panel]: { ...current, ...partial }
-          }
-        }
-      });
-    },
-    [form.ui, update]
-  );
+  const handlePanelsChange = (selected: string[]) => {
+    updateForm("ui", {
+      ...form.ui,
+      rotation: {
+        ...form.ui.rotation,
+        panels: selected,
+      },
+    });
+    resetErrorsFor("ui.rotation.panels");
+  };
+
+  const addPanel = () => {
+    const trimmed = newPanel.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (!form.ui.rotation.panels.includes(trimmed)) {
+      handlePanelsChange([...form.ui.rotation.panels, trimmed]);
+    }
+    setNewPanel("");
+  };
+
+  const isReady = status === "ready";
+  const disableInputs = !isReady || saving;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (status !== "ready") {
+    if (!isReady || saving) {
       return;
     }
+    const validationErrors = validateConfig(form, supports);
+    if (Object.keys(validationErrors).length > 0) {
+      setFieldErrors(validationErrors);
+      setBanner({ kind: "error", text: "Revisa los errores en la configuración" });
+      return;
+    }
+
     setSaving(true);
+    setBanner(null);
     try {
-      await saveConfig(form);
+      const saved = await saveConfig(form);
+      setForm(withConfigDefaults(saved));
+      setFieldErrors({});
       setBanner({ kind: "success", text: "Guardado" });
-      await refreshConfig();
     } catch (error) {
       console.error("[ConfigPage] Failed to save configuration", error);
-      setBanner({ kind: "error", text: "Error al guardar" });
+      if (error instanceof ApiError) {
+        const backendErrors = extractBackendErrors(error.body);
+        setFieldErrors(backendErrors);
+        const message = backendErrors.__root__ ?? "El backend rechazó la configuración";
+        setBanner({ kind: "error", text: message });
+      } else {
+        setBanner({ kind: "error", text: "Error al guardar" });
+      }
       try {
         await getHealth();
       } catch {
-        setErrorMessage(API_ERROR_MESSAGE);
         setStatus("error");
+        setErrorMessage(API_ERROR_MESSAGE);
       }
     } finally {
       setSaving(false);
     }
   };
 
-  const isReady = status === "ready";
-  const isLoading = status === "loading";
-  const disableInputs = !isReady || saving;
-  const showSkeleton = isLoading;
-
-  const renderWiFiTab = () => (
-    <div className="config-card">
-      <div>
-        <h2>Red Wi-Fi</h2>
-        <p>Gestiona la conectividad inalámbrica del dispositivo.</p>
-      </div>
-      <div className="config-grid">
-        <div className="config-field">
-          <label>Interfaz</label>
-          <input
-            type="text"
-            value={form.wifi.interface}
-            onChange={(event) => update("wifi", { ...form.wifi, interface: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>SSID</label>
-          <input
-            type="text"
-            value={form.wifi.ssid ?? ""}
-            onChange={(event) => update("wifi", { ...form.wifi, ssid: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>Contraseña</label>
-          <input
-            type="password"
-            value={form.wifi.psk ?? ""}
-            onChange={(event) => update("wifi", { ...form.wifi, psk: event.target.value })}
-          />
-        </div>
-      </div>
-    </div>
-  );
-
-  const renderAPITab = () => (
-    <div className="config-card">
-      <div>
-        <h2>Claves de API</h2>
-        <p>Define las credenciales necesarias para recuperar datos externos.</p>
-      </div>
-      <div className="config-grid">
-        <div className="config-field">
-          <label>API Clima</label>
-          <input
-            type="text"
-            value={form.api_keys.weather ?? ""}
-            onChange={(event) => update("api_keys", { ...form.api_keys, weather: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>API Noticias</label>
-          <input
-            type="text"
-            value={form.api_keys.news ?? ""}
-            onChange={(event) => update("api_keys", { ...form.api_keys, news: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>API Astronomía</label>
-          <input
-            type="text"
-            value={form.api_keys.astronomy ?? ""}
-            onChange={(event) => update("api_keys", { ...form.api_keys, astronomy: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>API Calendario</label>
-          <input
-            type="text"
-            value={form.api_keys.calendar ?? ""}
-            onChange={(event) => update("api_keys", { ...form.api_keys, calendar: event.target.value })}
-          />
-        </div>
-      </div>
-    </div>
-  );
-
-  const renderUITab = () => (
-    <div className="config-card">
-      <div>
-        <h2>Interfaz y datos</h2>
-        <p>Controla la rotación de módulos, el mapa y el formato de la pantalla.</p>
-      </div>
-
-      <section className="config-grid">
-        <div className="config-field">
-          <label>Zona horaria</label>
-          <input
-            type="text"
-            value={form.display.timezone}
-            onChange={(event) => update("display", { ...form.display, timezone: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>Rotación (legacy)</label>
-          <select
-            value={form.display.rotation}
-            onChange={(event) => update("display", { ...form.display, rotation: event.target.value })}
-          >
-            <option value="left">Izquierda</option>
-            <option value="normal">Normal</option>
-            <option value="right">Derecha</option>
-          </select>
-        </div>
-        <div className="config-field">
-          <label>Segundos por módulo (legacy)</label>
-          <input
-            type="number"
-            min={5}
-            max={600}
-            value={form.display.module_cycle_seconds}
-            onChange={(event) =>
-              update("display", { ...form.display, module_cycle_seconds: Number(event.target.value) })
-            }
-          />
-        </div>
-      </section>
-
-      <section className="config-grid">
-        <div className="config-field">
-          <label>Rotación de tarjetas</label>
-          <select
-            value={form.ui.rotation.enabled ? "true" : "false"}
-            onChange={(event) =>
-              update("ui", {
-                ...form.ui,
-                rotation: { ...form.ui.rotation, enabled: event.target.value === "true" }
-              })
-            }
-          >
-            {booleanOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="config-field">
-          <label>Duración por panel (segundos)</label>
-          <input
-            type="number"
-            min={3}
-            max={3600}
-            value={form.ui.rotation.duration_sec}
-            onChange={(event) =>
-              update("ui", {
-                ...form.ui,
-                rotation: { ...form.ui.rotation, duration_sec: Number(event.target.value) }
-              })
-            }
-          />
-        </div>
-        <div className="config-field" style={{ gridColumn: "1 / -1" }}>
-          <label>Paneles en rotación (uno por línea)</label>
-          <textarea
-            value={form.ui.rotation.panels.join("\n")}
-            onChange={(event) =>
-              update("ui", {
-                ...form.ui,
-                rotation: { ...form.ui.rotation, panels: parsePanelsInput(event.target.value) }
-              })
-            }
-          />
-        </div>
-      </section>
-
-      <section className="config-grid">
-        <div className="config-field">
-          <label>Proveedor de mapas</label>
-          <input
-            type="text"
-            value={form.ui.map.provider}
-            onChange={(event) => update("ui", { ...form.ui, map: { ...form.ui.map, provider: event.target.value } })}
-          />
-        </div>
-        <div className="config-field">
-          <label>Centro (latitud)</label>
-          <input
-            type="number"
-            value={form.ui.map.center[0]}
-            onChange={(event) =>
-              update("ui", {
-                ...form.ui,
-                map: { ...form.ui.map, center: [Number(event.target.value), form.ui.map.center[1]] }
-              })
-            }
-          />
-        </div>
-        <div className="config-field">
-          <label>Centro (longitud)</label>
-          <input
-            type="number"
-            value={form.ui.map.center[1]}
-            onChange={(event) =>
-              update("ui", {
-                ...form.ui,
-                map: { ...form.ui.map, center: [form.ui.map.center[0], Number(event.target.value)] }
-              })
-            }
-          />
-        </div>
-        <div className="config-field">
-          <label>Zoom</label>
-          <input
-            type="number"
-            min={0}
-            max={18}
-            value={form.ui.map.zoom}
-            onChange={(event) => update("ui", { ...form.ui, map: { ...form.ui.map, zoom: Number(event.target.value) } })}
-          />
-        </div>
-        <div className="config-field">
-          <label>Interacción</label>
-          <select
-            value={form.ui.map.interactive ? "true" : "false"}
-            onChange={(event) =>
-              update("ui", {
-                ...form.ui,
-                map: { ...form.ui.map, interactive: event.target.value === "true" }
-              })
-            }
-          >
-            {booleanOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="config-field">
-          <label>Controles</label>
-          <select
-            value={form.ui.map.controls ? "true" : "false"}
-            onChange={(event) =>
-              update("ui", { ...form.ui, map: { ...form.ui.map, controls: event.target.value === "true" } })
-            }
-          >
-            {booleanOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
-      </section>
-
-      <section className="config-grid">
-        <div className="config-field">
-          <label>Formato de hora</label>
-          <input
-            type="text"
-            value={form.ui.fixed.clock.format}
-            onChange={(event) =>
-              update("ui", {
-                ...form.ui,
-                fixed: {
-                  ...form.ui.fixed,
-                  clock: { ...form.ui.fixed.clock, format: event.target.value }
-                }
-              })
-            }
-          />
-        </div>
-        <div className="config-field">
-          <label>Unidad de temperatura (C/F/K)</label>
-          <input
-            type="text"
-            value={form.ui.fixed.temperature.unit}
-            onChange={(event) =>
-              update("ui", {
-                ...form.ui,
-                fixed: {
-                  ...form.ui.fixed,
-                  temperature: { ...form.ui.fixed.temperature, unit: event.target.value }
-                }
-              })
-            }
-          />
-        </div>
-      </section>
-
-      <section className="config-grid" style={{ gridTemplateColumns: "1fr" }}>
-        <div className="config-field">
-          <label>Scroll automático por panel</label>
-          <div className="config-grid" style={{ gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
-            {scrollPanels.map((panel) => {
-              const current = form.ui.text.scroll[panel] ?? defaultScroll(panel);
-              const speedValue = typeof current.speed === "number" ? String(current.speed) : current.speed;
-              return (
-                <fieldset key={panel} className="config-field" style={{ borderRadius: "16px", border: "1px solid rgba(109,182,255,0.2)", padding: "14px 16px" }}>
-                  <legend style={{ padding: "0 8px", fontSize: "0.95rem" }}>{panel}</legend>
-                  <div className="config-field">
-                    <label>Activar scroll</label>
-                    <select
-                      value={current.enabled ? "true" : "false"}
-                      onChange={(event) => handleScrollChange(panel, { enabled: event.target.value === "true" })}
-                    >
-                      {booleanOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="config-field">
-                    <label>Dirección</label>
-                    <select
-                      value={current.direction}
-                      onChange={(event) => handleScrollChange(panel, { direction: event.target.value as "left" | "up" })}
-                    >
-                      {directionOptions.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                  <div className="config-field">
-                    <label>Velocidad ({speedPlaceholders})</label>
-                    <input
-                      type="text"
-                      value={speedValue}
-                      onChange={(event) =>
-                        handleScrollChange(panel, { speed: parseSpeedInput(event.target.value, current.speed) })
-                      }
-                      list={`speed-${panel}`}
-                    />
-                    <datalist id={`speed-${panel}`}>
-                      <option value="slow" />
-                      <option value="normal" />
-                      <option value="fast" />
-                    </datalist>
-                  </div>
-                  <div className="config-field">
-                    <label>Separación (px)</label>
-                    <input
-                      type="number"
-                      min={0}
-                      value={current.gap_px}
-                      onChange={(event) => handleScrollChange(panel, { gap_px: Number(event.target.value) })}
-                    />
-                  </div>
-                </fieldset>
-              );
-            })}
-          </div>
-        </div>
-      </section>
-    </div>
-  );
-
-  const renderSystemTab = () => (
-    <div className="config-card">
-      <div>
-        <h2>Servicios del sistema</h2>
-        <p>Configura MQTT y revisa los módulos activos del dashboard.</p>
-      </div>
-      <section className="config-grid">
-        <div className="config-field">
-          <label>MQTT habilitado</label>
-          <select
-            value={form.mqtt.enabled ? "true" : "false"}
-            onChange={(event) => update("mqtt", { ...form.mqtt, enabled: event.target.value === "true" })}
-          >
-            {booleanOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="config-field">
-          <label>Host</label>
-          <input
-            type="text"
-            value={form.mqtt.host}
-            onChange={(event) => update("mqtt", { ...form.mqtt, host: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>Puerto</label>
-          <input
-            type="number"
-            value={form.mqtt.port}
-            onChange={(event) => update("mqtt", { ...form.mqtt, port: Number(event.target.value) })}
-          />
-        </div>
-        <div className="config-field">
-          <label>Tópico</label>
-          <input
-            type="text"
-            value={form.mqtt.topic}
-            onChange={(event) => update("mqtt", { ...form.mqtt, topic: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>Usuario</label>
-          <input
-            type="text"
-            value={form.mqtt.username ?? ""}
-            onChange={(event) => update("mqtt", { ...form.mqtt, username: event.target.value })}
-          />
-        </div>
-        <div className="config-field">
-          <label>Contraseña</label>
-          <input
-            type="password"
-            value={form.mqtt.password ?? ""}
-            onChange={(event) => update("mqtt", { ...form.mqtt, password: event.target.value })}
-          />
-        </div>
-      </section>
-      <section>
-        <h3>Módulos de pantalla</h3>
-        <p className="config-status">Puedes activar o desactivar los módulos directamente en el archivo de configuración.</p>
-        <ul className="saints-card__list" style={{ marginTop: "12px" }}>
-          {form.display.modules.map((module) => (
-            <li key={module.name}>
-              <span className="harvest-card__item">{module.name}</span>
-              <span className="harvest-card__status">
-                {module.enabled ? `Activo (${module.duration_seconds}s)` : "Desactivado"}
-              </span>
-            </li>
-          ))}
-        </ul>
-      </section>
-    </div>
-  );
-
-  const renderActiveTab = () => {
-    switch (activeTab) {
-      case "wifi":
-        return renderWiFiTab();
-      case "api":
-        return renderAPITab();
-      case "ui":
-        return renderUITab();
-      case "system":
-        return renderSystemTab();
-      default:
-        return null;
+  const renderFieldError = (path: string) => {
+    const message = fieldErrors[path];
+    if (!message) {
+      return null;
     }
+    return <span className="config-field__error">{message}</span>;
   };
 
-  const apiStatusLabel =
-    status === "loading" ? "API checking" : status === "ready" ? "API online" : "API offline";
-  const apiStatusClass =
-    status === "loading" ? " is-pending" : status === "ready" ? " is-online" : " is-offline";
-  const apiHint =
-    status === "loading"
-      ? "Comprobando el estado del backend…"
-      : status === "ready"
-      ? `Conectado al backend en ${API_ORIGIN}.`
-      : `API offline. ${API_ERROR_MESSAGE}`;
-
-  const renderSkeleton = () => (
-    <div className="config-skeleton" aria-hidden="true">
-      {[0, 1, 2].map((index) => (
-        <div key={index} className="config-skeleton__block" />
-      ))}
-    </div>
-  );
+  const renderHelp = (text: string) => {
+    return <span className="config-field__hint">{text}</span>;
+  };
 
   return (
     <div className="config-page">
-      <form className="config-page__container" onSubmit={handleSubmit}>
-        <div className={`config-status-bar${apiStatusClass}`}>
-          <span className="config-status-bar__label">{apiStatusLabel}</span>
-          <span className="config-status-bar__hint">{apiHint}</span>
+      {banner && (
+        <div className={`config-status config-status--${banner.kind}`} role="status">
+          {banner.text}
         </div>
-        <header className="config-page__header">
-          <h1>Configuración del sistema</h1>
-          <p>Gestiona la pantalla desde una red segura. Todas las opciones residen en esta consola.</p>
-        </header>
+      )}
 
-        {banner ? (
-          <div
-            className={`config-status${banner.kind === "error" ? " config-status--error" : " config-status--success"}`}
-            role="status"
-            aria-live="polite"
-          >
-            {banner.text}
+      {status === "error" && (
+        <div className="config-status config-status--error config-error-callout">
+          <p>{errorMessage ?? API_ERROR_MESSAGE}</p>
+          <button type="button" onClick={() => void initialize()} className="config-button primary">
+            Reintentar
+          </button>
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="config-form">
+        {supports("display") && (
+          <div className="config-card">
+            <div>
+              <h2>Reloj</h2>
+              <p>Define la zona horaria y el ritmo del carrusel principal.</p>
+            </div>
+            <div className="config-grid">
+              {supports("display.timezone") && (
+                <div className="config-field">
+                  <label htmlFor="timezone">Zona horaria</label>
+                  <input
+                    id="timezone"
+                    type="text"
+                    value={form.display.timezone}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      updateForm("display", {
+                        ...form.display,
+                        timezone: event.target.value,
+                      });
+                      resetErrorsFor("display.timezone");
+                    }}
+                  />
+                  {renderHelp("Formato IANA, p. ej. Europe/Madrid")}
+                  {renderFieldError("display.timezone")}
+                </div>
+              )}
+
+              {supports("display.module_cycle_seconds") && (
+                <div className="config-field">
+                  <label htmlFor="module_cycle">Segundos por módulo</label>
+                  <input
+                    id="module_cycle"
+                    type="number"
+                    min={5}
+                    max={600}
+                    value={form.display.module_cycle_seconds}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      if (Number.isNaN(value)) {
+                        return;
+                      }
+                      updateForm("display", {
+                        ...form.display,
+                        module_cycle_seconds: value,
+                      });
+                      resetErrorsFor("display.module_cycle_seconds");
+                    }}
+                  />
+                  {renderHelp("Tiempo que cada módulo permanece en pantalla")}
+                  {renderFieldError("display.module_cycle_seconds")}
+                </div>
+              )}
+            </div>
           </div>
-        ) : null}
+        )}
 
-        {status === "error" && errorMessage ? (
-          <div className="config-status config-status--error config-error-callout">
-            <p>{errorMessage}</p>
-            <button
-              type="button"
-              className="config-button"
-              onClick={() => {
-                void initialize();
-              }}
-              disabled={isLoading}
-            >
-              Reintentar
-            </button>
+        {supports("ui.map") && (
+          <div className="config-card">
+            <div>
+              <h2>Mapa</h2>
+              <p>Configura el estilo, proveedor y modo cine del mapa principal.</p>
+            </div>
+            <div className="config-grid">
+              {supports("ui.map.style") && (
+                <div className="config-field">
+                  <label htmlFor="map_style">Estilo</label>
+                  <select
+                    id="map_style"
+                    value={form.ui.map.style}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      updateForm("ui", {
+                        ...form.ui,
+                        map: { ...form.ui.map, style: event.target.value as AppConfig["ui"]["map"]["style"] },
+                      });
+                      resetErrorsFor("ui.map.style");
+                    }}
+                  >
+                    {MAP_STYLE_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                  {renderHelp("Tema base del mapa (vector o raster)")}
+                  {renderFieldError("ui.map.style")}
+                </div>
+              )}
+
+              {supports("ui.map.provider") && (
+                <div className="config-field">
+                  <label htmlFor="map_provider">Proveedor</label>
+                  <select
+                    id="map_provider"
+                    value={form.ui.map.provider}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      updateForm("ui", {
+                        ...form.ui,
+                        map: { ...form.ui.map, provider: event.target.value as AppConfig["ui"]["map"]["provider"] },
+                      });
+                      resetErrorsFor("ui.map.provider");
+                    }}
+                  >
+                    {MAP_PROVIDER_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                  {renderHelp("Proveedor de teselas para el mapa")}
+                  {renderFieldError("ui.map.provider")}
+                </div>
+              )}
+
+              {supports("ui.map.maptiler.key") && (
+                <div className="config-field">
+                  <label htmlFor="maptiler_key">Clave MapTiler</label>
+                  <input
+                    id="maptiler_key"
+                    type="text"
+                    value={form.ui.map.maptiler.key ?? ""}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      updateForm("ui", {
+                        ...form.ui,
+                        map: {
+                          ...form.ui.map,
+                          maptiler: {
+                            ...form.ui.map.maptiler,
+                            key: event.target.value || null,
+                          },
+                        },
+                      });
+                    }}
+                  />
+                  {renderHelp("Necesaria para MapTiler (vacío si usas Carto)")}
+                </div>
+              )}
+
+              {supports("ui.map.cinema.panLngDegPerSec") && (
+                <div className="config-field">
+                  <label htmlFor="cinema_pan">Velocidad panorámica</label>
+                  <input
+                    id="cinema_pan"
+                    type="number"
+                    step="0.01"
+                    value={form.ui.map.cinema.panLngDegPerSec}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      if (Number.isNaN(value)) {
+                        return;
+                      }
+                      setForm((prev) => ({
+                        ...prev,
+                        ui: {
+                          ...prev.ui,
+                          map: {
+                            ...prev.ui.map,
+                            cinema: {
+                              ...prev.ui.map.cinema,
+                              panLngDegPerSec: value,
+                            },
+                          },
+                        },
+                      }));
+                      resetErrorsFor("ui.map.cinema.panLngDegPerSec");
+                    }}
+                  />
+                  {renderHelp("Grados de longitud por segundo")}
+                  {renderFieldError("ui.map.cinema.panLngDegPerSec")}
+                </div>
+              )}
+
+              {supports("ui.map.cinema.bandTransition_sec") && (
+                <div className="config-field">
+                  <label htmlFor="cinema_transition">Transición entre bandas</label>
+                  <input
+                    id="cinema_transition"
+                    type="number"
+                    min={1}
+                    value={form.ui.map.cinema.bandTransition_sec}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      if (Number.isNaN(value)) {
+                        return;
+                      }
+                      setForm((prev) => ({
+                        ...prev,
+                        ui: {
+                          ...prev.ui,
+                          map: {
+                            ...prev.ui.map,
+                            cinema: {
+                              ...prev.ui.map.cinema,
+                              bandTransition_sec: value,
+                            },
+                          },
+                        },
+                      }));
+                      resetErrorsFor("ui.map.cinema.bandTransition_sec");
+                    }}
+                  />
+                  {renderHelp("Duración de la transición en segundos")}
+                  {renderFieldError("ui.map.cinema.bandTransition_sec")}
+                </div>
+              )}
+            </div>
+
+            {supports("ui.map.cinema.bands") && (
+              <div className="config-field">
+                <label>Bandas cinematográficas</label>
+                {renderHelp("Seis posiciones predefinidas para el recorrido mundial")}
+                {renderFieldError("ui.map.cinema.bands")}
+                <div className="config-table">
+                  <div className="config-table__header">
+                    <span>Banda</span>
+                    <span>Latitud</span>
+                    <span>Zoom</span>
+                    <span>Pitch</span>
+                    <span>minZoom</span>
+                    <span>Duración (s)</span>
+                  </div>
+                  {form.ui.map.cinema.bands.map((band, index) => (
+                    <div key={index} className="config-table__row">
+                      <span className="config-table__label">{index + 1}</span>
+                      <div className="config-table__cell">
+                        <input
+                          type="number"
+                          disabled={disableInputs}
+                          value={band.lat}
+                          onChange={(event) => {
+                            const value = Number(event.target.value);
+                            if (Number.isNaN(value)) return;
+                            handleBandChange(index, { lat: value });
+                            resetErrorsFor(`ui.map.cinema.bands.${index}.lat`);
+                          }}
+                        />
+                        {renderFieldError(`ui.map.cinema.bands.${index}.lat`)}
+                      </div>
+                      <div className="config-table__cell">
+                        <input
+                          type="number"
+                          step="0.1"
+                          disabled={disableInputs}
+                          value={band.zoom}
+                          onChange={(event) => {
+                            const value = Number(event.target.value);
+                            if (Number.isNaN(value)) return;
+                            handleBandChange(index, { zoom: value });
+                            resetErrorsFor(`ui.map.cinema.bands.${index}.zoom`);
+                          }}
+                        />
+                        {renderFieldError(`ui.map.cinema.bands.${index}.zoom`)}
+                      </div>
+                      <div className="config-table__cell">
+                        <input
+                          type="number"
+                          step="0.1"
+                          disabled={disableInputs}
+                          value={band.pitch}
+                          onChange={(event) => {
+                            const value = Number(event.target.value);
+                            if (Number.isNaN(value)) return;
+                            handleBandChange(index, { pitch: value });
+                            resetErrorsFor(`ui.map.cinema.bands.${index}.pitch`);
+                          }}
+                        />
+                        {renderFieldError(`ui.map.cinema.bands.${index}.pitch`)}
+                      </div>
+                      <div className="config-table__cell">
+                        <input
+                          type="number"
+                          step="0.1"
+                          disabled={disableInputs}
+                          value={band.minZoom}
+                          onChange={(event) => {
+                            const value = Number(event.target.value);
+                            if (Number.isNaN(value)) return;
+                            handleBandChange(index, { minZoom: value });
+                            resetErrorsFor(`ui.map.cinema.bands.${index}.minZoom`);
+                          }}
+                        />
+                        {renderFieldError(`ui.map.cinema.bands.${index}.minZoom`)}
+                      </div>
+                      <div className="config-table__cell">
+                        <input
+                          type="number"
+                          min={1}
+                          disabled={disableInputs}
+                          value={band.duration_sec}
+                          onChange={(event) => {
+                            const value = Number(event.target.value);
+                            if (Number.isNaN(value)) return;
+                            handleBandChange(index, { duration_sec: value });
+                            resetErrorsFor(`ui.map.cinema.bands.${index}.duration_sec`);
+                          }}
+                        />
+                        {renderFieldError(`ui.map.cinema.bands.${index}.duration_sec`)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {supports("ui.map.theme") && (
+              <div className="config-grid">
+                {supports("ui.map.theme.sea") && (
+                  <div className="config-field">
+                    <label htmlFor="theme_sea">Color mar</label>
+                    <input
+                      id="theme_sea"
+                      type="text"
+                      value={form.ui.map.theme.sea}
+                      disabled={disableInputs}
+                      onChange={(event) => {
+                        setForm((prev) => ({
+                          ...prev,
+                          ui: {
+                            ...prev.ui,
+                            map: {
+                              ...prev.ui.map,
+                              theme: { ...prev.ui.map.theme, sea: event.target.value },
+                            },
+                          },
+                        }));
+                      }}
+                    />
+                    {renderHelp("Color hexadecimal del agua")}
+                  </div>
+                )}
+
+                {supports("ui.map.theme.land") && (
+                  <div className="config-field">
+                    <label htmlFor="theme_land">Color tierra</label>
+                    <input
+                      id="theme_land"
+                      type="text"
+                      value={form.ui.map.theme.land}
+                      disabled={disableInputs}
+                      onChange={(event) => {
+                        setForm((prev) => ({
+                          ...prev,
+                          ui: {
+                            ...prev.ui,
+                            map: {
+                              ...prev.ui.map,
+                              theme: { ...prev.ui.map.theme, land: event.target.value },
+                            },
+                          },
+                        }));
+                      }}
+                    />
+                    {renderHelp("Color base para continentes")}
+                  </div>
+                )}
+
+                {supports("ui.map.theme.label") && (
+                  <div className="config-field">
+                    <label htmlFor="theme_label">Color etiquetas</label>
+                    <input
+                      id="theme_label"
+                      type="text"
+                      value={form.ui.map.theme.label}
+                      disabled={disableInputs}
+                      onChange={(event) => {
+                        setForm((prev) => ({
+                          ...prev,
+                          ui: {
+                            ...prev.ui,
+                            map: {
+                              ...prev.ui.map,
+                              theme: { ...prev.ui.map.theme, label: event.target.value },
+                            },
+                          },
+                        }));
+                      }}
+                    />
+                    {renderHelp("Color de texto en el mapa")}
+                  </div>
+                )}
+
+                {supports("ui.map.theme.contrast") && (
+                  <div className="config-field">
+                    <label htmlFor="theme_contrast">Contraste</label>
+                    <input
+                      id="theme_contrast"
+                      type="number"
+                      step="0.01"
+                      value={form.ui.map.theme.contrast}
+                      disabled={disableInputs}
+                      onChange={(event) => {
+                        const value = Number(event.target.value);
+                        if (Number.isNaN(value)) return;
+                        setForm((prev) => ({
+                          ...prev,
+                          ui: {
+                            ...prev.ui,
+                            map: {
+                              ...prev.ui.map,
+                              theme: { ...prev.ui.map.theme, contrast: value },
+                            },
+                          },
+                        }));
+                        resetErrorsFor("ui.map.theme.contrast");
+                      }}
+                    />
+                    {renderHelp("Intensidad del contraste adicional")}
+                    {renderFieldError("ui.map.theme.contrast")}
+                  </div>
+                )}
+
+                {supports("ui.map.theme.tint") && (
+                  <div className="config-field">
+                    <label htmlFor="theme_tint">Capa de tinte</label>
+                    <input
+                      id="theme_tint"
+                      type="text"
+                      value={form.ui.map.theme.tint}
+                      disabled={disableInputs}
+                      onChange={(event) => {
+                        setForm((prev) => ({
+                          ...prev,
+                          ui: {
+                            ...prev.ui,
+                            map: {
+                              ...prev.ui.map,
+                              theme: { ...prev.ui.map.theme, tint: event.target.value },
+                            },
+                          },
+                        }));
+                      }}
+                    />
+                    {renderHelp("RGBA opcional para resaltar el mapa")}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
-        ) : null}
+        )}
 
-        <fieldset className="config-form-fields" disabled={disableInputs}>
-          <div className="config-tabs">
-            {tabs.map((tab) => (
-              <button
-                key={tab.id}
-                type="button"
-                className={`config-tab${activeTab === tab.id ? " is-active" : ""}`}
-                onClick={() => setActiveTab(tab.id)}
-                disabled={disableInputs}
-              >
-                {tab.label}
-              </button>
-            ))}
+        {supports("ui.rotation") && (
+          <div className="config-card">
+            <div>
+              <h2>Rotación de paneles</h2>
+              <p>Controla la duración y las tarjetas presentes en la rotación.</p>
+            </div>
+            <div className="config-grid">
+              {supports("ui.rotation.duration_sec") && (
+                <div className="config-field">
+                  <label htmlFor="rotation_duration">Duración por panel</label>
+                  <input
+                    id="rotation_duration"
+                    type="number"
+                    min={3}
+                    max={3600}
+                    value={form.ui.rotation.duration_sec}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      const value = Number(event.target.value);
+                      if (Number.isNaN(value)) return;
+                      updateForm("ui", {
+                        ...form.ui,
+                        rotation: { ...form.ui.rotation, duration_sec: value },
+                      });
+                      resetErrorsFor("ui.rotation.duration_sec");
+                    }}
+                  />
+                  {renderHelp("Segundos que dura cada tarjeta en pantalla")}
+                  {renderFieldError("ui.rotation.duration_sec")}
+                </div>
+              )}
+
+              {supports("ui.rotation.panels") && (
+                <div className="config-field">
+                  <label htmlFor="rotation_panels">Paneles en rotación</label>
+                  <select
+                    id="rotation_panels"
+                    multiple
+                    value={form.ui.rotation.panels}
+                    disabled={disableInputs}
+                    onChange={(event) => {
+                      const selected = Array.from(event.target.selectedOptions).map((option) => option.value);
+                      handlePanelsChange(selected);
+                      resetErrorsFor("ui.rotation.panels");
+                    }}
+                  >
+                    {panelOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                  {renderHelp("Selecciona los paneles que deben rotar")}
+                  {renderFieldError("ui.rotation.panels")}
+                  <div className="config-field__inline">
+                    <input
+                      type="text"
+                      value={newPanel}
+                      disabled={disableInputs}
+                      placeholder="Añadir panel personalizado"
+                      onChange={(event) => setNewPanel(event.target.value)}
+                    />
+                    <button
+                      type="button"
+                      className="config-button"
+                      disabled={disableInputs || !newPanel.trim()}
+                      onClick={addPanel}
+                    >
+                      Añadir
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
           </div>
+        )}
 
-          {showSkeleton ? renderSkeleton() : renderActiveTab()}
+        {(supports("news.enabled") || supports("ai.enabled")) && (
+          <div className="config-card">
+            <div>
+              <h2>Módulos</h2>
+              <p>Activa o desactiva contenido adicional.</p>
+            </div>
+            <div className="config-grid">
+              {supports("news.enabled") && (
+                <div className="config-field config-field--checkbox">
+                  <label htmlFor="news_enabled">
+                    <input
+                      id="news_enabled"
+                      type="checkbox"
+                      checked={form.news.enabled}
+                      disabled={disableInputs}
+                      onChange={(event) => {
+                        updateForm("news", { enabled: event.target.checked });
+                      }}
+                    />
+                    Mostrar noticias
+                  </label>
+                  {renderHelp("Activa el módulo de titulares RSS")}
+                </div>
+              )}
 
-          <div className="config-actions">
-            <button
-              type="button"
-              className="config-button"
-              onClick={() => navigate("/")}
-              disabled={disableInputs}
-            >
-              Volver al panel
-            </button>
-            <button className="config-button primary" type="submit" disabled={disableInputs}>
-              {saving ? "Guardando…" : "Guardar cambios"}
-            </button>
+              {supports("ai.enabled") && (
+                <div className="config-field config-field--checkbox">
+                  <label htmlFor="ai_enabled">
+                    <input
+                      id="ai_enabled"
+                      type="checkbox"
+                      checked={form.ai.enabled}
+                      disabled={disableInputs}
+                      onChange={(event) => {
+                        updateForm("ai", { enabled: event.target.checked });
+                      }}
+                    />
+                    Funciones experimentales de IA
+                  </label>
+                  {renderHelp("Reserva para experiencias asistidas por IA")}
+                </div>
+              )}
+            </div>
           </div>
-        </fieldset>
+        )}
 
-        <footer className="config-page__footer">Backend: {API_ORIGIN}</footer>
+        <div className="config-actions">
+          <button type="submit" className="config-button primary" disabled={disableInputs}>
+            {saving ? "Guardando…" : "Guardar"}
+          </button>
+        </div>
       </form>
     </div>
   );
 };
 
-export default ConfigPage;
+export { ConfigPage };

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -872,6 +872,28 @@ main {
   resize: vertical;
 }
 
+.config-field__hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.config-field__error {
+  font-size: 0.8rem;
+  color: var(--danger);
+}
+
+.config-field__inline {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.config-field__inline input[type="text"],
+.config-field__inline input[type="number"] {
+  flex: 1;
+}
+
 .config-actions {
   display: flex;
   justify-content: flex-end;
@@ -899,6 +921,23 @@ main {
   cursor: not-allowed;
 }
 
+.config-field--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+
+.config-field--checkbox label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.config-field--checkbox input[type="checkbox"] {
+  width: auto;
+}
+
 .config-status {
   font-size: 0.95rem;
 }
@@ -923,6 +962,42 @@ main {
 
 .config-error-callout p {
   margin: 0;
+}
+
+.config-table {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.config-table__header,
+.config-table__row {
+  display: grid;
+  grid-template-columns: 0.8fr repeat(5, minmax(80px, 1fr));
+  gap: 12px;
+  align-items: center;
+}
+
+.config-table__header {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.config-table__label {
+  font-weight: 600;
+}
+
+.config-table__cell {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.config-table__row input {
+  width: 100%;
 }
 
 .config-status-bar {

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -1,68 +1,9 @@
-export type DisplayModule = {
-  name: string;
-  enabled: boolean;
-  duration_seconds: number;
-};
-
-export type DisplaySettings = {
+export type DisplayConfig = {
   timezone: string;
-  rotation: string;
   module_cycle_seconds: number;
-  modules: DisplayModule[];
 };
 
-export type APIKeys = {
-  weather: string | null;
-  news: string | null;
-  astronomy: string | null;
-  calendar: string | null;
-};
-
-export type MQTTSettings = {
-  enabled: boolean;
-  host: string;
-  port: number;
-  topic: string;
-  username: string | null;
-  password: string | null;
-};
-
-export type WiFiSettings = {
-  interface: string;
-  ssid: string | null;
-  psk: string | null;
-};
-
-export type StormMode = {
-  enabled: boolean;
-  last_triggered: string | null;
-};
-
-export type UIScrollSpeed = number | "slow" | "normal" | "fast";
-
-export type UIScrollSettings = {
-  enabled: boolean;
-  direction: "left" | "up";
-  speed: UIScrollSpeed;
-  gap_px: number;
-};
-
-export type UITextSettings = {
-  scroll: Record<string, UIScrollSettings>;
-};
-
-export type UIFixedSettings = {
-  clock: { format: string };
-  temperature: { unit: string };
-};
-
-export type UIRotationSettings = {
-  enabled: boolean;
-  duration_sec: number;
-  panels: string[];
-};
-
-export type UIMapCinemaBand = {
+export type MapCinemaBand = {
   lat: number;
   zoom: number;
   pitch: number;
@@ -70,59 +11,65 @@ export type UIMapCinemaBand = {
   duration_sec: number;
 };
 
-export type UIMapCinemaSettings = {
+export type UIScrollSpeed = number | "slow" | "normal" | "fast";
+
+export type MapCinemaConfig = {
   enabled: boolean;
   panLngDegPerSec: number;
-  bands: UIMapCinemaBand[];
   bandTransition_sec: number;
+  bands: MapCinemaBand[];
 };
 
-export type UIMapThemeSettings = {
-  sea?: string | null;
-  land?: string | null;
-  label?: string | null;
-  contrast?: number | null;
-  tint?: string | null;
+export type MapThemeConfig = {
+  sea: string;
+  land: string;
+  label: string;
+  contrast: number;
+  tint: string;
 };
 
-export type UIMapProviderMapTiler = {
-  key?: string | null;
-  styleUrlDark?: string | null;
-  styleUrlLight?: string | null;
-  styleUrlBright?: string | null;
+export type MaptilerConfig = {
+  key: string | null;
+  styleUrlDark: string | null;
+  styleUrlLight: string | null;
+  styleUrlBright: string | null;
 };
 
-export type UIMapSettings = {
-  engine?: string;
-  provider: string;
-  center: [number, number];
-  zoom: number;
+export type MapConfig = {
+  engine: "maplibre";
+  style: "vector-dark" | "vector-light" | "vector-bright" | "raster-carto-dark" | "raster-carto-light";
+  provider: "maptiler" | "carto";
+  maptiler: MaptilerConfig;
+  renderWorldCopies: boolean;
   interactive: boolean;
   controls: boolean;
-  renderWorldCopies?: boolean;
-  cinema?: UIMapCinemaSettings;
-  style?: string;
-  theme?: UIMapThemeSettings;
-  maptiler?: UIMapProviderMapTiler;
+  cinema: MapCinemaConfig;
+  theme: MapThemeConfig;
 };
 
-export type UISettings = {
-  rotation: UIRotationSettings;
-  fixed: UIFixedSettings;
-  map: UIMapSettings;
-  text: UITextSettings;
-  layout?: "full" | "widgets";
-  side_panel?: "left" | "right";
-  show_config?: boolean;
-  enable_demo?: boolean;
-  carousel?: boolean;
+export type RotationConfig = {
+  enabled: boolean;
+  duration_sec: number;
+  panels: string[];
+};
+
+export type UIConfig = {
+  layout: "grid-2-1";
+  map: MapConfig;
+  rotation: RotationConfig;
+};
+
+export type NewsConfig = {
+  enabled: boolean;
+};
+
+export type AIConfig = {
+  enabled: boolean;
 };
 
 export type AppConfig = {
-  display: DisplaySettings;
-  api_keys: APIKeys;
-  mqtt: MQTTSettings;
-  wifi: WiFiSettings;
-  storm_mode: StormMode;
-  ui: UISettings;
+  display: DisplayConfig;
+  ui: UIConfig;
+  news: NewsConfig;
+  ai: AIConfig;
 };


### PR DESCRIPTION
## Summary
- replace the backend configuration models with the supported v1.5 schema and expose `/api/config/schema`
- add atomic config persistence with daily snapshots and payload-size validation
- update the dashboard UI to render only schema-backed fields with inline validation and new API helpers

## Testing
- python -m compileall backend
- npm install *(fails: registry.npmjs.org returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ffc18ad7f8832682f45661da6d5c41