### PR TITLE
feat(opensky): add oauth2 flow and secure config handling

### DIFF
--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -122,7 +122,15 @@
     "poll_seconds": 10,
     "extended": 0,
     "max_aircraft": 400,
-    "cluster": true
+    "cluster": true,
+    "oauth2": {
+      "token_url": "https://auth.opensky-network.org/oauth/token",
+      "client_id": null,
+      "client_secret": null,
+      "scope": null,
+      "has_credentials": false,
+      "client_id_last4": null
+    }
   },
   "news": {
     "enabled": true,

--- a/backend/models.py
+++ b/backend/models.py
@@ -275,6 +275,20 @@ class OpenSkyBBox(BaseModel):
         return values
 
 
+class OpenSkyOAuthConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    token_url: str = Field(
+        default="https://auth.opensky-network.org/oauth/token",
+        max_length=512,
+    )
+    client_id: Optional[str] = Field(default=None, max_length=256)
+    client_secret: Optional[str] = Field(default=None, max_length=256)
+    scope: Optional[str] = Field(default=None, max_length=256)
+    has_credentials: bool = False
+    client_id_last4: Optional[str] = Field(default=None, max_length=16)
+
+
 class OpenSkyConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -285,6 +299,7 @@ class OpenSkyConfig(BaseModel):
     extended: Literal[0, 1] = Field(default=0)
     max_aircraft: int = Field(default=400, ge=50, le=1000)
     cluster: bool = True
+    oauth2: OpenSkyOAuthConfig = Field(default_factory=OpenSkyOAuthConfig)
 
 class OpenSkyAuth(BaseModel):
     """Configuración de autenticación OpenSky."""
@@ -518,6 +533,7 @@ __all__ = [
     "MapTheme",
     "News",
     "OpenSkyBBox",
+    "OpenSkyOAuthConfig",
     "OpenSkyConfig",
     "Rotation",
     "Saints",

--- a/dash-ui/src/lib/api.ts
+++ b/dash-ui/src/lib/api.ts
@@ -131,19 +131,21 @@ export async function getSchema() {
   return apiGet<Record<string, unknown> | undefined>("/api/config/schema");
 }
 
-type SecretMeta = {
-  set: boolean;
-};
-
 export type OpenSkyStatus = {
   enabled: boolean;
   mode: "bbox" | "global";
   configured_poll?: number;
   effective_poll?: number;
+  status?: "ok" | "error" | "stale" | string;
+  auth?: {
+    has_credentials: boolean;
+    token_cached: boolean;
+    expires_in_sec: number | null;
+  };
   has_credentials?: boolean;
-  token_set?: boolean;
-  token_valid?: boolean;
+  token_cached?: boolean;
   expires_in?: number | null;
+  expires_in_sec?: number | null;
   backoff_active?: boolean;
   backoff_seconds?: number;
   last_fetch_ok?: boolean | null;
@@ -151,40 +153,15 @@ export type OpenSkyStatus = {
   last_fetch_iso?: string | null;
   last_fetch_age?: number | null;
   last_error?: string | null;
-  items_count?: number;
+  items?: number | null;
+  items_count?: number | null;
+  rate_limit_hint?: string | null;
   bbox: { lamin: number; lamax: number; lomin: number; lomax: number };
   max_aircraft: number;
   extended: number;
   cluster: boolean;
   poll_warning?: string;
 };
-
-const sendSecretUpdate = async (path: string, value: string | null) => {
-  const payload = value ? value.trim() : "";
-  return apiRequest<undefined>(path, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "text/plain;charset=utf-8",
-    },
-    body: payload,
-  });
-};
-
-export async function updateOpenSkyClientId(value: string | null) {
-  return sendSecretUpdate("/api/config/secret/opensky_client_id", value);
-}
-
-export async function updateOpenSkyClientSecret(value: string | null) {
-  return sendSecretUpdate("/api/config/secret/opensky_client_secret", value);
-}
-
-export async function getOpenSkyClientIdMeta() {
-  return apiGet<SecretMeta>("/api/config/secret/opensky_client_id");
-}
-
-export async function getOpenSkyClientSecretMeta() {
-  return apiGet<SecretMeta>("/api/config/secret/opensky_client_secret");
-}
 
 export async function getOpenSkyStatus() {
   return apiGet<OpenSkyStatus | null>("/api/opensky/status");

--- a/dash-ui/src/pages/__tests__/ConfigPage.wifi.test.tsx
+++ b/dash-ui/src/pages/__tests__/ConfigPage.wifi.test.tsx
@@ -5,17 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConfigPage } from "../ConfigPage";
 import { withConfigDefaults } from "../../config/defaults";
-import {
-  getConfig,
-  getHealth,
-  getOpenSkyClientIdMeta,
-  getOpenSkyClientSecretMeta,
-  getOpenSkyStatus,
-  getSchema,
-  wifiNetworks,
-  wifiScan,
-  wifiStatus,
-} from "../../lib/api";
+import { getConfig, getHealth, getOpenSkyStatus, getSchema, wifiNetworks, wifiScan, wifiStatus } from "../../lib/api";
 
 vi.mock("../../lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../lib/api")>();
@@ -24,8 +14,6 @@ vi.mock("../../lib/api", async (importOriginal) => {
     getConfig: vi.fn(),
     getHealth: vi.fn(),
     getSchema: vi.fn(),
-    getOpenSkyClientIdMeta: vi.fn(),
-    getOpenSkyClientSecretMeta: vi.fn(),
     getOpenSkyStatus: vi.fn(),
     wifiScan: vi.fn(),
     wifiNetworks: vi.fn(),
@@ -35,16 +23,12 @@ vi.mock("../../lib/api", async (importOriginal) => {
     saveConfig: vi.fn(),
     testAemetApiKey: vi.fn(),
     updateAemetApiKey: vi.fn(),
-    updateOpenSkyClientId: vi.fn(),
-    updateOpenSkyClientSecret: vi.fn(),
   } satisfies Partial<typeof actual>;
 });
 
 const mockGetConfig = vi.mocked(getConfig);
 const mockGetHealth = vi.mocked(getHealth);
 const mockGetSchema = vi.mocked(getSchema);
-const mockGetOpenSkyClientIdMeta = vi.mocked(getOpenSkyClientIdMeta);
-const mockGetOpenSkyClientSecretMeta = vi.mocked(getOpenSkyClientSecretMeta);
 const mockGetOpenSkyStatus = vi.mocked(getOpenSkyStatus);
 const mockWifiScan = vi.mocked(wifiScan);
 const mockWifiNetworks = vi.mocked(wifiNetworks);
@@ -65,8 +49,6 @@ describe("ConfigPage WiFi panel", () => {
     mockGetConfig.mockResolvedValue(defaultConfig);
     mockGetHealth.mockResolvedValue({});
     mockGetSchema.mockResolvedValue({});
-    mockGetOpenSkyClientIdMeta.mockResolvedValue({ set: false });
-    mockGetOpenSkyClientSecretMeta.mockResolvedValue({ set: false });
     mockGetOpenSkyStatus.mockResolvedValue(null);
     mockWifiStatus.mockResolvedValue({
       interface: "wlp2s0",

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -165,9 +165,13 @@ export type CineFocusConfig = {
   hard_hide_outside: boolean;
 };
 
-export type OpenSkyAuthConfig = {
-  username?: string | null;
-  password?: string | null;
+export type OpenSkyOAuthConfig = {
+  token_url: string;
+  client_id: string | null;
+  client_secret: string | null;
+  scope: string | null;
+  has_credentials: boolean;
+  client_id_last4: string | null;
 };
 
 export type OpenSkyBBoxConfig = {
@@ -185,6 +189,7 @@ export type OpenSkyConfig = {
   extended: 0 | 1;
   max_aircraft: number;
   cluster: boolean;
+  oauth2: OpenSkyOAuthConfig;
 };
 
 export type AviationStackConfig = {
@@ -232,7 +237,6 @@ export type FlightsLayerConfig = {
   grid_px: number;
   styleScale: number;
   cine_focus: CineFocusConfig;
-  opensky?: OpenSkyAuthConfig;
   aviationstack?: AviationStackConfig;
   custom?: CustomFlightConfig;
 };


### PR DESCRIPTION
## Summary
- add OpenSky OAuth2 configuration defaults and persist credentials via the secret store while masking responses
- implement client-credential token acquisition with caching and extend provider health/status reporting
- refresh the configuration UI to manage OAuth2 settings inline and surface new provider diagnostics

## Testing
- pytest backend/tests

## Notes
- Para obtener client_id y client_secret visita https://openskynetwork.github.io/ y registra una aplicación OAuth2 (Client Credentials). Copia ambos valores en Configuración → OpenSky y guarda los cambios.


------
https://chatgpt.com/codex/tasks/task_e_690614ba62fc83268ce0e574aff3385b