### PR TITLE
Fix RotatingCard dev logging environment check

### DIFF
--- a/dash-ui/src/components/RotatingCard.tsx
+++ b/dash-ui/src/components/RotatingCard.tsx
@@ -51,7 +51,7 @@ export const RotatingCard = ({ cards, disabled = false }: RotatingCardProps): JS
   }, [signature]);
 
   useEffect(() => {
-    if (process.env.NODE_ENV !== "production") {
+    if (import.meta.env.DEV) {
       // eslint-disable-next-line no-console
       console.info(`[RotatingCard] signature → ${signature}`);
     }


### PR DESCRIPTION
## Summary
- replace the RotatingCard development logging guard to use the Vite-friendly `import.meta.env.DEV`

## Testing
- npm run build *(fails: TypeScript compilation reports missing JSX/React types in ConfigPage and dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690108915d3883269a07dfb2adef299e