### PR TITLE
Remove deprecated optimizeDeps dedupe option

### DIFF
--- a/dash-ui/vite.config.ts
+++ b/dash-ui/vite.config.ts
@@ -13,8 +13,7 @@ export default defineConfig({
     chunkSizeWarningLimit: 1500
   },
   optimizeDeps: {
-    include: ["react", "react-dom"],
-    dedupe: ["react", "react-dom"]
+    include: ["react", "react-dom"]
   },
   resolve: {
     dedupe: ["react", "react-dom"]


### PR DESCRIPTION
## Summary
- remove the deprecated `optimizeDeps.dedupe` option from the Vite config since Vite 5 no longer supports it
- keep dependency inclusion via `optimizeDeps.include` while relying on `resolve.dedupe` for React packages

## Testing
- npm run build *(fails: existing TypeScript errors in src/pages/ConfigPage.tsx and related modules complaining about missing JSX intrinsic elements and implicit any types)*

------
https://chatgpt.com/codex/tasks/task_e_6900f6713b14832695f3e59671aff63b