### PR TITLE
Fix NASA GIBS frame URLs to include timestamps

### DIFF
--- a/backend/global_providers.py
+++ b/backend/global_providers.py
@@ -83,7 +83,7 @@ class GIBSProvider:
         while current <= end_time:
             timestamp = int(current.timestamp())
             iso = current.replace(microsecond=0).isoformat().replace("+00:00", "Z")
-            time_key = current.strftime("%Y-%m-%d")
+            time_key = iso
             frames.append(
                 {
                     "timestamp": timestamp,
@@ -127,7 +127,7 @@ class GIBSProvider:
             URL del tile
         """
         dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-        date_str = dt.strftime("%Y-%m-%d")
+        date_str = dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
         return (
             f"{self.base_url}/wmts/epsg3857/best/{layer}/default/"
             f"{date_str}/{tile_matrix_set}/{z}/{y}/{x}.jpg"


### PR DESCRIPTION
## Summary
- format GIBS frame metadata so the time_key matches the full ISO timestamp for each frame
- emit WMTS tile URLs that include the full ISO instant instead of truncating to the calendar date

## Testing
- pytest backend/tests/test_global_satellite_frames.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691750d21d18832683c257ee4577ded3)