### PR TITLE
Restore apt chromium fallback for kiosk launcher

### DIFF
--- a/usr/local/bin/pantalla-kiosk
+++ b/usr/local/bin/pantalla-kiosk
@@ -79,6 +79,13 @@ find_chromium() {
     fi
   done
 
+  local apt_candidate="/usr/lib/chromium-browser/chromium-browser"
+  if [[ -x "$apt_candidate" ]]; then
+    log "INFO: Usando chromium-browser del paquete (${apt_candidate})"
+    printf '%s\n' "$apt_candidate"
+    return 0
+  fi
+
   return 1
 }
 


### PR DESCRIPTION
## Summary
- add a fallback to the Debian chromium-browser binary when the snap and PATH options are unavailable
- log when the legacy chromium-browser package binary is selected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904d34a21448326af17067479d7cd9f