### PR TITLE
Enable kiosk autopan diagnostics and runtime overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ Pantalla_reloj/
   depuración puntual.
 - Compilado con `npm run build` y servido por Nginx desde `/var/www/html`.
 
+#### Autopan y diagnósticos
+
+- El mapa GeoScope rota automáticamente en modo kiosk incluso si el panel lateral
+  no es visible; se escribe una traza periódica en `console.log`
+  (`[diagnostics:auto-pan] bearing=<valor>`) para que `journalctl` pueda validar el
+  movimiento.
+- Flags de runtime disponibles vía `window.location.search` o `localStorage`:
+  - `autopan=1|0` fuerza la animación ON/OFF.
+  - `reduced=1|0` controla si se respeta `prefers-reduced-motion` (`0` la ignora).
+  - `speed=<grados/segundo>` fija la velocidad sin recompilar (por defecto ~0.1 °/s).
+- `/diagnostics/auto-pan` monta solo el mapa a pantalla completa con
+  `autopan=1&reduced=0` y muestra un banner superior con el bearing actual, ideal para
+  comprobar rápidamente el kiosk.
+
 ### Nginx (reverse proxy `/api`)
 
 - El virtual host `etc/nginx/sites-available/pantalla-reloj.conf` debe quedar

--- a/dash-ui/src/pages/DiagnosticsAutoPan.tsx
+++ b/dash-ui/src/pages/DiagnosticsAutoPan.tsx
@@ -1,180 +1,67 @@
-import maplibregl from "maplibre-gl";
-import type { MapLibreEvent } from "maplibre-gl";
-import "maplibre-gl/dist/maplibre-gl.css";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { kioskRuntime } from "../lib/runtimeFlags";
+import GeoScopeMap, { GEO_SCOPE_AUTOPAN_EVENT } from "../components/GeoScope/GeoScopeMap";
 
-const ROTATE_DELTA_DEGREES = 0.05;
-const FRAME_MIN_INTERVAL_MS = 1000 / 60;
-const WATCHDOG_INTERVAL_MS = 1500;
-const WATCHDOG_TICK_MS = 500;
-const WATCHDOG_BEARING_DELTA = 1.5;
-const LOG_INTERVAL_MS = 2000;
+const DEFAULT_SPEED_PARAM = (6 / 60).toFixed(3);
 
