### PR TITLE
Fix storm help render syntax

### DIFF
--- a/dash-ui/src/pages/ConfigPage.tsx
+++ b/dash-ui/src/pages/ConfigPage.tsx
@@ -1365,7 +1365,7 @@ const ConfigPage: React.FC = () => {
                     />
                     Activar modo tormenta
                   </label>
-                  {renderHelp("Activa el modo de visualización para tormentas locales (zoom Castellón/Vila-real)"}
+                  {renderHelp("Activa el modo de visualización para tormentas locales (zoom Castellón/Vila-real)")}
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
- fix the JSX invocation of `renderHelp` for the storm mode toggle so the component compiles again

## Testing
- npm run build *(fails: missing local dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6904bbbe43508326b08e19967dd8e000