### PR TITLE
Improve Chromium kiosk supervision

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -18,6 +18,8 @@ Options:
   --purge-node      Remove frontend node_modules/dist artifacts
   --purge-assets    Remove assets stored in /opt/pantalla-reloj
   --purge-config    Remove configuration under /var/lib/pantalla-reloj
+  --purge-kiosk-chromium-state
+                    Remove Chromium kiosk profile and cache directories
   -h, --help        Show this message
 USAGE
 }
@@ -28,6 +30,7 @@ PURGE_VENV=0
 PURGE_NODE=0
 PURGE_ASSETS=0
 PURGE_CONFIG=0
+PURGE_KIOSK_CHROMIUM_STATE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -37,6 +40,7 @@ while [[ $# -gt 0 ]]; do
     --purge-node) PURGE_NODE=1 ;;
     --purge-assets) PURGE_ASSETS=1 ;;
     --purge-config) PURGE_CONFIG=1 ;;
+    --purge-kiosk-chromium-state) PURGE_KIOSK_CHROMIUM_STATE=1 ;;
     -h|--help)
       usage
       exit 0
@@ -212,6 +216,11 @@ if [[ $PURGE_CONFIG -eq 1 ]]; then
 else
   # Keep state but remove runtime markers
   rm -rf "$STATE_RUNTIME"
+fi
+
+if [[ $PURGE_KIOSK_CHROMIUM_STATE -eq 1 ]]; then
+  log_info "Removing Chromium kiosk state directories"
+  rm -rf /var/lib/pantalla-reloj/state/chromium /var/lib/pantalla-reloj/cache/chromium
 fi
 
 HOME_AUTH="/home/${USER_NAME}/.Xauthority"

--- a/scripts/verify_kiosk.sh
+++ b/scripts/verify_kiosk.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+exec "${REPO_ROOT}/usr/local/bin/pantalla-kiosk-verify" "$@"

--- a/systemd/pantalla-kiosk-chromium@.service
+++ b/systemd/pantalla-kiosk-chromium@.service
@@ -10,29 +10,11 @@ Environment=XAUTHORITY=/home/%i/.Xauthority
 Environment=GDK_BACKEND=x11
 Environment=GTK_USE_PORTAL=0
 Environment=GIO_USE_PORTALS=0
-Environment=CHROMIUM_SCALE=0.84
+Environment=CHROMIUM_SCALE=0.58
 
 ExecStartPre=/bin/sh -lc 'xset -dpms; xset s off; xset s noblank || true'
-ExecStartPre=/bin/sh -lc 'wmctrl -lx | awk "/pantalla-kiosk/ {print \\$1}" | xargs -r -n1 wmctrl -ic || true'
 
-ExecStart=/bin/sh -lc '\
-  chromium-browser \
-    --class=pantalla-kiosk \
-    --kiosk --start-fullscreen \
-    --app=http://127.0.0.1 \
-    --no-first-run --no-default-browser-check \
-    --disable-translate --disable-infobars --disable-session-crashed-bubble --noerrdialogs \
-    --disable-features=CalculateNativeWinOcclusion,InfiniteSessionRestore,Translate,HardwareMediaKeyHandling \
-    --disable-renderer-backgrounding --disable-background-timer-throttling --disable-backgrounding-occluded-windows \
-    --hide-scrollbars --overscroll-history-navigation=0 \
-    --password-store=basic \
-    --test-type \
-    --ozone-platform=x11 \
-    --disable-gpu \
-    --force-device-scale-factor=${CHROMIUM_SCALE} \
-    --disk-cache-dir=/var/lib/pantalla-reloj/cache/chromium \
-    --user-data-dir=/var/lib/pantalla-reloj/state/chromium \
-'
+ExecStart=/usr/local/bin/pantalla-kiosk-chromium
 Restart=on-failure
 RestartSec=2
 

--- a/usr/local/bin/pantalla-kiosk-chromium
+++ b/usr/local/bin/pantalla-kiosk-chromium
@@ -5,49 +5,52 @@ log() {
   printf '[pantalla-kiosk-chromium] %s\n' "$*"
 }
 
-find_chromium() {
-  local candidate
-  for candidate in "${CHROMIUM_BIN_OVERRIDE:-}" chromium-browser chromium /snap/bin/chromium; do
-    if [[ -n "$candidate" ]] && command -v "$candidate" >/dev/null 2>&1; then
-      command -v "$candidate"
-      return 0
-    fi
-  done
-  return 1
-}
+USER_NAME="${KIOSK_USER:-${USER:-$(id -un)}}"
+CLASS_NAME="pantalla-kiosk"
+PKILL_PATTERN="chromium.*--class=${CLASS_NAME}"
 
