### PR TITLE
feat: add serpentine auto-pan diagnostics mode

### DIFF
--- a/dash-ui/src/pages/DiagnosticsAutoPan.tsx
+++ b/dash-ui/src/pages/DiagnosticsAutoPan.tsx
@@ -2,7 +2,18 @@ import { useEffect, useState } from "react";
 
 import GeoScopeMap, { GEO_SCOPE_AUTOPAN_EVENT } from "../components/GeoScope/GeoScopeMap";
 
-const DEFAULT_SPEED_PARAM = (6 / 60).toFixed(3);
+const DEFAULT_STEP_DEG = 0.4;
+const DEFAULT_LAT_STEP_DEG = 5;
+const DEFAULT_PAUSE_MS = 500;
+const DEFAULT_LOOPS = -1;
+
+type AutoPanEventDetail =
+  | { mode?: "spin"; bearing?: number }
+  | { mode: "serpentine"; lat?: number; lon?: number; band?: number; direction?: "E" | "W" };
+
+type DiagnosticsAutoPanState =
+  | { mode: "spin"; bearing: number }
+  | { mode: "serpentine"; lat: number; lon: number; band: number; direction: "E" | "W" };
 
 const ensureDiagnosticsParams = () => {
   if (typeof window === "undefined") {
@@ -26,8 +37,24 @@ const ensureDiagnosticsParams = () => {
     params.set("reduced", "0");
     changed = true;
   }
-  if (!params.has("speed")) {
-    params.set("speed", DEFAULT_SPEED_PARAM);
+  if (!params.has("mode")) {
+    params.set("mode", "serpentine");
+    changed = true;
+  }
+  if (!params.has("stepDeg") && !params.has("speed")) {
+    params.set("stepDeg", DEFAULT_STEP_DEG.toString());
+    changed = true;
+  }
+  if (!params.has("latStepDeg")) {
+    params.set("latStepDeg", DEFAULT_LAT_STEP_DEG.toString());
+    changed = true;
+  }
+  if (!params.has("pauseMs") && !params.has("pause")) {
+    params.set("pauseMs", DEFAULT_PAUSE_MS.toString());
+    changed = true;
+  }
+  if (!params.has("loops")) {
+    params.set("loops", DEFAULT_LOOPS.toString());
     changed = true;
   }
 
@@ -39,7 +66,10 @@ const ensureDiagnosticsParams = () => {
 };
 
 const DiagnosticsAutoPan = () => {
-  const [bearing, setBearing] = useState(0);
+  const [state, setState] = useState<DiagnosticsAutoPanState>({
+    mode: "spin",
+    bearing: 0
+  });
 
   useEffect(() => {
     ensureDiagnosticsParams();
@@ -48,11 +78,20 @@ const DiagnosticsAutoPan = () => {
     }
 
     const handleBearing: EventListener = (event) => {
-      const detail = (event as CustomEvent<{ bearing?: number }>).detail;
-      if (!detail || typeof detail.bearing !== "number") {
+      const detail = (event as CustomEvent<AutoPanEventDetail>).detail;
+      if (!detail) {
         return;
       }
-      setBearing(detail.bearing);
+      if (detail.mode === "serpentine") {
+        const lat = typeof detail.lat === "number" ? detail.lat : 0;
+        const lon = typeof detail.lon === "number" ? detail.lon : 0;
+        const band = typeof detail.band === "number" ? detail.band : 0;
+        const direction = detail.direction === "W" ? "W" : "E";
+        setState({ mode: "serpentine", lat, lon, band, direction });
+        return;
+      }
+      const bearing = typeof detail.bearing === "number" ? detail.bearing : 0;
+      setState({ mode: "spin", bearing });
     };
 
     window.addEventListener(GEO_SCOPE_AUTOPAN_EVENT, handleBearing);
@@ -61,6 +100,12 @@ const DiagnosticsAutoPan = () => {
     };
   }, []);
 
+  const label = state.mode === "serpentine" ? "Lat / Lon" : "Bearing";
+  const value =
+    state.mode === "serpentine"
+      ? `${state.lat.toFixed(2)}°, ${state.lon.toFixed(2)}° · band ${state.band} ${state.direction}`
+      : `${state.bearing.toFixed(1)}°`;
+
   return (
     <div className="diagnostics-auto-pan">
       <div className="diagnostics-auto-pan__map" aria-hidden="true">
@@ -68,8 +113,8 @@ const DiagnosticsAutoPan = () => {
       </div>
       <div className="diagnostics-auto-pan__overlay">
         <div className="diagnostics-auto-pan__ticker" aria-live="polite">
-          <span className="diagnostics-auto-pan__label">Bearing</span>
-          <span className="diagnostics-auto-pan__value">{bearing.toFixed(1)}°</span>
+          <span className="diagnostics-auto-pan__label">{label}</span>
+          <span className="diagnostics-auto-pan__value">{value}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a serpentine auto-pan runner that sweeps map bands, throttles logs, and emits structured step telemetry
- parse diagnostics query parameters for serpentine settings while keeping spin mode compatibility
- surface serpentine state in the diagnostics overlay ticker when mode is active

## Testing
- npm run build *(fails: missing npm packages in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6903a28e22108326899086f2c22a37b3