### PR TITLE
Update NASA GIBS tile configuration for satellite frames

### DIFF
--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,7 +1,11 @@
 """Shared constants for backend services."""
 
 GIBS_DEFAULT_LAYER = "MODIS_Terra_CorrectedReflectance_TrueColor"
-GIBS_DEFAULT_TILE_MATRIX_SET = "GoogleMapsCompatible_Level6"
+GIBS_DEFAULT_TILE_MATRIX_SET = "GoogleMapsCompatible_Level9"
+GIBS_DEFAULT_EPSG = "epsg3857"
+GIBS_DEFAULT_FORMAT_EXT = "jpg"
+GIBS_DEFAULT_TIME_MODE = "default"
+GIBS_DEFAULT_TIME_VALUE = "default"
 GIBS_DEFAULT_MIN_ZOOM = 1
 GIBS_DEFAULT_MAX_ZOOM = 6
 GIBS_DEFAULT_DEFAULT_ZOOM = 2

--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -224,10 +224,18 @@
         "frame_step": 10,
         "opacity": 0.7,
         "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
-        "tile_matrix_set": "GoogleMapsCompatible_Level6",
+        "tile_matrix_set": "GoogleMapsCompatible_Level9",
         "min_zoom": 1,
         "max_zoom": 6,
-        "default_zoom": 2
+        "default_zoom": 2,
+        "gibs": {
+          "epsg": "epsg3857",
+          "tile_matrix_set": "GoogleMapsCompatible_Level9",
+          "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
+          "format_ext": "jpg",
+          "time_mode": "default",
+          "time_value": "default"
+        }
       },
       "radar": {
         "enabled": true,
@@ -245,12 +253,20 @@
       "provider": "gibs",
       "opacity": 1.0,
       "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
-      "tile_matrix_set": "GoogleMapsCompatible_Level6",
+      "tile_matrix_set": "GoogleMapsCompatible_Level9",
       "min_zoom": 1,
       "max_zoom": 6,
       "default_zoom": 2,
       "history_minutes": 90,
-      "frame_step": 10
+      "frame_step": 10,
+      "gibs": {
+        "epsg": "epsg3857",
+        "tile_matrix_set": "GoogleMapsCompatible_Level9",
+        "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
+        "format_ext": "jpg",
+        "time_mode": "default",
+        "time_value": "default"
+      }
     }
   }
 }

--- a/backend/default_config_v2.json
+++ b/backend/default_config_v2.json
@@ -57,12 +57,20 @@
       "provider": "gibs",
       "opacity": 1.0,
       "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
-      "tile_matrix_set": "GoogleMapsCompatible_Level6",
+      "tile_matrix_set": "GoogleMapsCompatible_Level9",
       "min_zoom": 1,
       "max_zoom": 6,
       "default_zoom": 2,
       "history_minutes": 90,
