### PR TITLE
Fix install verification order for backend health

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -394,13 +394,6 @@ configure_nginx() {
   else
     log_info "Backend OK (HTTP 200)"
   fi
-
-  log_info "Ejecutando verificador post-deploy"
-  if ! "$REPO_ROOT/scripts/verify_api.sh"; then
-    log_error "La verificación de Nginx/API falló"
-    exit 1
-  fi
-  log_info "Verificador post-deploy completado"
 }
 
 configure_nginx
@@ -541,6 +534,13 @@ else
   log_warn "Backend /api/health not responding yet"
   SUMMARY+=('[install] backend /api/health no responde')
 fi
+
+log_info "Ejecutando verificador post-deploy"
+if ! "$REPO_ROOT/scripts/verify_api.sh"; then
+  log_error "La verificación de Nginx/API falló"
+  exit 1
+fi
+log_info "Verificador post-deploy completado"
 
 if DISPLAY=:0 XAUTHORITY=/home/${USER_NAME}/.Xauthority wmctrl -lx | grep -q 'chromium-browser\.pantalla-kiosk'; then
   log_ok "Ventana de Chromium detectada"


### PR DESCRIPTION
## Summary
- avoid running the API verifier before the FastAPI backend is started by systemd
- keep nginx checks intact while ensuring the post-deploy verifier runs after the backend restart

## Testing
- bash -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_69003848b3c08326839e0db04e2be811