### PR TITLE
Fix Vitest configuration and typing

### DIFF
--- a/dash-ui/src/pages/__tests__/ConfigPage.wifi.test.tsx
+++ b/dash-ui/src/pages/__tests__/ConfigPage.wifi.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import { ConfigPage } from "../ConfigPage";
 import { withConfigDefaults } from "../../config/defaults";
@@ -41,7 +41,7 @@ vi.mock("../../lib/api", async (importOriginal) => {
 });
 
 type Mocked<T> = T extends (...args: infer Args) => infer Return
-  ? vi.Mock<Promise<Awaited<Return>>, Args>
+  ? Mock<Promise<Awaited<Return>>, Args>
   : never;
 
 const mockGetConfig = getConfig as Mocked<typeof getConfig>;

--- a/dash-ui/vite.config.ts
+++ b/dash-ui/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary
- import Vitest's typed configuration helper so the `test` options are recognized by TypeScript
- use Vitest's exported `Mock` type in the WiFi configuration test to avoid namespace typing errors

## Testing
- npm run build *(fails: missing npm dependencies due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_690504cf830c83268fc5dd3bc5cd5907