### PR TITLE
feat: add ultra-safe kiosk mode

### DIFF
--- a/dash-ui/README.md
+++ b/dash-ui/README.md
@@ -20,6 +20,14 @@ Add `?static=1` to the kiosk URL or set the environment variable
 components. This mode performs a single weather/astronomy fetch on load to aid
 debugging runaway renders.
 
+### Ultra-safe kiosk mode
+
+Append `?ultra=1` to the kiosk URL or set `VITE_ULTRA_SAFE=1` to render a
+minimal "ULTRA-SAFE MODE" clock screen. This path bypasses all rotating cards,
+map components, intervals, and timers so recurring React `#185` errors can be
+isolated. If the loop persists with this flag, the fault lies outside the
+rotating/map layers.
+
 ## Build
 
 ```bash

--- a/dash-ui/src/App.tsx
+++ b/dash-ui/src/App.tsx
@@ -11,7 +11,7 @@ import { useConfigStore } from "./state/configStore";
 import useWebglStatus from "./hooks/useWebglStatus";
 import { ConfigPage } from "./pages/ConfigPage";
 import { SAFE_MODE_ENABLED } from "./utils/safeMode";
-import { isStaticMode } from "./lib/staticMode";
+import { isStaticMode } from "./lib/flags";
 
 const StaticDashboardShell: React.FC = () => {
   const shellClassName = "app-shell";

--- a/dash-ui/src/UltraSafeApp.tsx
+++ b/dash-ui/src/UltraSafeApp.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+// ZERO timers, ZERO effects, ZERO rotating/map. Pure render only.
+export const UltraSafeApp: React.FC = () => {
+  const now = new Date();
+  const hh = String(now.getHours()).padStart(2, "0");
+  const mm = String(now.getMinutes()).padStart(2, "0");
+
+  return (
+    <div
+      style={{
+        width: "100vw",
+        height: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+        fontFamily: "system-ui, sans-serif"
+      }}
+    >
+      <div style={{ opacity: 0.7, fontSize: 14, marginBottom: 8 }}>
+        ULTRA-SAFE MODE
+      </div>
+      <div style={{ fontSize: 120, lineHeight: 1, letterSpacing: 2 }}>
+        {hh}:{mm}
+      </div>
+      <div style={{ marginTop: 12, fontSize: 18 }}>
+        Kiosk minimal sin rotaciones ni mapa
+      </div>
+    </div>
+  );
+};
+
+export default UltraSafeApp;

--- a/dash-ui/src/components/OverlayRotator.tsx
+++ b/dash-ui/src/components/OverlayRotator.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 
 import { withConfigDefaults } from "../config/defaults";
 import { apiGet } from "../lib/api";
-import { isStaticMode } from "../lib/staticMode";
+import { isStaticMode } from "../lib/flags";
 import { useConfig } from "../lib/useConfig";
 import { dayjs } from "../utils/dayjs";
 import { ensurePlainText, sanitizeRichText } from "../utils/sanitize";

--- a/dash-ui/src/lib/flags.ts
+++ b/dash-ui/src/lib/flags.ts
@@ -1,0 +1,23 @@
+export const isUltraSafe = (): boolean => {
+  const url = new URL(window.location.href);
+  return (
+    url.searchParams.get("ultra") === "1" ||
+    import.meta.env.VITE_ULTRA_SAFE === "1"
+  );
+};
+
+export const isStaticMode = (): boolean => {
+  const url = new URL(window.location.href);
+  return (
+    url.searchParams.get("static") === "1" ||
+    import.meta.env.VITE_STATIC_OVERLAY === "1"
+  );
+};
+
+export const isSafeMode = (): boolean => {
+  const url = new URL(window.location.href);
+  return (
+    url.searchParams.get("safe") === "1" ||
+    import.meta.env.VITE_SAFE_MODE === "1"
+  );
+};

--- a/dash-ui/src/lib/staticMode.ts
+++ b/dash-ui/src/lib/staticMode.ts
@@ -1,7 +1,0 @@
-export const isStaticMode = (): boolean => {
-  const url = new URL(window.location.href);
-  return (
-    url.searchParams.get("static") === "1" ||
-    import.meta.env.VITE_STATIC_OVERLAY === "1"
-  );
-};

--- a/dash-ui/src/main.tsx
+++ b/dash-ui/src/main.tsx
@@ -1,17 +1,44 @@
 import React from "react";
-import ReactDOM from "react-dom/client";
+import { createRoot } from "react-dom/client";
 import { HashRouter } from "react-router-dom";
 
-import App from "./App";
-import ErrorBoundary from "./components/ErrorBoundary";
+import { isSafeMode, isStaticMode, isUltraSafe } from "./lib/flags";
+import UltraSafeApp from "./UltraSafeApp";
 import "./styles/global.css";
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  <React.StrictMode>
-    <ErrorBoundary>
-      <HashRouter>
-        <App />
-      </HashRouter>
-    </ErrorBoundary>
-  </React.StrictMode>
-);
+const rootElement = document.getElementById("root") as HTMLElement;
+const root = createRoot(rootElement);
+
+if (isUltraSafe()) {
+  console.info("[flags] ULTRA-SAFE mode enabled");
+  root.render(
+    <React.StrictMode>
+      <UltraSafeApp />
+    </React.StrictMode>
+  );
+} else {
+  void Promise.all([
+    import("./App"),
+    import("./components/ErrorBoundary")
+  ]).then(([{ default: App }, { default: ErrorBoundary }]) => {
+    const activeFlags: string[] = [];
+    if (isSafeMode()) {
+      activeFlags.push("safe");
+    }
+    if (isStaticMode()) {
+      activeFlags.push("static");
+    }
+    if (activeFlags.length > 0) {
+      console.info(`[flags] active: ${activeFlags.join(", ")}`);
+    }
+    root.render(
+      <React.StrictMode>
+        <ErrorBoundary>
+          <HashRouter>
+            <App />
+          </HashRouter>
+        </ErrorBoundary>
+      </React.StrictMode>
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add a shared flags helper that detects ultra-safe, static, and safe kiosk modes
- render a new UltraSafeApp when ?ultra=1 or VITE_ULTRA_SAFE=1 is set so the heavy app tree never mounts
- log active flags in the normal path and document the ultra-safe escape hatch in the README

## Testing
- npm run build *(fails: existing TypeScript errors in ConfigPage.tsx and missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_69010380b10883269e57d57df5189f18