### PR TITLE
feat: hide aircraft layer toggle in kiosk mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,12 @@ Pantalla_reloj/
   muestra enmascarado (•••• 1234), el botón «Mostrar» habilita la edición en
   claro y el botón «Probar clave» ejecuta `/api/aemet/test_key` para validar la
   credencial sin exponerla al resto del formulario.
-- El panel derecho incorpora el bloque **Capas**, que permite activar o desactivar la
-  capa de aviones desde la UI sin abandonar `/`.
+- Cuando `ui.isInteractive` es `true`, el panel derecho incorpora el bloque **Capas**
+  para activar o desactivar la capa de aviones sin abandonar `/`. En modo kiosk
+  (`ui.isInteractive=false`) se oculta para liberar espacio en la tarjeta rotatoria.
+- El flag `ui.isInteractive` (expuesto por `/api/config`) gobierna la visibilidad
+  de cualquier control interactivo en producción: mantenlo en `false` en kiosk y
+  actívalo (`true`) solo en entornos de configuración o desarrollo.
 - Compilado con `npm run build` y servido por Nginx desde `/var/www/html`.
 
 #### Autopan y diagnósticos

--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -9,6 +9,7 @@
   },
   "ui": {
     "layout": "grid-2-1",
+    "isInteractive": false,
     "map": {
       "engine": "maplibre",
       "style": "vector-dark",

--- a/backend/models.py
+++ b/backend/models.py
@@ -157,6 +157,7 @@ class UI(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     layout: Literal["grid-2-1"] = "grid-2-1"
+    is_interactive: bool = Field(default=False, alias="isInteractive")
     map: MapConfig = Field(default_factory=MapConfig)
     rotation: Rotation = Field(default_factory=Rotation)
     cine_mode: bool = Field(default=True, alias="cineMode")

--- a/dash-ui/src/components/LayerControls.tsx
+++ b/dash-ui/src/components/LayerControls.tsx
@@ -22,6 +22,7 @@ export const LayerControls: React.FC<LayerControlsProps> = ({ configState }) => 
   const [localError, setLocalError] = useState<string | null>(null);
 
   const flightsEnabled = data?.layers.flights.enabled ?? false;
+  const isInteractive = data?.ui?.isInteractive ?? false;
 
   const disabled = loading || pending || !data;
 
@@ -57,6 +58,10 @@ export const LayerControls: React.FC<LayerControlsProps> = ({ configState }) => 
   }, [data, flightsEnabled, pending, reload]);
 
   if (!data) {
+    return null;
+  }
+
+  if (!isInteractive) {
     return null;
   }
 

--- a/dash-ui/src/config/defaults.ts
+++ b/dash-ui/src/config/defaults.ts
@@ -446,6 +446,7 @@ export const DEFAULT_CONFIG: AppConfig = {
   map: createDefaultMapPreferences(),
   ui: {
     layout: "grid-2-1",
+    isInteractive: false,
     map: createDefaultMapSettings(),
     rotation: mergeRotation(undefined),
     cineMode: true,
@@ -1060,6 +1061,7 @@ export const withConfigDefaults = (payload?: Partial<AppConfig>): AppConfig => {
     map: mergeMapPreferences(map),
     ui: {
       layout: "grid-2-1",
+      isInteractive: toBoolean(ui.isInteractive, DEFAULT_CONFIG.ui.isInteractive),
       map: mergeMap(ui.map),
       rotation: mergeRotation(ui.rotation),
       cineMode: toBoolean(ui.cineMode, DEFAULT_CONFIG.ui.cineMode ?? true),

--- a/dash-ui/src/types/config.ts
+++ b/dash-ui/src/types/config.ts
@@ -80,6 +80,7 @@ export type RotationConfig = {
 
 export type UIConfig = {
   layout: "grid-2-1";
+  isInteractive: boolean;
   map: MapConfig;
   rotation: RotationConfig;
   cineMode?: boolean;

--- a/docs/kiosk.md
+++ b/docs/kiosk.md
@@ -10,6 +10,10 @@ Con esta configuración, al iniciar `pantalla-xorg.service` se obtiene un arranq
 
 Chromium se ejecuta desde el usuario normal y necesita la cookie real de Xauthority. Asegúrate de que `~/.Xauthority` exista y sea un archivo regular (`-rw-------`) perteneciente a `dani:dani`. El servicio de Xorg ya se inicia con `-auth /home/dani/.Xauthority`, por lo que no es necesario crear enlaces simbólicos en `/var/lib`.
 
+## Controles interactivos
+
+Los elementos táctiles/interactivos del dashboard se gobiernan con `ui.isInteractive` en `config.json`. El backend lo expone vía `/api/config` y su valor por defecto es `false`. Mantén ese valor en kiosk para ocultar el interruptor de capa de aviones (y futuros controles) y permitir que la tarjeta rotatoria ocupe todo el panel. Solo en entornos de configuración o desarrollo debe activarse (`true`) para mostrar los controles.
+
 ## Arranque determinista (X11 + navegador kiosk)
 
 ### Requisitos


### PR DESCRIPTION
## Summary
- add the ui.isInteractive flag to the default backend config and expose it through the AppConfig model
- propagate the new flag across the frontend defaults/types and gate the aircraft layer toggle behind it
- update kiosk documentation to explain how ui.isInteractive governs interactive controls

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_6906531f0aa08326b22d64acd31c0b7b