### PR TITLE
Fix backend import failure in config migrator

### DIFF
--- a/backend/config_migrator.py
+++ b/backend/config_migrator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, Tuple, Optional
 
 from .models import AppConfig as AppConfigV1
-from .models_v2 import AppConfigV2, MapCenter, XyzConfig, MapFixedView, MapRegion
+from .models_v2 import AppConfigV2, MapCenter, MapFixedView, MapRegion
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- stop importing the nonexistent `XyzConfig` symbol from `models_v2`
- ensure the backend package can be imported without raising `ImportError`

## Testing
- pytest backend/tests *(fails: existing cinema defaults and opensky oauth expectations)*

------
https://chatgpt.com/codex/tasks/task_e_690783ea4aa483268c2fa0026906508c