### PR TITLE
Fix TypeScript build errors for GeoScope autopan and runtime flags

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -721,18 +721,6 @@ export default function GeoScopeMap() {
       }, FALLBACK_TICK_INTERVAL_MS);
     };
 
-    const startPan = () => {
-      if (animationFrameRef.current != null) return;
-      if (!mapRef.current) return;
-
-      lastFrameTimeRef.current = null;
-      lastRepaintTimeRef.current = null;
-      const now = typeof performance !== "undefined" ? performance.now() : Date.now();
-      lastLogTimeRef.current = now - AUTOPAN_LOG_INTERVAL_MS;
-      animationFrameRef.current = requestAnimationFrame(stepPan);
-      ensureFallbackTimer();
-    };
-
     const handleDprChange = () => {
       safeFit();
       const previous = dprMediaRef.current;


### PR DESCRIPTION
## Summary
- remove the duplicate `startPan` definition in `GeoScopeMap` to prevent TypeScript redeclaration failures
- isolate access to a Node-style `process` global when computing runtime flags and clarify kiosk detection fallbacks

## Testing
- npm run build *(fails: missing React/dayjs type declarations in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902d94338bc8326a64575e877994891