### PR TITLE
Fix-kiosk-black-screen-597f1

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -143,6 +143,12 @@ if (( DIAG_MODE == 1 )); then
   ACTIVE_KIOSK_URL="$DIAG_KIOSK_URL"
   SUMMARY+=("[install] modo diagnóstico habilitado (${ACTIVE_KIOSK_URL})")
 fi
+
+# Inicializar variables de navegador (se definirán más adelante)
+CHROME_FOUND=0
+CHROME_BIN=""
+CHROMIUM_FOUND=0
+CHROMIUM_BIN=""
 if [[ ! -f "$KIOSK_ENV_FILE" ]]; then
   cat >"$KIOSK_ENV_FILE" <<EOF
 # Pantalla_reloj kiosk configuration
@@ -850,11 +856,6 @@ fix_chromium_profile_permissions() {
     log_ok "Permisos del cache arreglados"
   fi
 }
-
-CHROME_FOUND=0
-CHROME_BIN=""
-CHROMIUM_FOUND=0
-CHROMIUM_BIN=""
 
 # Prioridad 1: Intentar instalar Google Chrome .deb (preferido)
 log_info "Verificando/instalando Google Chrome .deb (preferido sobre Chromium)..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -590,7 +590,7 @@ install -D -m 0644 "$REPO_ROOT/systemd/pantalla-kiosk-watchdog@.service.d/10-rol
   /etc/systemd/system/pantalla-kiosk-watchdog@.service.d/10-rollback.conf
 
 # Instalar unit user para Chrome kiosk (si Chrome está disponible)
-if [[ $CHROME_FOUND -eq 1 ]]; then
+if [[ ${CHROME_FOUND:-0} -eq 1 ]]; then
   log_info "Instalando unit user para Chrome kiosk..."
   USER_SYSTEMD_DIR="${USER_HOME}/.config/systemd/user"
   install -d -m 0755 -o "$USER_NAME" -g "$USER_NAME" "$USER_SYSTEMD_DIR"
@@ -610,7 +610,7 @@ fi
 # Recargar systemd DESPUÉS de instalar todos los servicios
 log_info "Recargando systemd después de instalar servicios"
 systemctl daemon-reload
-if [[ $CHROME_FOUND -eq 1 ]]; then
+if [[ ${CHROME_FOUND:-0} -eq 1 ]]; then
   # Recargar systemd user también
   sudo -u "$USER_NAME" systemctl --user daemon-reload 2>/dev/null || true
 fi
@@ -869,7 +869,7 @@ if install_google_chrome; then
 fi
 
 # Prioridad 2: Verificar si ya hay un Chromium real instalado (fallback)
-if [[ $CHROME_FOUND -eq 0 ]]; then
+if [[ ${CHROME_FOUND:-0} -eq 0 ]]; then
   log_info "Google Chrome no disponible, verificando Chromium..."
   if command -v chromium-browser >/dev/null 2>&1; then
     if ! is_snap_binary "$(command -v chromium-browser)"; then
@@ -1080,7 +1080,7 @@ fi
 systemctl disable --now "pantalla-kiosk@${USER_NAME}.service" 2>/dev/null || true
 
 # Habilitar y arrancar unit user de Chrome kiosk (preferido)
-if [[ $CHROME_FOUND -eq 1 ]]; then
+if [[ ${CHROME_FOUND:-0} -eq 1 ]]; then
   log_info "Habilitando unit user Chrome kiosk..."
   CHROME_USER_UNIT="pantalla-kiosk-chrome@${USER_NAME}.service"
   


### PR DESCRIPTION
- Modified checks for the CHROME_FOUND variable to ensure it defaults to 0 if not set, improving robustness in the installation process.
- Enhanced logging and systemd user unit management for Chrome kiosk installation.