-main() {
-  local chromium_bin url user_data_dir cache_dir
+if command -v pkill >/dev/null 2>&1; then
+  pkill -9 -u "$USER_NAME" -f "$PKILL_PATTERN" >/dev/null 2>&1 || true
+fi
 
-  if ! chromium_bin="$(find_chromium)"; then
-    log "ERROR: No se encontró un binario de Chromium disponible"
-    exit 1
-  fi
+STATE_DIR="${STATE_DIR:-/var/lib/pantalla-reloj/state/chromium}"
+CACHE_DIR="${CACHE_DIR:-/var/lib/pantalla-reloj/cache/chromium}"
 
-  url="${KIOSK_URL:-http://127.0.0.1}"
-  user_data_dir="${CHROMIUM_USER_DATA_DIR:-/var/lib/pantalla-reloj/state/chromium}"
-  cache_dir="${CHROMIUM_CACHE_DIR:-/var/lib/pantalla-reloj/cache/chromium}"
+mkdir -p "$STATE_DIR" "$CACHE_DIR"
+chown "$USER_NAME:$USER_NAME" "$STATE_DIR" "$CACHE_DIR" 2>/dev/null || true
 
-  install -d -m 0700 "$user_data_dir"
-  install -d -m 0755 "$cache_dir"
+CHROME_BIN="${CHROME_BIN:-}"
+if [[ -z "$CHROME_BIN" ]]; then
+  CHROME_BIN="$(readlink -f /snap/chromium/current/usr/lib/chromium-browser/chrome 2>/dev/null || true)"
+fi
 
-  log "Usando Chromium en: ${chromium_bin}"
-  log "Perfil: ${user_data_dir}"
-  log "Cache: ${cache_dir}"
-  log "URL: ${url}"
+if [[ -z "$CHROME_BIN" || ! -x "$CHROME_BIN" ]]; then
+  log "ERROR: No se encontró el binario principal de Chromium en el snap"
+  exit 1
+fi
 
-  exec "$chromium_bin" \
-    --kiosk --start-fullscreen \
-    --app="${url}" \
-    --no-first-run --no-default-browser-check \
-    --disable-translate --disable-infobars \
-    --overscroll-history-navigation=0 \
-    --password-store=basic \
-    --test-type \
-    --ozone-platform=x11 \
-    --disable-gpu \
-    --disk-cache-dir="${cache_dir}" \
-    --user-data-dir="${user_data_dir}"
-}
+URL="${KIOSK_URL:-http://127.0.0.1}"
+SCALE="${CHROMIUM_SCALE:-0.58}"
 
-main "$@"
+log "Usando binario: ${CHROME_BIN}"
+log "Perfil: ${STATE_DIR}"
+log "Cache: ${CACHE_DIR}"
+log "URL: ${URL}"
+log "Escala: ${SCALE}"
+
+exec "$CHROME_BIN" \
+  --class="${CLASS_NAME}" \
+  --kiosk --start-fullscreen \
+  --app="${URL}" \
+  --no-first-run --no-default-browser-check \
+  --disable-translate --disable-infobars \
+  --disable-session-crashed-bubble --noerrdialogs \
+  --disable-features=InfiniteSessionRestore,Translate,HardwareMediaKeyHandling,CalculateNativeWinOcclusion \
+  --hide-scrollbars --overscroll-history-navigation=0 \
+  --password-store=basic \
+  --test-type \
+  --ozone-platform=x11 \
+  --disable-gpu \
+  --force-device-scale-factor="${SCALE}" \
+  --disk-cache-dir="${CACHE_DIR}" \
+  --user-data-dir="${STATE_DIR}"

--- a/usr/local/bin/pantalla-kiosk-verify
+++ b/usr/local/bin/pantalla-kiosk-verify
@@ -1,191 +1,58 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+log() {
+  printf '[pantalla-kiosk-verify] %s\n' "$*"
+}
+
+KIOSK_USER="${KIOSK_USER:-dani}"
 : "${DISPLAY:=:0}"
-: "${XAUTHORITY:=/var/lib/pantalla-reloj/.Xauthority}"
+: "${XAUTHORITY:=/home/${KIOSK_USER}/.Xauthority}"
 
-LOG_DIR=/var/log/pantalla
-VERIFY_LOG="${LOG_DIR}/kiosk-verify.log"
-SANITIZE_LOG="${LOG_DIR}/kiosk-sanitize.log"
-SANITIZER=/opt/pantalla/bin/pantalla-kiosk-sanitize.sh
-WM_CLASS="epiphany.epiphany"
-prepare_logs() {
-  install -d -m 0755 "$LOG_DIR"
-  : >"${VERIFY_LOG}.tmp"
-  touch "$SANITIZE_LOG"
-}
+PROCESS_PATTERN='/snap/chromium/.*/chrome .*--class=pantalla-kiosk'
 
