### PR TITLE
Install gnupg before fetching Node.js from NodeSource

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -138,6 +138,7 @@ APT_PACKAGES=(
   jq
   rsync
   file
+  gnupg  # required for NodeSource key import
   xauth
   python3-venv
   unclutter-xfixes


### PR DESCRIPTION
## Summary
- ensure the installer pulls in gnupg so the NodeSource setup script can import its signing key

## Testing
- bash -n scripts/install.sh

------
https://chatgpt.com/codex/tasks/task_e_69009de56ca88326bf803270cae682e6