### PR TITLE
Fix GeoScope type safety and config defaults

### DIFF
--- a/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
@@ -2,6 +2,7 @@ import maplibregl from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
+import { getExistingPopup, isGeoJSONSource } from "./layerUtils";
 
 interface AircraftLayerOptions {
   enabled?: boolean;
@@ -95,7 +96,7 @@ export default class AircraftLayer implements Layer {
             const content = `<strong>${callsign}</strong><br/>Altitud: ${alt}m<br/>Velocidad: ${speed}`;
             
             // Crear popup si no existe
-            if (!map.getPopup()) {
+            if (!getExistingPopup(map)) {
               new maplibregl.Popup({ closeOnClick: false, closeButton: true })
                 .setLngLat(e.lngLat)
                 .setHTML(content)
@@ -107,7 +108,7 @@ export default class AircraftLayer implements Layer {
 
       map.on("mouseleave", this.id, () => {
         map.getCanvas().style.cursor = "";
-        const popup = map.getPopup();
+        const popup = getExistingPopup(map);
         if (popup) {
           popup.remove();
         }
@@ -116,7 +117,7 @@ export default class AircraftLayer implements Layer {
 
       map.on("mousemove", this.id, (e) => {
         if (e.features && e.features.length > 0 && hoveredId) {
-          const popup = map.getPopup();
+          const popup = getExistingPopup(map);
           if (popup) {
             popup.setLngLat(e.lngLat);
           }
@@ -187,7 +188,7 @@ export default class AircraftLayer implements Layer {
     };
 
     const source = this.map.getSource(this.sourceId);
-    if (source && source.type === "geojson") {
+    if (isGeoJSONSource(source)) {
       source.setData(featuresWithAge);
     }
   }
@@ -195,7 +196,7 @@ export default class AircraftLayer implements Layer {
   getData(): FeatureCollection {
     if (!this.map) return EMPTY;
     const source = this.map.getSource(this.sourceId);
-    if (source && source.type === "geojson") {
+    if (isGeoJSONSource(source)) {
       return (source.getData() as FeatureCollection) ?? EMPTY;
     }
     return EMPTY;

--- a/dash-ui/src/components/GeoScope/layers/LightningLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/LightningLayer.ts
@@ -2,6 +2,7 @@ import maplibregl from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
+import { isGeoJSONSource } from "./layerUtils";
 
 interface LightningLayerOptions {
   enabled?: boolean;
@@ -65,7 +66,7 @@ export default class LightningLayer implements Layer {
   updateData(data: FeatureCollection): void {
     if (!this.map) return;
     const source = this.map.getSource(this.sourceId);
-    if (source && source.type === "geojson") {
+    if (isGeoJSONSource(source)) {
       source.setData(data);
     }
   }
@@ -73,7 +74,7 @@ export default class LightningLayer implements Layer {
   getData(): FeatureCollection {
     if (!this.map) return EMPTY;
     const source = this.map.getSource(this.sourceId);
-    if (source && source.type === "geojson") {
+    if (isGeoJSONSource(source)) {
       return (source.getData() as FeatureCollection) ?? EMPTY;
     }
     return EMPTY;

--- a/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
@@ -2,6 +2,7 @@ import maplibregl from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
+import { getExistingPopup, isGeoJSONSource } from "./layerUtils";
 
 interface ShipsLayerOptions {
   enabled?: boolean;
@@ -99,7 +100,7 @@ export default class ShipsLayer implements Layer {
             const content = `<strong>${name}</strong><br/>MMSI: ${mmsi}<br/>Velocidad: ${speed}<br/>Curso: ${course}<br/>Última actualización: ${timestamp}`;
             
             // Crear popup si no existe
-            if (!map.getPopup()) {
+            if (!getExistingPopup(map)) {
               new maplibregl.Popup({ closeOnClick: false, closeButton: true })
                 .setLngLat(e.lngLat)
                 .setHTML(content)
@@ -111,7 +112,7 @@ export default class ShipsLayer implements Layer {
 
       map.on("mouseleave", this.id, () => {
         map.getCanvas().style.cursor = "";
-        const popup = map.getPopup();
+        const popup = getExistingPopup(map);
         if (popup) {
           popup.remove();
         }
@@ -120,7 +121,7 @@ export default class ShipsLayer implements Layer {
 
       map.on("mousemove", this.id, (e) => {
         if (e.features && e.features.length > 0 && hoveredId) {
-          const popup = map.getPopup();
+          const popup = getExistingPopup(map);
           if (popup) {
             popup.setLngLat(e.lngLat);
           }
@@ -191,7 +192,7 @@ export default class ShipsLayer implements Layer {
     };
 
     const source = this.map.getSource(this.sourceId);
-    if (source && source.type === "geojson") {
+    if (isGeoJSONSource(source)) {
       source.setData(featuresWithAge);
     }
   }
@@ -199,7 +200,7 @@ export default class ShipsLayer implements Layer {
   getData(): FeatureCollection {
     if (!this.map) return EMPTY;
     const source = this.map.getSource(this.sourceId);
-    if (source && source.type === "geojson") {
+    if (isGeoJSONSource(source)) {
       return (source.getData() as FeatureCollection) ?? EMPTY;
     }
     return EMPTY;

--- a/dash-ui/src/components/GeoScope/layers/layerUtils.ts
+++ b/dash-ui/src/components/GeoScope/layers/layerUtils.ts
@@ -1,0 +1,31 @@
+import type maplibregl from "maplibre-gl";
+import type { GeoJSONSource, Popup } from "maplibre-gl";
+
+const isFunction = (value: unknown): value is (...args: unknown[]) => unknown =>
+  typeof value === "function";
+
+type GeoJSONSourceWithData = GeoJSONSource & {
+  type: "geojson";
+};
+
+type SourceCandidate = {
+  type?: string;
+};
+
+export const isGeoJSONSource = (
+  source: unknown,
+): source is GeoJSONSourceWithData => {
+  if (!source || typeof source !== "object") {
+    return false;
+  }
+  return (source as SourceCandidate).type === "geojson";
+};
+
+export const getExistingPopup = (map: maplibregl.Map): Popup | undefined => {
+  const candidate = (map as maplibregl.Map & { getPopup?: () => Popup | null }).getPopup;
+  if (!isFunction(candidate)) {
+    return undefined;
+  }
+  const popup = candidate.call(map);
+  return popup ?? undefined;
+};

--- a/dash-ui/src/lib/api.ts
+++ b/dash-ui/src/lib/api.ts
@@ -41,14 +41,17 @@ const apiRequest = async <T>(path: string, init?: RequestInit): Promise<T> => {
       }
     : {};
 
+  const { headers: initHeaders, cache: initCache, ...restInit } = init ?? {};
+  const headers = new Headers(initHeaders ?? {});
+  headers.set("Accept", "application/json");
+  for (const [key, value] of Object.entries(cacheHeaders)) {
+    headers.set(key, value);
+  }
+
   const response = await fetch(withBase(path), {
-    headers: {
-      Accept: "application/json",
-      ...cacheHeaders,
-      ...(init?.headers ?? {}),
-    },
-    cache: isConfigEndpoint ? "no-store" : "default",
-    ...init,
+    ...restInit,
+    headers,
+    cache: isConfigEndpoint ? "no-store" : initCache ?? "default",
   });
   if (!response.ok) {
     const body = await readJson(response);

--- a/dash-ui/src/pages/ConfigPage.tsx
+++ b/dash-ui/src/pages/ConfigPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
-import { DEFAULT_CONFIG, withConfigDefaults } from "../config/defaults";
+import { DEFAULT_CONFIG, createDefaultGlobalLayers, withConfigDefaults } from "../config/defaults";
 import {
   API_ORIGIN,
   ApiError,
@@ -2791,7 +2791,7 @@ const ConfigPage: React.FC = () => {
         {supports("layers.global") && (() => {
           // Helper para obtener valores de global con defaults completos
           const getGlobalWithDefaults = (prev: AppConfig) => {
-            const defaultGlobal = DEFAULT_CONFIG.layers.global;
+            const defaultGlobal = DEFAULT_CONFIG.layers.global ?? createDefaultGlobalLayers();
             const currentGlobal = prev.layers.global;
             
             return {


### PR DESCRIPTION
## Summary
- add shared GeoScope layer utilities to guard popup access and GeoJSON source updates
- tighten GeoScope map feature loading, WebGL error handling, and event typing to satisfy TypeScript
- harden config defaults, global layer helpers, and API header merging to avoid undefined fallbacks
- update the configuration UI to rely on safe global defaults when composing state

## Testing
- npm run build *(fails: missing dependencies are blocked by the registry policy in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6904bc8843308326bd4da854e6d64852