### PR TITLE
Add GIBS global satellite frames endpoint

### DIFF
--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,0 +1,11 @@
+"""Shared constants for backend services."""
+
+GIBS_DEFAULT_LAYER = "MODIS_Terra_CorrectedReflectance_TrueColor"
+GIBS_DEFAULT_TILE_MATRIX_SET = "GoogleMapsCompatible_Level6"
+GIBS_DEFAULT_MIN_ZOOM = 1
+GIBS_DEFAULT_MAX_ZOOM = 6
+GIBS_DEFAULT_DEFAULT_ZOOM = 2
+
+# Default temporal configuration for GIBS frames
+GIBS_DEFAULT_HISTORY_MINUTES = 90
+GIBS_DEFAULT_FRAME_STEP = 10

--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -222,7 +222,12 @@
         "refresh_minutes": 10,
         "history_minutes": 90,
         "frame_step": 10,
-        "opacity": 0.7
+        "opacity": 0.7,
+        "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
+        "tile_matrix_set": "GoogleMapsCompatible_Level6",
+        "min_zoom": 1,
+        "max_zoom": 6,
+        "default_zoom": 2
       },
       "radar": {
         "enabled": true,
@@ -232,6 +237,20 @@
         "frame_step": 5,
         "opacity": 0.7
       }
+    }
+  },
+  "ui_global": {
+    "satellite": {
+      "enabled": true,
+      "provider": "gibs",
+      "opacity": 1.0,
+      "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
+      "tile_matrix_set": "GoogleMapsCompatible_Level6",
+      "min_zoom": 1,
+      "max_zoom": 6,
+      "default_zoom": 2,
+      "history_minutes": 90,
+      "frame_step": 10
     }
   }
 }