-export const DiagnosticsAutoPan: React.FC = () => {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<maplibregl.Map | null>(null);
-  const animationFrameRef = useRef<number | null>(null);
-  const lastFrameRef = useRef<number | null>(null);
-  const watchdogRef = useRef<number | null>(null);
-  const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const lastLogRef = useRef<number>(0);
-  const [bearingDisplay, setBearingDisplay] = useState(0);
+const ensureDiagnosticsParams = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const params = new URLSearchParams(window.location.search);
+  let changed = false;
+  if (!params.has("autopan")) {
+    params.set("autopan", "1");
+    changed = true;
+  }
+  if (!params.has("reduced")) {
+    params.set("reduced", "0");
+    changed = true;
+  }
+  if (!params.has("speed")) {
+    params.set("speed", DEFAULT_SPEED_PARAM);
+    changed = true;
+  }
+
+  if (changed) {
+    const query = params.toString();
+    const nextUrl = `${window.location.pathname}?${query}${window.location.hash}`;
+    window.history.replaceState(null, "", nextUrl);
+  }
+};
+
+const DiagnosticsAutoPan = () => {
+  const [bearing, setBearing] = useState(0);
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (!container) {
+    ensureDiagnosticsParams();
+    if (typeof window === "undefined") {
       return;
     }
 
-    const map = new maplibregl.Map({
-      container,
-      style: "https://demotiles.maplibre.org/style.json",
-      center: [0, 20],
-      zoom: 2.4,
-      pitch: 25,
-      bearing: 0,
-      interactive: false,
-      attributionControl: false,
-      renderWorldCopies: true,
-      dragRotate: false,
-      dragPan: false,
-      keyboard: false,
-      boxZoom: false,
-      doubleClickZoom: false,
-      touchPitch: false,
-      touchZoomRotate: false
-    });
-
-    mapRef.current = map;
-
-    const logBearing = (bearing: number, timestamp: number) => {
-      if (!lastLogRef.current) {
-        lastLogRef.current = timestamp;
-      }
-      if (timestamp - lastLogRef.current >= LOG_INTERVAL_MS) {
-        lastLogRef.current = timestamp;
-        setBearingDisplay(bearing);
-        console.log(`[diagnostics:auto-pan] bearing=${bearing.toFixed(2)}`);
-      }
-    };
-
-    const step = (timestamp: number) => {
-      const mapInstance = mapRef.current;
-      if (!mapInstance) {
-        animationFrameRef.current = null;
+    const handleBearing: EventListener = (event) => {
+      const detail = (event as CustomEvent<{ bearing?: number }>).detail;
+      if (!detail || typeof detail.bearing !== "number") {
         return;
       }
-
-      const lastFrame = lastFrameRef.current ?? timestamp - FRAME_MIN_INTERVAL_MS;
-      const delta = timestamp - lastFrame;
-      if (delta >= FRAME_MIN_INTERVAL_MS) {
-        const nextBearing = mapInstance.getBearing() + ROTATE_DELTA_DEGREES;
-        mapInstance.jumpTo({ bearing: nextBearing });
-        mapInstance.triggerRepaint();
-        lastFrameRef.current = timestamp;
-        logBearing(nextBearing, timestamp);
-      }
-
-      animationFrameRef.current = requestAnimationFrame(step);
+      setBearing(detail.bearing);
     };
 
-    const ensureAnimationFrame = () => {
-      if (animationFrameRef.current == null) {
-        animationFrameRef.current = requestAnimationFrame(step);
-      }
-    };
-
-    const ensureWatchdog = () => {
-      if (watchdogRef.current != null) {
-        return;
-      }
-      watchdogRef.current = window.setInterval(() => {
-        const mapInstance = mapRef.current;
-        if (!mapInstance) {
-          return;
-        }
-        const now = performance.now();
-        const lastFrame = lastFrameRef.current;
-        if (!lastFrame || now - lastFrame >= WATCHDOG_INTERVAL_MS) {
-          const nextBearing = mapInstance.getBearing() + WATCHDOG_BEARING_DELTA;
-          mapInstance.jumpTo({ bearing: nextBearing });
-          mapInstance.triggerRepaint();
-          lastFrameRef.current = now;
-          logBearing(nextBearing, now);
-          console.warn(
-            `[diagnostics:auto-pan] watchdog jump bearing=${nextBearing.toFixed(2)}`
-          );
-          ensureAnimationFrame();
-        }
-      }, WATCHDOG_TICK_MS);
-    };
-
-    const start = () => {
-      lastLogRef.current = performance.now() - LOG_INTERVAL_MS;
-      ensureAnimationFrame();
-      ensureWatchdog();
-    };
-
-    const handleContextLost = (event: MapLibreEvent & { originalEvent?: WebGLContextEvent }) => {
-      event.originalEvent?.preventDefault();
-      ensureAnimationFrame();
-      ensureWatchdog();
-    };
-
-    const handleContextRestored = () => {
-      ensureAnimationFrame();
-    };
-
-    map.once("load", () => {
-      if (kioskRuntime.isMotionForced()) {
-        console.info("[diagnostics:auto-pan] forcing animation (kiosk override)");
-      }
-      start();
-    });
-    map.on("webglcontextlost", handleContextLost);
-    map.on("webglcontextrestored", handleContextRestored);
-
-    if (typeof ResizeObserver !== "undefined") {
-      const observer = new ResizeObserver(() => {
-        map.resize();
-        map.triggerRepaint();
-      });
-      observer.observe(container);
-      resizeObserverRef.current = observer;
-    }
-
+    window.addEventListener(GEO_SCOPE_AUTOPAN_EVENT, handleBearing);
     return () => {
-      if (animationFrameRef.current != null) {
-        cancelAnimationFrame(animationFrameRef.current);
-        animationFrameRef.current = null;
-      }
-      if (watchdogRef.current != null) {
-        window.clearInterval(watchdogRef.current);
-        watchdogRef.current = null;
-      }
-
-      const observer = resizeObserverRef.current;
-      if (observer) {
-        observer.disconnect();
-        resizeObserverRef.current = null;
-      }
-
-      map.off("webglcontextlost", handleContextLost);
-      map.off("webglcontextrestored", handleContextRestored);
-      map.remove();
-      mapRef.current = null;
+      window.removeEventListener(GEO_SCOPE_AUTOPAN_EVENT, handleBearing);
     };
   }, []);
 
   return (
     <div className="diagnostics-auto-pan">
-      <div className="diagnostics-auto-pan__map" ref={containerRef} />
+      <div className="diagnostics-auto-pan__map" aria-hidden="true">
+        <GeoScopeMap />
+      </div>
       <div className="diagnostics-auto-pan__overlay">
         <div className="diagnostics-auto-pan__ticker" aria-live="polite">
           <span className="diagnostics-auto-pan__label">Bearing</span>
-          <span className="diagnostics-auto-pan__value">{bearingDisplay.toFixed(1)}°</span>
+          <span className="diagnostics-auto-pan__value">{bearing.toFixed(1)}°</span>
         </div>
       </div>
     </div>

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -215,7 +215,7 @@ body {
 .diagnostics-auto-pan__overlay {
   position: absolute;
   inset: auto;
-  bottom: 1.5rem;
+  top: 1.5rem;
   left: 1.5rem;
   pointer-events: none;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;

--- a/scripts/pantalla-kiosk-verify
+++ b/scripts/pantalla-kiosk-verify
@@ -8,9 +8,9 @@ STATE_ROOT="/var/lib/pantalla-reloj"
 KIOSK_ENV_FILE="${STATE_ROOT}/state/kiosk.env"
 TARGET_USER="${VERIFY_USER:-${SUDO_USER:-$(id -un)}}"
 
-declare -r PY_VALIDATE_UI=$'import json, sys\nfrom pathlib import Path\nbody = Path(sys.argv[1]).read_text()\ntry:\n    payload = json.loads(body)\nexcept json.JSONDecodeError:\n    sys.exit(1)\nif payload.get("ui") == "ok":\n    sys.exit(0)\nsys.exit(1)\n'
+declare -r PY_VALIDATE_UI='import json, sys; from pathlib import Path; body = Path(sys.argv[1]).read_text(); payload = json.loads(body); sys.exit(0) if payload.get("ui") == "ok" else sys.exit(1)'
 
-declare -r PY_AUTOPAN_DELTA=$'import sys\nstart = float(sys.argv[1])\nend = float(sys.argv[2])\ndelta = abs(end - start)\nif delta < 0.1:\n    sys.exit(1)\nprint(f"{delta:.2f}")\n'
+declare -r PY_AUTOPAN_DELTA='import sys; start = float(sys.argv[1]); end = float(sys.argv[2]); delta = abs(end - start); sys.exit(1) if delta < 0.1 else print(f"{delta:.2f}")'
 
 log() {
   printf '[pantalla-kiosk-verify] %s\n' "$*"
@@ -164,13 +164,7 @@ maybe_restart_for_swiftshader() {
 }
 
 check_autopan_rotation() {
-  local diag_url="$1"
   local unit="pantalla-kiosk-chromium@${TARGET_USER}.service"
-  if ! is_diag_mode "$diag_url"; then
-    record_result "autopan" "skipped"
-    return 0
-  fi
-
   local journal_output
   if ! journal_output="$(journalctl -u "$unit" --since "-10 minutes" --no-pager 2>/dev/null)"; then
     record_result "autopan" "journal-missing"
@@ -253,7 +247,7 @@ main() {
   record_result "kiosk_url" "${kiosk_url:-<unset>}"
 
   maybe_restart_for_swiftshader "$kiosk_url"
-  check_autopan_rotation "$kiosk_url" || failures=$((failures + 1))
+  check_autopan_rotation || failures=$((failures + 1))
   check_kiosk_logs || failures=$((failures + 1))
 
   printf 'pantalla-kiosk-verify summary\n'


### PR DESCRIPTION
## Summary
- update kiosk runtime flag parsing to support autopan/reduced/speed overrides and improved kiosk heuristics
- rework GeoScope autopan loop to rotate via bearing, emit diagnostics logs/events, and respect runtime flags even in kiosk mode
- add a diagnostics-only map route, surface the bearing banner, move the overlay to the top, and document the runtime controls
- teach pantalla-kiosk-verify to scan journalctl for autopan motion and report the measured delta

## Testing
- npm run build *(fails: dependencies such as react/dayjs not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_690261a5d33c8326bca1bc51e8d03cd7