### PR TITLE
Fix uvicorn entrypoint to run with module object

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9993,7 +9993,7 @@ def run(host: str = "127.0.0.1", port: int = 8081) -> None:
     import uvicorn
 
     uvicorn.run(
-        "backend.main:app",
+        app,
         host=host,
         port=port,
         proxy_headers=True,


### PR DESCRIPTION
## Summary
- update backend/main.py to pass the FastAPI app object to uvicorn.run so the module can be executed directly without PYTHONPATH tweaks

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f055708748326af852c53bac432b2)