### PR TITLE
Fix ConfigPage disableInputs initialization order

### DIFF
--- a/dash-ui/src/pages/ConfigPage.tsx
+++ b/dash-ui/src/pages/ConfigPage.tsx
@@ -333,6 +333,9 @@ const ConfigPage: React.FC = () => {
     return Array.from(base);
   }, [form.ui.rotation.panels]);
 
+  const isReady = status === "ready";
+  const disableInputs = !isReady || saving;
+
   const cinemaBlocked = !form.ui.rotation.enabled || !form.ui.map.cinema.enabled;
   const disableCinemaControls = disableInputs || cinemaBlocked;
   const disableIdlePanControls =
@@ -429,9 +432,6 @@ const ConfigPage: React.FC = () => {
     }
     setNewPanel("");
   };
-
-  const isReady = status === "ready";
-  const disableInputs = !isReady || saving;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- define `isReady` and `disableInputs` before derived cinema control flags to avoid use-before-declaration errors

## Testing
- npm run build *(fails: project missing dependencies or type declarations for React/Day.js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69042bb719d88326ac2006beae753185