-log_sanitize() {
-  local ts
-  ts="$(date -Is)"
-  printf '%s %s\n' "$ts" "$*" >>"$SANITIZE_LOG"
-}
+if ! pgrep -af "$PROCESS_PATTERN" >/dev/null; then
+  log "Proceso de Chromium con clase pantalla-kiosk no encontrado"
+  exit 1
+fi
 
-run_and_capture() {
-  local desc="$1"
-  shift
-  {
-    printf '--- %s ---\n' "$desc"
-    printf 'CMD: %s\n' "$*"
-    if "$@"; then
-      printf 'status=0\n\n'
-    else
-      printf 'status=%s\n\n' "$?"
-    fi
-  } >>"${VERIFY_LOG}.tmp" 2>&1
-}
+if ! command -v wmctrl >/dev/null 2>&1; then
+  log "wmctrl no disponible"
+  exit 1
+fi
 
-normalize_wid() {
-  local wid="$1"
-  wid="${wid,,}"
-  if [[ "$wid" != 0x* ]]; then
-    printf '0x%x' "$((16#$wid))"
-  else
-    printf '%s' "$wid"
-  fi
-}
+WINDOW_LIST=$(DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -lx 2>/dev/null || true)
+if [[ -z "$WINDOW_LIST" ]]; then
+  log "No se pudo obtener la lista de ventanas"
+  exit 1
+fi
 
-declare -gA WINDOW_INFO=()
-declare -ga WINDOW_ORDER=()
-declare -ga STACKING_IDS=()
-stacking_primary=""
+if ! grep -q 'pantalla-kiosk' <<<"$WINDOW_LIST"; then
+  log "No hay ventanas con clase pantalla-kiosk"
+  exit 1
+fi
 
-read_windows() {
-  WINDOW_INFO=()
-  WINDOW_ORDER=()
-  local line wid cls
-  while IFS= read -r line; do
-    wid="${line%% *}"
-    cls="$(printf '%s' "$line" | awk '{print $3}')"
-    if [[ "$cls" == "$WM_CLASS" ]]; then
-      wid="$(normalize_wid "$wid")"
-      WINDOW_INFO["$wid"]="$line"
-      WINDOW_ORDER+=("$wid")
-    fi
-  done < <(env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -lx 2>/dev/null || true)
-}
+WINDOW_ID=$(awk '/pantalla-kiosk/{print $1; exit}' <<<"$WINDOW_LIST")
+if [[ -z "$WINDOW_ID" ]]; then
+  log "No se pudo determinar el ID de la ventana"
+  exit 1
+fi
 
