### PR TITLE
Respect autopan disable flags for serpentine mode

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -882,19 +882,6 @@ export default function GeoScopeMap() {
     };
 
     const recomputeAutopanActivation = () => {
-      if (autopanModeRef.current !== "rotate") {
-        autopanEnabledRef.current = false;
-        stopPan();
-        if (autopanModeRef.current === "serpentine") {
-          ensureSerpentine();
-        } else {
-          cancelSerpentine();
-        }
-        return;
-      }
-
-      cancelSerpentine();
-
       const forcedOff = autopanForcedOffRef.current;
       const kioskDetected = kioskModeRef.current;
       const motionForced = motionForcedRef.current || autopanForcedOnRef.current;
@@ -909,6 +896,23 @@ export default function GeoScopeMap() {
           shouldRun = false;
         }
       }
+
+      if (autopanModeRef.current !== "rotate") {
+        autopanEnabledRef.current = false;
+        stopPan();
+        if (autopanModeRef.current === "serpentine") {
+          if (shouldRun) {
+            ensureSerpentine();
+          } else {
+            cancelSerpentine();
+          }
+        } else {
+          cancelSerpentine();
+        }
+        return;
+      }
+
+      cancelSerpentine();
 
       autopanEnabledRef.current = shouldRun;
 


### PR DESCRIPTION
## Summary
- gate the serpentine auto-pan runner on the same forced-off and reduced-motion checks used by the rotate mode
- cancel any pending serpentine sweep when auto-pan is disabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6902f49937988326bcf98ecf4e3f980b