### PR TITLE
Remove duplicate startPan definition

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -518,18 +518,6 @@ export default function GeoScopeMap() {
       lastLogTimeRef.current = 0;
     };
 
-    const startPan = () => {
-      if (animationFrameRef.current != null) return;
-      if (!mapRef.current) return;
-
-      lastFrameTimeRef.current = null;
-      lastRepaintTimeRef.current = null;
-      const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-      lastLogTimeRef.current = now - AUTOPAN_LOG_INTERVAL_MS;
-      animationFrameRef.current = requestAnimationFrame(stepPan);
-      ensureFallbackTimer();
-    };
-
     const recomputeAutopanActivation = () => {
       const forcedOff = autopanForcedOffRef.current;
       const kioskDetected = kioskModeRef.current;


### PR DESCRIPTION
## Summary
- remove the duplicate `startPan` declaration in GeoScopeMap to avoid TS redeclaration errors

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69026a230f608326a274f2651c9d25b2