-select_primary_from_stacking() {
-  local stacking raw token wid
-  stacking_primary=""
-  STACKING_IDS=()
-  stacking=$(env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xprop -root _NET_CLIENT_LIST_STACKING 2>/dev/null || true)
-  if [[ "$stacking" == *_NET_CLIENT_LIST_STACKING* ]]; then
-    raw="${stacking#*_NET_CLIENT_LIST_STACKING(WINDOW): window id # }"
-    raw="${raw//,/ }"
-    for token in $raw; do
-      [[ "$token" =~ 0x[0-9a-fA-F]+ ]] || continue
-      wid="$(normalize_wid "$token")"
-      STACKING_IDS+=("$wid")
-    done
-    for (( idx=${#STACKING_IDS[@]}-1; idx>=0; idx-- )); do
-      wid="${STACKING_IDS[idx]}"
-      if [[ -n "${WINDOW_INFO[$wid]:-}" ]]; then
-        stacking_primary="$wid"
-        return
-      fi
-    done
-  fi
-}
+if ! command -v xprop >/dev/null 2>&1; then
+  log "xprop no disponible"
+  exit 1
+fi
 
-sanitize_windows_manual() {
-  if ! command -v wmctrl >/dev/null 2>&1; then
-    log_sanitize "wmctrl-missing"
-    return
-  fi
+STATE=$(DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xprop -id "$WINDOW_ID" _NET_WM_STATE 2>/dev/null || true)
+if [[ -z "$STATE" ]]; then
+  log "No se pudo obtener _NET_WM_STATE para la ventana $WINDOW_ID"
+  exit 1
+fi
 
-  read_windows
-  local count
-  count=${#WINDOW_ORDER[@]}
-  if (( count == 0 )); then
-    log_sanitize "no-windows wmclass=$WM_CLASS"
-    return
-  fi
+if ! grep -Eq 'FULLSCREEN|ABOVE' <<<"$STATE"; then
+  log "La ventana $WINDOW_ID no está en estado FULLSCREEN o ABOVE"
+  exit 1
+fi
 
-  select_primary_from_stacking
-  local primary="${stacking_primary:-${WINDOW_ORDER[-1]}}"
-  if [[ -z "$primary" ]]; then
-    primary="${WINDOW_ORDER[0]}"
-  fi
-
-  log_sanitize "verify-windows count=${count} primary=${primary}"
-
-  local wid
-  for wid in "${WINDOW_ORDER[@]}"; do
-    [[ "$wid" == "$primary" ]] && continue
-    if env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -i -c "$wid" >/dev/null 2>&1; then
-      log_sanitize "verify-closed-extra id=$wid"
-    else
-      log_sanitize "verify-close-extra-failed id=$wid"
-    fi
-    sleep 0.1 2>/dev/null || true
-  done
-
-  if env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -i -r "$primary" -b add,fullscreen >/dev/null 2>&1; then
-    log_sanitize "verify-fullscreen id=$primary"
-  else
-    log_sanitize "verify-fullscreen-failed id=$primary"
-  fi
-
-  if env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -i -R "$primary" >/dev/null 2>&1; then
-    log_sanitize "verify-raise id=$primary"
-  else
-    log_sanitize "verify-raise-failed id=$primary"
-  fi
-
-  if env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -i -a "$primary" >/dev/null 2>&1; then
-    log_sanitize "verify-focus id=$primary"
-  else
-    log_sanitize "verify-focus-failed id=$primary"
-  fi
-
-  local active
-  if command -v xprop >/dev/null 2>&1; then
-    active=$(env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xprop -root _NET_ACTIVE_WINDOW 2>/dev/null | awk -F'# ' 'NF>1 {print $2}' | awk '{print $1}' | tr 'A-F' 'a-f')
-    if [[ -z "$active" ]]; then
-      log_sanitize "verify-active-empty"
-    else
-      log_sanitize "verify-active id=$active"
-      if [[ "$active" != "$primary" ]]; then
-        if env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -i -a "$primary" >/dev/null 2>&1; then
-          log_sanitize "verify-active-corrected from=$active to=$primary"
-        else
-          log_sanitize "verify-active-correction-failed from=$active to=$primary"
-        fi
-      fi
-    fi
-  fi
-
-  while IFS= read -r line; do
-    log_sanitize "verify-wmctrl ${line}"
-  done < <(env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -lx 2>/dev/null || true)
-}
-
-main() {
-  prepare_logs
-
-  if [[ -x "$SANITIZER" ]]; then
-    if DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" "$SANITIZER" --delay 0 --timeout 8 --wm-class "$WM_CLASS" --log "$SANITIZE_LOG"; then
-      log_sanitize "sanitizer-invoked"
-    else
-      log_sanitize "sanitizer-error"
-    fi
-  fi
-
-  sanitize_windows_manual
-
-  run_and_capture "xrandr --query" env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xrandr --query
-  run_and_capture "wmctrl -lx" env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" wmctrl -lx
-  run_and_capture "_NET_ACTIVE_WINDOW" env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xprop -root _NET_ACTIVE_WINDOW
-  if command -v xprop >/dev/null 2>&1; then
-    active_id=$(env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xprop -root _NET_ACTIVE_WINDOW 2>/dev/null | awk -F'# ' 'NF>1 {print $2}' | awk '{print $1}')
-    if [[ -n "$active_id" ]]; then
-      run_and_capture "_NET_WM_STATE ${active_id}" env DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" xprop -id "$active_id" _NET_WM_STATE
-    fi
-  fi
-  run_and_capture "backend health" curl -fsS -o /dev/null -w '%{http_code}\n' "${PANTALLA_KIOSK_HEALTH_URL:-http://127.0.0.1:8081/healthz}"
-
-  mv "${VERIFY_LOG}.tmp" "$VERIFY_LOG"
-}
-
-main "$@"
+log "Kiosk operativo (proceso y ventana válidos)"
+exit 0


### PR DESCRIPTION
## Summary
- replace the Chromium kiosk wrapper with one that launches the snap chrome binary directly, purges prior kiosk windows, and stores state under /var/lib/pantalla-reloj
- point the systemd service at the new wrapper and update defaults for the kiosk session
- simplify the kiosk verification helper and expose it via scripts/verify_kiosk.sh
- add an uninstall flag to purge the Chromium kiosk profile and cache directories

## Testing
- not run (environment does not provide graphical stack)


------
https://chatgpt.com/codex/tasks/task_e_6900c3b88a1083269f4f866c834fff3a