### PR TITLE
Allow null OpenSky status responses

### DIFF
--- a/dash-ui/src/lib/api.ts
+++ b/dash-ui/src/lib/api.ts
@@ -168,7 +168,7 @@ export async function getOpenSkyClientSecretMeta() {
 }
 
 export async function getOpenSkyStatus() {
-  return apiGet<OpenSkyStatus>("/api/opensky/status");
+  return apiGet<OpenSkyStatus | null>("/api/opensky/status");
 }
 
 // Storm Mode API


### PR DESCRIPTION
## Summary
- allow the dashboard API client to treat missing OpenSky status responses as null so tests can mock that scenario

## Testing
- npm run build *(fails: existing TypeScript configuration issues unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_6905067b60708326ac5996635a2f457e