### PR TITLE
feat(kiosk+config/aemet): kiosk estable y secretos AEMET seguros

### DIFF
--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -26,6 +26,13 @@
         "enabled": false,
         "panLngDegPerSec": 0,
         "bandTransition_sec": 8,
+        "motion": {
+          "speedPreset": "medium",
+          "amplitudeDeg": 60,
+          "easing": "ease-in-out",
+          "pauseWithOverlay": true,
+          "phaseOffsetDeg": 25
+        },
         "bands": [
           { "lat": 0.0, "zoom": 2.8, "pitch": 10.0, "minZoom": 2.6, "duration_sec": 900 },
           { "lat": 18.0, "zoom": 3.0, "pitch": 8.0, "minZoom": 2.8, "duration_sec": 720 },

--- a/backend/models.py
+++ b/backend/models.py
@@ -40,6 +40,20 @@ class MapCinemaBand(BaseModel):
         return values
 
 
+class MapCinemaMotion(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    speed_preset: Literal["slow", "medium", "fast"] = Field(
+        default="medium", alias="speedPreset"
+    )
+    amplitude_deg: float = Field(default=60.0, ge=1.0, le=180.0, alias="amplitudeDeg")
+    easing: Literal["linear", "ease-in-out"] = "ease-in-out"
+    pause_with_overlay: bool = Field(default=True, alias="pauseWithOverlay")
+    phase_offset_deg: float = Field(
+        default=25.0, ge=0.0, le=360.0, alias="phaseOffsetDeg"
+    )
+
+
 class MapCinema(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -49,6 +63,7 @@ class MapCinema(BaseModel):
     bands: List[MapCinemaBand] = Field(
         default_factory=lambda: [MapCinemaBand(**band) for band in DEFAULT_CINEMA_BANDS]
     )
+    motion: MapCinemaMotion = Field(default_factory=MapCinemaMotion)
 
     @model_validator(mode="after")
     def validate_bands(cls, values: "MapCinema") -> "MapCinema":  # type: ignore[override]
@@ -454,6 +469,7 @@ __all__ = [
     "Harvest",
     "MapBackend",
     "MapCinema",
+    "MapCinemaMotion",
     "MapCinemaBand",
     "MapConfig",
     "MapIdlePan",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,5 @@ shapely>=2.0.0
 astral>=3.2
 Pillow>=10.0.0
 numpy>=1.24.0
+pytest
+httpx

--- a/backend/tests/test_aemet_endpoints.py
+++ b/backend/tests/test_aemet_endpoints.py
@@ -1,0 +1,182 @@
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Generator, Tuple
+
+import pytest
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "default_config.json"
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: Dict[str, object] | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self) -> Dict[str, object]:
+        if self._payload is None:
+            raise ValueError("no json payload")
+        return self._payload
+
+
+@pytest.fixture()
+def app_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Generator[Tuple[object, Path], None, None]:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    config_file = state_dir / "config.json"
+    config_file.write_text(DEFAULT_CONFIG_PATH.read_text(encoding="utf-8"), encoding="utf-8")
+
+    monkeypatch.setenv("PANTALLA_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("PANTALLA_CONFIG_FILE", str(config_file))
+    monkeypatch.setenv("PANTALLA_DEFAULT_CONFIG_FILE", str(DEFAULT_CONFIG_PATH))
+
+    if "backend.main" in sys.modules:
+        del sys.modules["backend.main"]
+
+    module = importlib.import_module("backend.main")
+    yield module, config_file
+
+
+def _write_aemet_key(module: object, api_key: str | None) -> None:
+    config = module.config_manager.read()
+    payload = config.model_dump(mode="json", by_alias=True)
+    payload.setdefault("aemet", {})["api_key"] = api_key
+    module.config_manager.write(payload)
+
+
+def test_config_masks_aemet_secret(app_module: Tuple[object, Path]) -> None:
+    module, _ = app_module
+    _write_aemet_key(module, "SECRETKEY1234")
+
+    public = module._build_public_config(module.config_manager.read())
+    aemet_info = public["aemet"]
+
+    assert "api_key" not in aemet_info
+    assert aemet_info["has_api_key"] is True
+    assert aemet_info["api_key_last4"] == "1234"
+
+
+def test_update_aemet_secret_persists(app_module: Tuple[object, Path]) -> None:
+    module, config_path = app_module
+
+    asyncio.run(module.update_aemet_secret(module.AemetSecretRequest(api_key="AEMET123456")))
+
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    assert raw["aemet"]["api_key"] == "AEMET123456"
+
+    public = module._build_public_config(module.config_manager.read())["aemet"]
+    assert public["has_api_key"] is True
+    assert public["api_key_last4"] == "3456"
+
+
+def test_update_aemet_secret_allows_clearing(app_module: Tuple[object, Path]) -> None:
+    module, config_path = app_module
+    _write_aemet_key(module, "ABCD9876")
+
+    asyncio.run(module.update_aemet_secret(module.AemetSecretRequest(api_key=None)))
+
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    assert "api_key" not in raw["aemet"]
+
+    public = module._build_public_config(module.config_manager.read())["aemet"]
+    assert public["has_api_key"] is False
+    assert public["api_key_last4"] is None
+
+
+def test_test_key_requires_secret(app_module: Tuple[object, Path]) -> None:
+    module, _ = app_module
+    result = module.test_aemet_key(module.AemetTestRequest(api_key=None))
+    assert result == {"ok": False, "reason": "missing_api_key"}
+
+
+def test_test_key_uses_candidate(monkeypatch: pytest.MonkeyPatch, app_module: Tuple[object, Path]) -> None:
+    module, _ = app_module
+    captured: Dict[str, object] = {}
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: float):  # type: ignore[override]
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return DummyResponse(200, {"estado": 200})
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    response = module.test_aemet_key(module.AemetTestRequest(api_key="INLINEKEY"))
+    assert response == {"ok": True}
+
+    assert captured["headers"]["api_key"] == "INLINEKEY"
+    assert captured["timeout"] == 6
+
+
+def test_test_key_network_failure(monkeypatch: pytest.MonkeyPatch, app_module: Tuple[object, Path]) -> None:
+    module, _ = app_module
+    _write_aemet_key(module, "NETWORKKEY")
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: float):  # type: ignore[override]
+        raise module.requests.RequestException("network down")
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    result = module.test_aemet_key(module.AemetTestRequest(api_key=None))
+    assert result == {"ok": False, "reason": "network"}
+
+
+def test_test_key_http_errors(monkeypatch: pytest.MonkeyPatch, app_module: Tuple[object, Path]) -> None:
+    module, _ = app_module
+    _write_aemet_key(module, "HTTPKEY")
+
+    monkeypatch.setattr(module.requests, "get", lambda *_, **__: DummyResponse(401))
+    unauthorized = module.test_aemet_key(module.AemetTestRequest(api_key=None))
+    assert unauthorized == {"ok": False, "reason": "unauthorized"}
+
+    monkeypatch.setattr(module.requests, "get", lambda *_, **__: DummyResponse(503))
+    upstream = module.test_aemet_key(module.AemetTestRequest(api_key=None))
+    assert upstream == {"ok": False, "reason": "upstream"}
+
+    monkeypatch.setattr(module.requests, "get", lambda *_, **__: DummyResponse(200, {"estado": 401}))
+    payload_unauthorized = module.test_aemet_key(module.AemetTestRequest(api_key=None))
+    assert payload_unauthorized == {"ok": False, "reason": "unauthorized"}
+
+
+def test_cinema_motion_serialization(app_module: Tuple[object, Path]) -> None:
+    module, _ = app_module
+    config = module.config_manager.read()
+    payload = config.model_dump(mode="json", by_alias=True)
+
+    motion = payload["ui"]["map"]["cinema"]["motion"]
+    motion.update(
+        {
+            "speedPreset": "fast",
+            "amplitudeDeg": 120,
+            "easing": "linear",
+            "pauseWithOverlay": False,
+            "phaseOffsetDeg": 90,
+        }
+    )
+    payload["ui"]["map"]["cinema"].update(
+        {
+            "motion": motion,
+            "enabled": True,
+            "panLngDegPerSec": 9,
+        }
+    )
+
+    module.config_manager.write(payload)
+
+    public = module._build_public_config(module.config_manager.read())
+    returned_motion = public["ui"]["map"]["cinema"]["motion"]
+    assert returned_motion == {
+        "speedPreset": "fast",
+        "amplitudeDeg": 120,
+        "easing": "linear",
+        "pauseWithOverlay": False,
+        "phaseOffsetDeg": 90,
+    }
+
+    stored_motion = module.config_manager.read().ui.map.cinema.motion
+    assert stored_motion.speed_preset == "fast"
+    assert pytest.approx(stored_motion.amplitude_deg) == 120
+    assert stored_motion.pause_with_overlay is False
+    assert pytest.approx(stored_motion.phase_offset_deg) == 90

--- a/dash-ui/src/lib/api.ts
+++ b/dash-ui/src/lib/api.ts
@@ -88,6 +88,26 @@ export async function saveConfig(data: AppConfig) {
   return apiPost<AppConfig>("/api/config", data);
 }
 
+export type AemetSecretRequest = {
+  api_key: string | null;
+};
+
+export type AemetTestResponse = {
+  ok: boolean;
+  reason?: string;
+};
+
+export async function updateAemetApiKey(apiKey: string | null) {
+  return apiPost<undefined>("/api/config/secret/aemet_api_key", {
+    api_key: apiKey,
+  } satisfies AemetSecretRequest);
+}
+
+export async function testAemetApiKey(apiKey?: string) {
+  const body = apiKey && apiKey.trim().length > 0 ? { api_key: apiKey } : {};
+  return apiPost<AemetTestResponse | undefined>("/api/aemet/test_key", body);
+}
+
 export async function getSchema() {
   return apiGet<Record<string, unknown> | undefined>("/api/config/schema");
 }

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -1025,6 +1025,32 @@ main {
   flex: 1;
 }
 
+.config-field__secret {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.config-field__secret input[type="text"],
+.config-field__secret input[type="password"] {
+  flex: 1;
+}
+
+.config-field__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+.config-field__hint--success {
+  color: var(--success);
+}
+
+.config-field__hint--error {
+  color: var(--danger);
+}
+
 .config-actions {
   display: flex;
   justify-content: flex-end;

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -11,6 +11,14 @@ export type MapCinemaBand = {
   duration_sec: number;
 };
 
+export type MapCinemaMotionConfig = {
+  speedPreset: "slow" | "medium" | "fast";
+  amplitudeDeg: number;
+  easing: "linear" | "ease-in-out";
+  pauseWithOverlay: boolean;
+  phaseOffsetDeg: number;
+};
+
 export type UIScrollSpeed = number | "slow" | "normal" | "fast";
 
 export type MapCinemaConfig = {
@@ -18,6 +26,7 @@ export type MapCinemaConfig = {
   panLngDegPerSec: number;
   bandTransition_sec: number;
   bands: MapCinemaBand[];
+  motion: MapCinemaMotionConfig;
 };
 
 export type MapIdlePanConfig = {
@@ -127,11 +136,13 @@ export type StormModeConfig = {
 
 export type AEMETConfig = {
   enabled: boolean;
-  api_key: string | null;
+  api_key?: string | null;
   cap_enabled: boolean;
   radar_enabled: boolean;
   satellite_enabled: boolean;
   cache_minutes: number;
+  has_api_key?: boolean;
+  api_key_last4?: string | null;
 };
 
 export type BlitzortungConfig = {

--- a/scripts/pantalla-kiosk-verify
+++ b/scripts/pantalla-kiosk-verify
@@ -247,11 +247,60 @@ check_kiosk_logs() {
   return 0
 }
 
+check_window_consistency() {
+  if ! command -v wmctrl >/dev/null 2>&1; then
+    record_result "windows" "skipped-no-wmctrl"
+    return 0
+  fi
+  local display_env="${DISPLAY:-:0}"
+  local xauth_env="${XAUTHORITY:-/home/${TARGET_USER}/.Xauthority}"
+  local wm_output
+  if ! wm_output=$(DISPLAY="$display_env" XAUTHORITY="$xauth_env" wmctrl -lx 2>/dev/null); then
+    record_result "windows" "wmctrl-fail"
+    return 1
+  fi
+  local kiosk_count
+  kiosk_count=$(printf '%s\n' "$wm_output" | awk '$4 ~ /pantalla-kiosk/ {count++} END {print count+0}')
+  if (( kiosk_count == 0 )); then
+    record_result "windows" "missing-kiosk"
+    return 1
+  fi
+  local residual_count
+  residual_count=$(printf '%s\n' "$wm_output" | awk '$4 ~ /^(chromium-browser\.Chromium-browser|chrome\.chromium|chromium\.Chromium)$/ {count++} END {print count+0}')
+  if (( residual_count > 0 )); then
+    record_result "windows" "residual-${residual_count}"
+    return 1
+  fi
+  record_result "windows" "ok"
+  return 0
+}
+
+check_gl_flag() {
+  if ! command -v pgrep >/dev/null 2>&1; then
+    record_result "egl" "skipped-no-pgrep"
+    return 0
+  fi
+  local processes
+  processes=$(pgrep -af -- '--class=pantalla-kiosk' 2>/dev/null || true)
+  if [[ -z "$processes" ]]; then
+    record_result "egl" "missing-process"
+    return 1
+  fi
+  if ! grep -q -- '--use-gl=egl-angle' <<<"$processes"; then
+    record_result "egl" "missing-flag"
+    return 1
+  fi
+  record_result "egl" "ok"
+  return 0
+}
+
 main() {
   local failures=0
   check_ui_health || failures=$((failures + 1))
   check_backend_health || failures=$((failures + 1))
   check_kiosk_units || failures=$((failures + 1))
+  check_window_consistency || failures=$((failures + 1))
+  check_gl_flag || failures=$((failures + 1))
 
   local kiosk_unit="pantalla-kiosk-chromium@${TARGET_USER}.service"
   local kiosk_url

--- a/scripts/verify_kiosk.sh
+++ b/scripts/verify_kiosk.sh
@@ -23,6 +23,24 @@ if command -v wmctrl >/dev/null 2>&1; then
   fi
 fi
 
+residual_chrome=0
+if [[ $wmctrl_status -eq 0 ]]; then
+  residual_chrome=$(printf '%s\n' "$wmctrl_output" | awk '{print $4}' | grep -E '^(chromium-browser\.Chromium-browser|chrome\.chromium|chromium\.Chromium)$' | wc -l | tr -d ' ')
+fi
+
+egl_check_output=""
+egl_flag_missing=0
+pgrep_available=0
+if command -v pgrep >/dev/null 2>&1; then
+  pgrep_available=1
+  egl_check_output=$(pgrep -af -- '--class=pantalla-kiosk' 2>/dev/null || true)
+  if [[ -z "$egl_check_output" ]]; then
+    egl_flag_missing=1
+  elif ! grep -q -- '--use-gl=egl-angle' <<<"$egl_check_output"; then
+    egl_flag_missing=1
+  fi
+fi
+
 match_line=""
 match_class=""
 match_title=""
@@ -57,6 +75,24 @@ if command -v xprop >/dev/null 2>&1; then
 fi
 
 if [[ -n "$match_line" ]]; then
+  if (( residual_chrome > 0 )); then
+    echo "WARN ventana Chromium residual detectada (${residual_chrome})"
+    if [[ -n "$wmctrl_output" ]]; then
+      echo "$wmctrl_output" | awk '{print "    " $0}'
+    fi
+    exit 1
+  fi
+
+  if (( pgrep_available == 1 && egl_flag_missing == 1 )); then
+    echo "WARN proceso Chromium sin flag --use-gl=egl-angle"
+    if [[ -n "$egl_check_output" ]]; then
+      echo "    $egl_check_output"
+    fi
+    exit 1
+  elif (( pgrep_available == 0 )); then
+    echo "WARN pgrep no disponible; se omite verificación de --use-gl=egl-angle"
+  fi
+
   echo "OK ventana Chromium (pantalla-kiosk) detectada"
   echo "    WM_CLASS=${match_class}"
   echo "    TITLE=${match_title}"

--- a/systemd/pantalla-kiosk-chromium@.service
+++ b/systemd/pantalla-kiosk-chromium@.service
@@ -17,7 +17,7 @@ EnvironmentFile=-/var/lib/pantalla-reloj/state/kiosk.env
 
 ExecStartPre=/bin/sh -c 'i=0; while [ $i -lt 10 ]; do if test -r "$XAUTHORITY"; then exit 0; fi; sleep 1; i=$((i+1)); done; echo "XAUTHORITY no es legible tras 10 segundos: $XAUTHORITY" >&2; exit 1'
 ExecStartPre=/bin/sh -lc 'xset -dpms; xset s off; xset s noblank || true'
-ExecStartPre=/bin/sh -lc 'wmctrl -lx | awk '\''/pantalla-kiosk/ {print $1}'\'' | xargs -r -n1 wmctrl -ic || true'
+ExecStartPre=/bin/sh -lc 'pat="pantalla-kiosk|chrome.chromium|chromium-browser.Chromium-browser|chromium.Chromium"; wmctrl -lx 2>/dev/null | awk -v pat="$pat" '\''$3 ~ pat {print $1}'\'' | xargs -r -n1 wmctrl -ic || true'
 ExecStartPre=/bin/sh -c 'curl -sf --max-time 5 http://127.0.0.1:8081/api/health >/dev/null || echo "WARN: Backend no responde, pero continuando (el script tolera backend ausente)" >&2 || true'
 
 ExecStart=/usr/local/bin/pantalla-kiosk-chromium

--- a/usr/local/bin/pantalla-kiosk-chromium
+++ b/usr/local/bin/pantalla-kiosk-chromium
@@ -8,6 +8,57 @@ log() {
   printf '[pantalla-kiosk-chromium] %s\n' "$*" >&2
 }
 
+list_matching_windows() {
+  local patterns="$1"
+  if ! command -v wmctrl >/dev/null 2>&1; then
+    return 0
+  fi
+  local display="${DISPLAY:-:0}"
+  local auth="${XAUTHORITY:-}"
+  DISPLAY="$display" XAUTHORITY="$auth" wmctrl -lx 2>/dev/null | awk -v pat="$patterns" '$3 ~ pat {print $1}'
+}
+
+close_existing_windows() {
+  local patterns='pantalla-kiosk|chrome.chromium|chromium-browser.Chromium-browser|chromium.Chromium'
+  if ! command -v wmctrl >/dev/null 2>&1; then
+    log "wmctrl no disponible: se omite limpieza previa de ventanas"
+    return
+  fi
+  local -a ids
+  mapfile -t ids < <(list_matching_windows "$patterns")
+  if ((${#ids[@]} == 0)); then
+    return
+  fi
+  log "cerrando ${#ids[@]} ventanas Chromium residuales"
+  local display="${DISPLAY:-:0}"
+  local auth="${XAUTHORITY:-}"
+  for wid in "${ids[@]}"; do
+    [[ -n "$wid" ]] || continue
+    DISPLAY="$display" XAUTHORITY="$auth" wmctrl -ic "$wid" || true
+  done
+  sleep 0.3
+}
+
+cleanup_profile_artifacts() {
+  local profile_dir="$1"
+  local cache_dir="$2"
+  local -a singleton_patterns=(SingletonLock SingletonCookie SingletonSocket)
+  local base
+  for base in "$profile_dir" "$cache_dir"; do
+    [[ -d "$base" ]] || continue
+    find "$base" -maxdepth 2 -type f \( -name "${singleton_patterns[0]}" -o -name "${singleton_patterns[1]}" -o -name "${singleton_patterns[2]}" \) -delete 2>/dev/null || true
+    local -a locks=()
+    mapfile -t locks < <(find "$base" -maxdepth 3 -type f -name 'LOCK' -print 2>/dev/null)
+    if ((${#locks[@]} > 0)); then
+      local lock
+      for lock in "${locks[@]}"; do
+        rm -f "$lock"
+      done
+      log "eliminados ${#locks[@]} LOCK residuales en ${base}"
+    fi
+  done
+}
+
 resolve_url() {
   local candidate="$1"
   if [[ -z "$candidate" ]]; then
@@ -97,8 +148,6 @@ launch_chromium() {
     --ignore-gpu-blocklist
     --enable-webgl
     --use-gl=egl-angle
-    --enable-logging=stderr
-    --v=1
     "--disk-cache-dir=${cache_dir}"
     "--user-data-dir=${profile_dir}"
   )
@@ -107,17 +156,38 @@ launch_chromium() {
     args+=("--force-device-scale-factor=${CHROMIUM_SCALE}")
   fi
 
+  if [[ "${PANTALLA_CHROMIUM_VERBOSE:-0}" == "1" ]]; then
+    args+=(--enable-logging=stderr --v=1)
+  else
+    args+=(--enable-logging=stderr --log-level=1)
+  fi
+
   if (( use_swiftshader )); then
     args+=(--enable-unsafe-swiftshader)
+    log "swiftshader habilitado para esta ejecución"
   fi
 
   log "launch: ${args[*]}"
   log "url: ${url}"
 
-  local log_file
-  log_file="$(mktemp -t pantalla-chromium.XXXXXX)"
+  local log_dir="/var/log/pantalla"
+  install -d -m 0755 "$log_dir"
+  local persistent_log="${log_dir}/browser-kiosk.log"
+  touch "$persistent_log"
+  chmod 0644 "$persistent_log" 2>/dev/null || true
+  if [[ -s "$persistent_log" ]]; then
+    tail -n 4000 "$persistent_log" >"${persistent_log}.tmp" 2>/dev/null && mv "${persistent_log}.tmp" "$persistent_log"
+  fi
 
-  "${args[@]}" 2> >(tee -a "$log_file" >&2)
+  local log_file
+  log_file="$(mktemp -p /tmp pantalla-chromium.XXXXXX.log)"
+  if [[ -z "$log_file" ]]; then
+    log "no se pudo crear archivo temporal en /tmp"
+    log_file="/tmp/pantalla-chromium.log"
+  fi
+  log "stderr se registrará en ${log_file} y ${persistent_log}"
+
+  "${args[@]}" 2> >(tee -a "$log_file" | tee -a "$persistent_log" >&2)
   local status=$?
 
   local fallback=0
@@ -132,8 +202,6 @@ launch_chromium() {
       fi
     fi
   fi
-
-  rm -f "$log_file"
 
   if (( fallback )); then
     return 99
@@ -202,16 +270,19 @@ main() {
   local target_url
   target_url="$(resolve_url "$raw_url")"
 
+  local allow_swiftshader=0
+  if [[ "${PANTALLA_ALLOW_SWIFTSHADER:-0}" == "1" ]]; then
+    allow_swiftshader=1
+    log "SwiftShader permitido bajo demanda (PANTALLA_ALLOW_SWIFTSHADER=1)"
+  fi
+
   local base_dir profile_dir cache_dir
   base_dir="${CHROMIUM_BASE_DIR:-${HOME}/snap/chromium/common/pantalla-reloj}"
   profile_dir="${CHROMIUM_USER_DATA_DIR:-${base_dir}/chromium}"
   cache_dir="${CHROMIUM_CACHE_DIR:-${base_dir}/cache}"
 
   prepare_dirs "$profile_dir" "$cache_dir"
-
-  find "$profile_dir" -maxdepth 2 -type f \
-    \( -name 'SingletonLock' -o -name 'SingletonCookie' -o -name 'SingletonSocket' \) \
-    -print -delete || true
+  cleanup_profile_artifacts "$profile_dir" "$cache_dir"
 
   if [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
     export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/$(id -u)/bus"
@@ -224,18 +295,28 @@ main() {
   log "cache_dir: ${cache_dir}"
   log "url: ${target_url}"
 
+  if [[ "${PANTALLA_CHROMIUM_VERBOSE:-0}" == "1" ]]; then
+    log "Chromium se inicia en modo verbose (--v=1)"
+  fi
+
+  close_existing_windows
+
   if launch_chromium 0 "$chromium_bin" "$target_url" "$profile_dir" "$cache_dir"; then
     exit 0
   fi
 
   local first_status=$?
   if (( first_status == 99 )); then
-    log "swiftshader fallback enabled"
-    if launch_chromium 1 "$chromium_bin" "$target_url" "$profile_dir" "$cache_dir"; then
-      exit 0
+    if (( allow_swiftshader )); then
+      log "Activando fallback SwiftShader (--enable-unsafe-swiftshader)"
+      if launch_chromium 1 "$chromium_bin" "$target_url" "$profile_dir" "$cache_dir"; then
+        exit 0
+      fi
+      local second_status=$?
+      exit $second_status
     fi
-    local second_status=$?
-    exit $second_status
+    log "SwiftShader deshabilitado (exporta PANTALLA_ALLOW_SWIFTSHADER=1 para permitirlo)"
+    exit $first_status
   fi
 
   exit $first_status


### PR DESCRIPTION
## Summary
- completa los controles de modo cine y el gestor seguro de la API key de AEMET en /config, con estilos y ayudas revisados
- oculta el secreto de AEMET en el backend, añade endpoints específicos y pruebas unitarias, y suaviza el autopan del mapa según los nuevos parámetros
- refuerza el lanzador/systemd/diagnóstico de Chromium (EGL ANGLE, limpieza de ventanas, logs rotados, fallback SwiftShader opcional) y documenta el flujo

## Testing
- pytest backend/tests
- npm run build *(falla: dependencias npm bloqueadas por el registro)*

------
https://chatgpt.com/codex/tasks/task_e_6904d9b24f40832693b134360724bad0