### PR TITLE
Configure pantalla backend service for uvicorn

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9980,3 +9980,35 @@ def on_startup() -> None:
     root = Path(os.getenv("PANTALLA_STATE_DIR", "/var/lib/pantalla-reloj"))
     for child in (root / "cache").glob("*.json"):
         child.touch(exist_ok=True)
+
+
+def run(host: str = "127.0.0.1", port: int = 8081) -> None:
+    """Ejecuta la aplicación FastAPI usando uvicorn.
+
+    Args:
+        host: Dirección IP en la que se expone el servicio.
+        port: Puerto TCP del servicio.
+    """
+
+    import uvicorn
+
+    uvicorn.run(
+        "backend.main:app",
+        host=host,
+        port=port,
+        proxy_headers=True,
+    )
+
+
+if __name__ == "__main__":
+    host = os.getenv("PANTALLA_BACKEND_HOST", "127.0.0.1")
+    port_raw = os.getenv("PANTALLA_BACKEND_PORT", "8081")
+
+    try:
+        port_value = int(port_raw)
+    except ValueError as exc:  # pragma: no cover - configuración inválida
+        raise RuntimeError(
+            f"Invalid port value in PANTALLA_BACKEND_PORT: {port_raw!r}"
+        ) from exc
+
+    run(host=host, port=port_value)

--- a/etc/systemd/system/pantalla-backend.service
+++ b/etc/systemd/system/pantalla-backend.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Pantalla_reloj Backend (FastAPI)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=dani
+WorkingDirectory=/home/dani/proyectos/Pantalla_reloj/backend
+Environment="PYTHONUNBUFFERED=1"
+Environment="PYTHONPATH=/home/dani/proyectos/Pantalla_reloj"
+ExecStart=/home/dani/proyectos/Pantalla_reloj/backend/.venv/bin/uvicorn backend.main:app --host 127.0.0.1 --port 8081 --proxy-headers
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Requisitos principales del proyecto Pantalla_reloj.
+# Incluye las dependencias del backend de FastAPI.
+-r backend/requirements.txt


### PR DESCRIPTION
## Summary
- add a project-level requirements.txt that points to the backend dependencies to simplify virtualenv installation
- add a run() helper and __main__ guard in backend/main.py so the app can be executed via uvicorn with configured host and port
- provide a systemd unit for pantalla-backend that runs uvicorn from the backend virtualenv and exports the project root on PYTHONPATH

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef0c6c98483269e3c32d38f887049)