### PR TITLE
Fix RotatingCard effect dependencies to prevent React #185

### DIFF
--- a/dash-ui/src/components/RotatingCard.tsx
+++ b/dash-ui/src/components/RotatingCard.tsx
@@ -36,12 +36,13 @@ export const RotatingCard = ({ cards }: RotatingCardProps): JSX.Element => {
   const [isTransitioning, setIsTransitioning] = useState(false);
   const timeoutRef = useRef<number | null>(null);
 
+  const cardCount = fallbackCards.length;
   useEffect(() => {
-    setActiveIndex(0);
-  }, [fallbackCards]);
+    setActiveIndex((prev) => (prev >= cardCount ? 0 : prev));
+  }, [cardCount]);
 
   useEffect(() => {
-    if (fallbackCards.length === 0) {
+    if (cardCount === 0) {
       return undefined;
     }
 
@@ -62,7 +63,7 @@ export const RotatingCard = ({ cards }: RotatingCardProps): JSX.Element => {
         timeoutRef.current = null;
       }
     };
-  }, [activeIndex, fallbackCards]);
+  }, [activeIndex, cardCount]);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- derive the rotating card count from fallback cards and track it separately
- reset the active index only when the number of cards changes
- update the timer effect to depend on the card count instead of the array identity

## Testing
- `cd dash-ui && npm ci` *(fails: 403 Forbidden when fetching maplibre-gl from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6900fedddef88326ac5ce8d01f3a3f7f