-      "frame_step": 10
+      "frame_step": 10,
+      "gibs": {
+        "epsg": "epsg3857",
+        "tile_matrix_set": "GoogleMapsCompatible_Level9",
+        "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
+        "format_ext": "jpg",
+        "time_mode": "default",
+        "time_value": "default"
+      }
     },
     "radar": { "enabled": true, "provider": "rainviewer", "opacity": 0.7, "layer_type": "precipitation_new" },
     "weather_layers": {
@@ -98,10 +106,18 @@
         "history_minutes": 90,
         "frame_step": 10,
         "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
-        "tile_matrix_set": "GoogleMapsCompatible_Level6",
+        "tile_matrix_set": "GoogleMapsCompatible_Level9",
         "min_zoom": 1,
         "max_zoom": 6,
-        "default_zoom": 2
+        "default_zoom": 2,
+        "gibs": {
+          "epsg": "epsg3857",
+          "tile_matrix_set": "GoogleMapsCompatible_Level9",
+          "layer": "MODIS_Terra_CorrectedReflectance_TrueColor",
+          "format_ext": "jpg",
+          "time_mode": "default",
+          "time_value": "default"
+        }
       },
       "radar": {
         "enabled": true,

--- a/backend/models.py
+++ b/backend/models.py
@@ -8,12 +8,16 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from .constants import (
     GIBS_DEFAULT_DEFAULT_ZOOM,
+    GIBS_DEFAULT_EPSG,
+    GIBS_DEFAULT_FORMAT_EXT,
     GIBS_DEFAULT_FRAME_STEP,
     GIBS_DEFAULT_HISTORY_MINUTES,
     GIBS_DEFAULT_LAYER,
     GIBS_DEFAULT_MAX_ZOOM,
     GIBS_DEFAULT_MIN_ZOOM,
     GIBS_DEFAULT_TILE_MATRIX_SET,
+    GIBS_DEFAULT_TIME_MODE,
+    GIBS_DEFAULT_TIME_VALUE,
 )
 
 
@@ -362,6 +366,22 @@ class ShipsLayer(BaseModel):
         return self
 
 
+class GlobalSatelliteGibsConfig(BaseModel):
+    """Configuración específica de WMTS para NASA GIBS."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    epsg: str = Field(default=GIBS_DEFAULT_EPSG, min_length=1, max_length=32)
+    tile_matrix_set: str = Field(
+        default=GIBS_DEFAULT_TILE_MATRIX_SET,
+        min_length=1,
+        max_length=128,
+    )
+    layer: str = Field(default=GIBS_DEFAULT_LAYER, min_length=1, max_length=128)
+    format_ext: str = Field(default=GIBS_DEFAULT_FORMAT_EXT, min_length=1, max_length=16)
+    time_mode: Literal["default", "date"] = Field(default=GIBS_DEFAULT_TIME_MODE)
+    time_value: str = Field(default=GIBS_DEFAULT_TIME_VALUE, min_length=1, max_length=64)
+
 class GlobalSatelliteLayer(BaseModel):
     """Configuración de capa global de satélite."""
     model_config = ConfigDict(extra="ignore")
@@ -381,6 +401,7 @@ class GlobalSatelliteLayer(BaseModel):
     min_zoom: int = Field(default=GIBS_DEFAULT_MIN_ZOOM, ge=0, le=24)
     max_zoom: int = Field(default=GIBS_DEFAULT_MAX_ZOOM, ge=0, le=24)
     default_zoom: int = Field(default=GIBS_DEFAULT_DEFAULT_ZOOM, ge=0, le=24)
+    gibs: GlobalSatelliteGibsConfig = Field(default_factory=GlobalSatelliteGibsConfig)
 
     @model_validator(mode="after")
     def ensure_zoom_bounds(cls, values: "GlobalSatelliteLayer") -> "GlobalSatelliteLayer":  # type: ignore[override]

--- a/backend/models_v2.py
+++ b/backend/models_v2.py
@@ -10,12 +10,16 @@ from typing import Optional, Literal, List, Dict, Any, Union
 
 from .constants import (
     GIBS_DEFAULT_DEFAULT_ZOOM,
+    GIBS_DEFAULT_EPSG,
+    GIBS_DEFAULT_FORMAT_EXT,
     GIBS_DEFAULT_FRAME_STEP,
     GIBS_DEFAULT_HISTORY_MINUTES,
     GIBS_DEFAULT_LAYER,
     GIBS_DEFAULT_MAX_ZOOM,
     GIBS_DEFAULT_MIN_ZOOM,
     GIBS_DEFAULT_TILE_MATRIX_SET,
+    GIBS_DEFAULT_TIME_MODE,
+    GIBS_DEFAULT_TIME_VALUE,
 )
 
 
@@ -277,6 +281,21 @@ class WeatherLayersConfig(BaseModel):
     )
 
 
+class GlobalSatelliteGibsConfig(BaseModel):
+    """Configuración de parámetros WMTS específicos de NASA GIBS."""
+
+    epsg: str = Field(default=GIBS_DEFAULT_EPSG, min_length=1, max_length=32)
+    tile_matrix_set: str = Field(
+        default=GIBS_DEFAULT_TILE_MATRIX_SET,
+        min_length=1,
+        max_length=128,
+    )
+    layer: str = Field(default=GIBS_DEFAULT_LAYER, min_length=1, max_length=128)
+    format_ext: str = Field(default=GIBS_DEFAULT_FORMAT_EXT, min_length=1, max_length=16)
+    time_mode: Literal["default", "date"] = Field(default=GIBS_DEFAULT_TIME_MODE)
+    time_value: str = Field(default=GIBS_DEFAULT_TIME_VALUE, min_length=1, max_length=64)
+
+
 class SatelliteConfig(BaseModel):
     """Configuración de satélite global."""
     enabled: bool = True
@@ -293,6 +312,7 @@ class SatelliteConfig(BaseModel):
     default_zoom: int = Field(default=GIBS_DEFAULT_DEFAULT_ZOOM, ge=0, le=24)
     history_minutes: int = Field(default=GIBS_DEFAULT_HISTORY_MINUTES, ge=1, le=360)
     frame_step: int = Field(default=GIBS_DEFAULT_FRAME_STEP, ge=1, le=120)
+    gibs: GlobalSatelliteGibsConfig = Field(default_factory=GlobalSatelliteGibsConfig)
 
     @model_validator(mode="after")
     def ensure_zoom_bounds(cls, values: "SatelliteConfig") -> "SatelliteConfig":  # type: ignore[override]
@@ -505,6 +525,7 @@ class GlobalSatelliteLayerConfig(BaseModel):
     min_zoom: int = Field(default=GIBS_DEFAULT_MIN_ZOOM, ge=0, le=24)
     max_zoom: int = Field(default=GIBS_DEFAULT_MAX_ZOOM, ge=0, le=24)
     default_zoom: int = Field(default=GIBS_DEFAULT_DEFAULT_ZOOM, ge=0, le=24)
+    gibs: GlobalSatelliteGibsConfig = Field(default_factory=GlobalSatelliteGibsConfig)
 
     @model_validator(mode="after")
     def ensure_zoom_bounds(

--- a/backend/tests/test_global_satellite_frames.py
+++ b/backend/tests/test_global_satellite_frames.py
@@ -80,7 +80,11 @@ def test_global_satellite_frames_default_config_returns_frames(
     assert last_frame.t_iso == "2025-11-14T15:30:00Z"
 
     assert module.GIBS_DEFAULT_LAYER in first_frame.tile_url
+    assert first_frame.tile_matrix_set == module.GIBS_DEFAULT_TILE_MATRIX_SET
+    assert f"/{module.GIBS_DEFAULT_TILE_MATRIX_SET}/" in first_frame.tile_url
+    assert "/default/default/" in first_frame.tile_url
     assert "{z}/{y}/{x}.jpg" in first_frame.tile_url
+    assert first_frame.time_key == module.GIBS_DEFAULT_TIME_VALUE
 
 
 def test_openapi_includes_global_satellite_frames(app_module: Tuple[object, Path]) -> None:


### PR DESCRIPTION
## Summary
- align the default GIBS WMTS configuration with the MODIS TrueColor 250 m layer
- expose epsg, format and time controls through the satellite configuration and provider
- refresh defaults and tests to cover the new tile URL template

## Testing
- pytest backend/tests/test_global_satellite_frames.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691758020c6483268c174dd7a4d450fa)