### PR TITLE
Fix TypeScript map imports and provider labels

### DIFF
--- a/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
@@ -1,5 +1,5 @@
 import maplibregl from "maplibre-gl";
-import type { MapLayerMouseEvent } from "maplibregl";
+import type { MapLayerMouseEvent } from "maplibre-gl";
 import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";

--- a/dash-ui/src/pages/ConfigPage.tsx
+++ b/dash-ui/src/pages/ConfigPage.tsx
@@ -58,6 +58,7 @@ const MAP_BACKEND_PROVIDERS: AppConfig["map"]["provider"][] = ["maptiler", "osm"
 const MAP_PROVIDER_LABELS: Record<AppConfig["map"]["provider"], string> = {
   maptiler: "MapTiler",
   osm: "OpenStreetMap",
+  openstreetmap: "OpenStreetMap",
 };
 const MAPTILER_KEY_PATTERN = /^[A-Za-z0-9._-]+$/;
 const MAPTILER_DOCS_TEXT = "Obtén la clave en docs.maptiler.com/cloud/api-keys";


### PR DESCRIPTION
## Summary
- fix the AircraftLayer MapLibre type import so TypeScript can resolve the module
- add the missing `openstreetmap` entry to the map provider label record to cover all provider variants

## Testing
- `npm install` *(fails: 403 Forbidden when contacting registry)*
- `npm run build` *(fails: missing dev dependencies because installation was blocked)*

------
https://chatgpt.com/codex/tasks/task_e_69066170e8508326b6f741b8885c5ecf