### PR TITLE
Fix GeoScope map jump options and kiosk runtime flag naming

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -448,8 +448,7 @@ export default function GeoScopeMap() {
       center: [lng, lat],
       zoom,
       pitch,
-      bearing,
-      animate: false
+      bearing
     });
   };
 

--- a/dash-ui/src/lib/runtimeFlags.ts
+++ b/dash-ui/src/lib/runtimeFlags.ts
@@ -42,7 +42,7 @@ const kioskEnabled = Boolean(kioskWindow?.__KIOSK__?.ENABLED ?? kioskEnabledFrom
 
 const params = getSearchParams();
 const reducedOverrideFromQuery = parseBoolean(params.get("reduced"));
-const reducedOverride =
+const reducedMotionOverride =
   typeof kioskWindow?.__KIOSK__?.REDUCED_MOTION === "boolean"
     ? kioskWindow.__KIOSK__!.REDUCED_MOTION
     : reducedOverrideFromQuery;
@@ -55,14 +55,14 @@ export const kioskRuntime = {
       return defaultRespect;
     }
 
-    if (typeof reducedOverride === "boolean") {
-      return reducedOverride;
+    if (typeof reducedMotionOverride === "boolean") {
+      return reducedMotionOverride;
     }
 
     return defaultRespect;
   },
   isMotionForced(): boolean {
-    return kioskEnabled && reducedOverride === false;
+    return kioskEnabled && reducedMotionOverride === false;
   }
 };
 


### PR DESCRIPTION
## Summary
- remove the unsupported animate option from the GeoScope map jumpTo call
- rename the reduced motion override variable so the exported runtime flag is defined

## Testing
- npm run build *(fails: missing type declarations because dependencies such as react and maplibre-gl are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69024234c134832696e6ff85c54d9a37