### PR TITLE
Fix MapLibre type references in aircraft layer

### DIFF
--- a/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
@@ -119,7 +119,7 @@ export default class AircraftLayer implements Layer {
     }
 
     if (!map.getSource(this.sourceId)) {
-      const sourceInit: maplibregl.GeoJSONSourceRaw = {
+      const sourceInit: maplibregl.GeoJSONSourceSpecification = {
         type: "geojson",
         data: this.lastData,
       };
@@ -212,7 +212,7 @@ export default class AircraftLayer implements Layer {
     }
   }
 
-  private getOpacityExpression(): maplibregl.Expression {
+  private getOpacityExpression(): maplibregl.ExpressionSpecification {
     return [
       "interpolate",
       ["linear"],


### PR DESCRIPTION
## Summary
- use the GeoJSONSourceSpecification type when creating the aircraft source
- return an ExpressionSpecification for the aircraft opacity expression to match MapLibre typings

## Testing
- npm install *(fails: registry returned 403 Forbidden for maplibre-gl)*

------
https://chatgpt.com/codex/tasks/task_e_690500d9636c83268beb347b4eac3a9b