--- a/backend/default_config_v2.json
+++ b/backend/default_config_v2.json
@@ -52,7 +52,18 @@
     "region": { "postalCode": "12540" }
   },
   "ui_global": {
-    "satellite": { "enabled": true, "provider": "gibs", "opacity": 1.0 },
+    "satellite": {
+      "enabled": true,
+      "provider": "gibs",
+      "opacity": 1.0,
+      "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
+      "tile_matrix_set": "GoogleMapsCompatible_Level6",
+      "min_zoom": 1,
+      "max_zoom": 6,
+      "default_zoom": 2,
+      "history_minutes": 90,
+      "frame_step": 10
+    },
     "radar": { "enabled": true, "provider": "rainviewer", "opacity": 0.7, "layer_type": "precipitation_new" },
     "weather_layers": {
       "radar": { "enabled": true, "provider": "rainviewer", "opacity": 0.7 },
@@ -85,7 +96,12 @@
         "provider": "gibs",
         "refresh_minutes": 10,
         "history_minutes": 90,
-        "frame_step": 10
+        "frame_step": 10,
+        "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
+        "tile_matrix_set": "GoogleMapsCompatible_Level6",
+        "min_zoom": 1,
+        "max_zoom": 6,
+        "default_zoom": 2
       },
       "radar": {
         "enabled": true,

--- a/backend/models.py
+++ b/backend/models.py
@@ -6,6 +6,16 @@ from typing import Dict, List, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from .constants import (
+    GIBS_DEFAULT_DEFAULT_ZOOM,
+    GIBS_DEFAULT_FRAME_STEP,
+    GIBS_DEFAULT_HISTORY_MINUTES,
+    GIBS_DEFAULT_LAYER,
+    GIBS_DEFAULT_MAX_ZOOM,
+    GIBS_DEFAULT_MIN_ZOOM,
+    GIBS_DEFAULT_TILE_MATRIX_SET,
+)
+
 
 class Display(BaseModel):
     model_config = ConfigDict(extra="ignore")
@@ -359,9 +369,28 @@ class GlobalSatelliteLayer(BaseModel):
     enabled: bool = True
     provider: Literal["gibs"] = Field(default="gibs")
     refresh_minutes: int = Field(default=10, ge=1, le=1440)
-    history_minutes: int = Field(default=90, ge=1, le=1440)
-    frame_step: int = Field(default=10, ge=1, le=1440)
+    history_minutes: int = Field(default=GIBS_DEFAULT_HISTORY_MINUTES, ge=1, le=1440)
+    frame_step: int = Field(default=GIBS_DEFAULT_FRAME_STEP, ge=1, le=1440)
     opacity: float = Field(default=0.7, ge=0.0, le=1.0)
+    layer: str = Field(default=GIBS_DEFAULT_LAYER, min_length=1, max_length=128)
+    tile_matrix_set: str = Field(
+        default=GIBS_DEFAULT_TILE_MATRIX_SET,
+        min_length=1,
+        max_length=128,
+    )
+    min_zoom: int = Field(default=GIBS_DEFAULT_MIN_ZOOM, ge=0, le=24)
+    max_zoom: int = Field(default=GIBS_DEFAULT_MAX_ZOOM, ge=0, le=24)
+    default_zoom: int = Field(default=GIBS_DEFAULT_DEFAULT_ZOOM, ge=0, le=24)
+
+    @model_validator(mode="after")
+    def ensure_zoom_bounds(cls, values: "GlobalSatelliteLayer") -> "GlobalSatelliteLayer":  # type: ignore[override]
+        if values.max_zoom < values.min_zoom:
+            values.max_zoom = values.min_zoom
+        if values.default_zoom < values.min_zoom:
+            values.default_zoom = values.min_zoom
+        elif values.default_zoom > values.max_zoom:
+            values.default_zoom = values.max_zoom
+        return values
 
 
 class GlobalRadarLayer(BaseModel):

--- a/backend/models_global_satellite.py
+++ b/backend/models_global_satellite.py
@@ -1,0 +1,31 @@
+"""Pydantic models for global satellite endpoints."""
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class GlobalSatelliteFrame(BaseModel):
+    """Metadata for a single GIBS frame."""
+
+    timestamp: int = Field(..., ge=0, description="Unix timestamp for the frame")
+    t_iso: str = Field(..., min_length=1, description="UTC timestamp in ISO8601 format")
+    layer: str = Field(..., min_length=1, max_length=128)
+    time_key: str = Field(..., min_length=1, max_length=32)
+    tile_matrix_set: str = Field(..., min_length=1, max_length=128)
+    z: int = Field(..., ge=0, le=24, description="Recommended zoom level for the animation")
+    min_zoom: int = Field(..., ge=0, le=24)
+    max_zoom: int = Field(..., ge=0, le=24)
+    tile_url: str = Field(..., min_length=1, description="Tile URL template containing {z}/{y}/{x} placeholders")
+
+
+class GlobalSatelliteFramesResponse(BaseModel):
+    """Response payload for /api/global/satellite/frames."""
+
+    provider: str = Field(default="gibs")
+    enabled: bool = Field(...)
+    history_minutes: Optional[int] = Field(default=None, ge=1, le=720)
+    frame_step: Optional[int] = Field(default=None, ge=1, le=240)
+    now_iso: str = Field(..., min_length=1)
+    frames: List[GlobalSatelliteFrame] = Field(default_factory=list)
+    error: Optional[str] = Field(default=None, description="Optional error information when frames are unavailable")

--- a/backend/tests/test_global_satellite_frames.py
+++ b/backend/tests/test_global_satellite_frames.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Tuple
+from unittest.mock import patch
+
+
+
+class _FixedDateTime(datetime):
+    """Helper datetime that always returns the same moment."""
+
+    _fixed = datetime(2025, 11, 14, 15, 30, tzinfo=timezone.utc)
+
+    @classmethod
+    def now(cls, tz: timezone | None = None):  # type: ignore[override]
+        if tz is None:
+            return cls._fixed.replace(tzinfo=None)
+        return cls._fixed.astimezone(tz)
+
+    @classmethod
+    def utcnow(cls):  # type: ignore[override]
+        return cls._fixed.replace(tzinfo=None)
+
+
+def test_global_satellite_frames_disabled_when_config_disabled(
+    app_module: Tuple[object, Path]
+) -> None:
+    module, _ = app_module
+
+    config_path = Path(module.config_manager.config_file)
+    original = config_path.read_text(encoding="utf-8")
+    try:
+        config_data = json.loads(original)
+        layers = config_data.setdefault("layers", {})
+        key = "global" if "global" in layers else "global_"
+        layers.setdefault(key, {}).setdefault("satellite", {})
+        layers[key]["satellite"]["enabled"] = False
+        if key == "global_":
+            layers.setdefault("global", json.loads(json.dumps(layers[key])))
+            layers["global"].setdefault("satellite", {})
+            layers["global"]["satellite"]["enabled"] = False
+        config_path.write_text(json.dumps(config_data), encoding="utf-8")
+
+        response = module.get_global_satellite_frames()
+
+        assert response.enabled is False
+        assert response.frames == []
+        assert response.provider == "gibs"
+    finally:
+        config_path.write_text(original, encoding="utf-8")
+
+
+def test_global_satellite_frames_default_config_returns_frames(
+    app_module: Tuple[object, Path]
+) -> None:
+    module, _ = app_module
+
+    with patch("backend.main.datetime", _FixedDateTime):
+        response = module.get_global_satellite_frames()
+
+    assert response.enabled is True
+    assert response.provider == "gibs"
+    assert response.now_iso == "2025-11-14T15:30:00Z"
+
+    assert response.history_minutes == 90
+    assert response.frame_step == 10
+
+    timestamps = [frame.timestamp for frame in response.frames]
+    assert timestamps == sorted(timestamps)
+
+    expected_frames = (response.history_minutes // response.frame_step) + 1
+    assert len(response.frames) == expected_frames
+
+    first_frame = response.frames[0]
+    last_frame = response.frames[-1]
+
+    assert first_frame.t_iso == "2025-11-14T14:00:00Z"
+    assert last_frame.t_iso == "2025-11-14T15:30:00Z"
+
+    assert module.GIBS_DEFAULT_LAYER in first_frame.tile_url
+    assert "{z}/{y}/{x}.jpg" in first_frame.tile_url
+
+
+def test_openapi_includes_global_satellite_frames(app_module: Tuple[object, Path]) -> None:
+    module, _ = app_module
+    schema = module.app.openapi()
+
+    assert "/api/global/satellite/frames" in schema.get("paths", {})


### PR DESCRIPTION
## Summary
- add a dedicated response model and constants for NASA GIBS metadata
- extend satellite configuration defaults and expose the `GET /api/global/satellite/frames` handler that builds frame URLs
- update the tile proxy and include regression tests for the global satellite frames API

## Testing
- pytest backend/tests/test_global_satellite_frames.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69174a6eda28832693f85b5539b3c2f1)