### PR TITLE
Add MapTiler provider configuration and kiosk map fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ Pantalla_reloj/
   `force=1&reducedMotion=0` y muestra un banner superior con el bearing actual, ideal
   para comprobar rápidamente el kiosk.
 
+### Configurar MapTiler
+
+- Crea una cuenta en [MapTiler](https://maptiler.com/) y genera una API key desde el
+  panel **Cloud → API keys**. Copia el identificador alfanumérico (solo letras,
+  números, punto, guion y guion bajo).
+- En la UI de configuración (`/#/config`), abre la tarjeta **Mapas**, selecciona
+  **MapTiler** como proveedor y pega la API key. Usa el botón «Mostrar» para
+  comprobarla antes de guardar.
+- La clave queda almacenada en `config.json` y se envía al navegador para cargar los
+  estilos vectoriales, por lo que se considera información visible desde el cliente.
+  Si el plan de MapTiler lo permite, restringe la API key a los dominios o direcciones
+  IP del kiosk desde el panel de MapTiler.
+
 ### Nginx (reverse proxy `/api`)
 
 - El virtual host `etc/nginx/sites-available/pantalla-reloj.conf` debe quedar

--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -3,12 +3,16 @@
     "timezone": "Europe/Madrid",
     "module_cycle_seconds": 20
   },
+  "map": {
+    "provider": "osm",
+    "maptiler_api_key": null
+  },
   "ui": {
     "layout": "grid-2-1",
     "map": {
       "engine": "maplibre",
       "style": "vector-dark",
-      "provider": "maptiler",
+      "provider": "osm",
       "maptiler": {
         "key": null,
         "styleUrlDark": "https://api.maptiler.com/maps/dark/style.json",

--- a/backend/main.py
+++ b/backend/main.py
@@ -247,7 +247,7 @@ def on_startup() -> None:
         config_manager.config_file,
         config.ui.layout,
         config.ui.map.style,
-        config.ui.map.provider,
+        config.map.provider,
     )
     root = Path(os.getenv("PANTALLA_STATE_DIR", "/var/lib/pantalla"))
     for child in (root / "cache").glob("*.json"):

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -38,7 +38,7 @@ export type MaptilerConfig = {
 export type MapConfig = {
   engine: "maplibre";
   style: "vector-dark" | "vector-light" | "vector-bright" | "raster-carto-dark" | "raster-carto-light";
-  provider: "maptiler" | "carto";
+  provider: "maptiler" | "osm";
   maptiler: MaptilerConfig;
   renderWorldCopies: boolean;
   interactive: boolean;
@@ -49,6 +49,11 @@ export type MapConfig = {
 };
 
 export type UIMapSettings = MapConfig;
+
+export type MapPreferences = {
+  provider: "maptiler" | "osm";
+  maptiler_api_key: string | null;
+};
 
 export type RotationConfig = {
   enabled: boolean;
@@ -78,6 +83,7 @@ export type AIConfig = {
 
 export type AppConfig = {
   display: DisplayConfig;
+  map: MapPreferences;
   ui: UIConfig;
   news: NewsConfig;
   ai: AIConfig;

--- a/deploy/nginx/pantalla-reloj.conf
+++ b/deploy/nginx/pantalla-reloj.conf
@@ -19,6 +19,9 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
+    proxy_no_cache 1;
+    proxy_cache_bypass 1;
+    add_header Cache-Control "no-store" always;
   }
 
   location = /gpu-check.html {


### PR DESCRIPTION
## Summary
- extend the configuration schema with a top-level `map` section that tracks the provider and MapTiler API key, including validation on the backend
- update the React configuration UI to manage the provider and API key with show/hide controls, refresh the defaults, and drive the kiosk map to use MapTiler when available or fall back to OpenStreetMap otherwise
- document MapTiler setup steps and disable caching for `/api/config` in Nginx so configuration reads stay fresh

## Testing
- npm install *(fails: 403 Forbidden when downloading maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_6902e919075c832692fd7d762eea3775