### PR TITLE
Add OpenSky credential support to flights layer configuration

### DIFF
--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -29,6 +29,7 @@ import type {
   NewsConfig,
   OpenSkyOAuthConfig,
   OpenSkyConfig,
+  OpenSkyAuthConfig,
   RotationConfig,
   SaintsConfig,
   ShipsLayerConfig,
@@ -481,6 +482,10 @@ export const DEFAULT_CONFIG: AppConfig = {
         outside_dim_opacity: 0.25,
         hard_hide_outside: false,
       },
+      opensky: {
+        username: null,
+        password: null,
+      },
       aviationstack: {
         base_url: "http://api.aviationstack.com/v1",
         api_key: null,
@@ -725,6 +730,12 @@ const mergeFlightsLayer = (candidate: unknown): FlightsLayerConfig => {
   const cineFocusSource: Partial<FlightsLayerConfig["cine_focus"]> = source.cine_focus ?? {};
   const cineFocusFallback = fallback.cine_focus;
 
+  const openskySource: Partial<OpenSkyAuthConfig> = source.opensky ?? {};
+  const openskyFallback: Required<OpenSkyAuthConfig> = {
+    username: fallback.opensky?.username ?? null,
+    password: fallback.opensky?.password ?? null,
+  };
+
   const aviationstackSource: Partial<AviationStackConfig> = source.aviationstack ?? {};
   const aviationstackFallback: Required<AviationStackConfig> = {
     base_url: fallback.aviationstack?.base_url ?? "http://api.aviationstack.com/v1",
@@ -798,8 +809,8 @@ const mergeFlightsLayer = (candidate: unknown): FlightsLayerConfig => {
       hard_hide_outside: toBoolean(cineFocusSource.hard_hide_outside, cineFocusFallback.hard_hide_outside),
     },
     opensky: {
-      username: sanitizeNullableString(openskySource.username, openskyFallback.username ?? null),
-      password: sanitizeNullableString(openskySource.password, openskyFallback.password ?? null),
+      username: sanitizeNullableString(openskySource.username, openskyFallback.username),
+      password: sanitizeNullableString(openskySource.password, openskyFallback.password),
     },
     aviationstack: {
       base_url: sanitizeNullableString(aviationstackSource.base_url, aviationstackFallback.base_url ?? null),

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -192,6 +192,11 @@ export type OpenSkyConfig = {
   oauth2: OpenSkyOAuthConfig;
 };
 
+export type OpenSkyAuthConfig = {
+  username?: string | null;
+  password?: string | null;
+};
+
 export type AviationStackConfig = {
   base_url?: string | null;
   api_key?: string | null;
@@ -237,6 +242,7 @@ export type FlightsLayerConfig = {
   grid_px: number;
   styleScale: number;
   cine_focus: CineFocusConfig;
+  opensky?: OpenSkyAuthConfig;
   aviationstack?: AviationStackConfig;
   custom?: CustomFlightConfig;
 };


### PR DESCRIPTION
## Summary
- add an OpenSky authentication sub-config to the flights layer types
- expose default OpenSky credential placeholders and sanitize them when merging config

## Testing
- npm run build *(fails: missing dev dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690619f191388326a7c49ff3640c1a04