### PR TITLE
feat: add OpenWeatherMap global radar provider

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -408,7 +408,7 @@ class GlobalRadarLayer(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     enabled: bool = True
-    provider: Literal["rainviewer"] = Field(default="rainviewer")
+    provider: Literal["rainviewer", "openweathermap"] = Field(default="rainviewer")
     refresh_minutes: int = Field(default=5, ge=1, le=1440)
     history_minutes: int = Field(default=90, ge=1, le=1440)
     frame_step: int = Field(default=5, ge=1, le=1440)

--- a/dash-ui/src/lib/api.ts
+++ b/dash-ui/src/lib/api.ts
@@ -97,6 +97,11 @@ export type AemetTestResponse = {
   reason?: string;
 };
 
+export type MaskedSecretMeta = {
+  has_api_key: boolean;
+  api_key_last4: string | null;
+};
+
 export async function updateAemetApiKey(apiKey: string | null) {
   return apiPost<undefined>("/api/config/secret/aemet_api_key", {
     api_key: apiKey,
@@ -112,6 +117,14 @@ export async function updateAISStreamApiKey(apiKey: string | null) {
 export async function testAemetApiKey(apiKey?: string) {
   const body = apiKey && apiKey.trim().length > 0 ? { api_key: apiKey } : {};
   return apiPost<AemetTestResponse | undefined>("/api/aemet/test_key", body);
+}
+
+export async function updateOpenWeatherMapApiKey(apiKey: string | null) {
+  return apiPost<undefined>("/api/config/secret/openweathermap_api_key", { api_key: apiKey });
+}
+
+export async function getOpenWeatherMapApiKeyMeta() {
+  return apiGet<MaskedSecretMeta>("/api/config/secret/openweathermap_api_key");
 }
 
 export async function getSchema() {

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -266,11 +266,13 @@ export type GlobalSatelliteLayerConfig = {
 
 export type GlobalRadarLayerConfig = {
   enabled: boolean;
-  provider: "rainviewer";
+  provider: "rainviewer" | "openweathermap";
   refresh_minutes: number;
   history_minutes: number;
   frame_step: number;
   opacity: number;
+  has_api_key?: boolean;
+  api_key_last4?: string | null;
 };
 
 export type GlobalLayersConfig = {


### PR DESCRIPTION
## Summary
- add an OpenWeatherMap-backed global radar provider with API key resolution while keeping RainViewer available
- update backend config exposure, health reporting, frames endpoint, and tile proxy logic to respect the configured provider and surface degraded states
- expose new secret endpoints plus UI controls to select the provider and manage the OpenWeatherMap key, including masked metadata in config

## Testing
- pytest backend

------
https://chatgpt.com/codex/tasks/task_e_6905c58528948326b100ab60964a0ba4