### PR TITLE
Define connection_upgrade map for nginx

### DIFF
--- a/deploy/nginx/pantalla-reloj.conf
+++ b/deploy/nginx/pantalla-reloj.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
 server {
   listen 80;
   listen [::]:80;

--- a/etc/nginx/sites-available/pantalla-reloj.conf
+++ b/etc/nginx/sites-available/pantalla-reloj.conf
@@ -1,3 +1,8 @@
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
 server {
   listen 80;
   listen [::]:80;


### PR DESCRIPTION
## Summary
- define the connection_upgrade map in the nginx configuration used by the installer
- ensure the same websocket header mapping is present in the deployed nginx site

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690048c2bd188326a4219c039774dab9