### PR TITLE
Fix map style fallback for MapTiler

### DIFF
--- a/dash-ui/src/kiosk/mapStyle.ts
+++ b/dash-ui/src/kiosk/mapStyle.ts
@@ -1,5 +1,9 @@
 import maplibregl from "maplibre-gl";
-import { buildFinalMaptilerStyleUrl, buildMaptilerStyleUrl } from "../lib/map/maptilerRuntime";
+import {
+  buildFinalMaptilerStyleUrl,
+  buildMaptilerStyleUrl,
+  resolveMaptilerStyleSlug,
+} from "../lib/map/maptilerRuntime";
 
 let styleChangeInFlight = false;
 
@@ -199,21 +203,7 @@ export function computeStyleUrlFromConfig(mapConfig: any, health?: any): string 
 
   // Usar el estilo de la configuración, pero no forzar "vector-dark" como fallback
   // Si no hay estilo definido, devolver null para que se use el styleUrl si está disponible
-  const style = mapConfig.style;
-  if (!style) return null;
-  
-  // Mapear estilos a URLs de MapTiler
-  const styleMap: Record<string, string> = {
-    "vector-dark": "dataviz-dark",
-    "vector-light": "streets-v2",
-    "vector-bright": "bright-v2",
-    "streets-v4": "streets-v4",
-    "dark": "dataviz-dark",
-    "light": "streets-v2",
-    "bright": "bright-v2",
-  };
-
-  const styleSlug = styleMap[style];
+  const styleSlug = resolveMaptilerStyleSlug(mapConfig.style);
   if (!styleSlug) return null;
   
   const baseUrl = `https://api.maptiler.com/maps/${styleSlug}/style.json`;

--- a/dash-ui/src/lib/map/maptilerRuntime.test.ts
+++ b/dash-ui/src/lib/map/maptilerRuntime.test.ts
@@ -5,6 +5,7 @@ import {
   containsApiKey,
   extractMaptilerApiKey,
   buildFinalMaptilerStyleUrl,
+  resolveMaptilerStyleSlug,
 } from "./maptilerRuntime";
 
 describe("maptilerRuntime helpers", () => {
@@ -177,6 +178,21 @@ describe("maptilerRuntime helpers", () => {
       const result = buildFinalMaptilerStyleUrl(cfg, health, baseStyleUrl);
       expect(result).toBe("https://api.maptiler.com/maps/streets-v4/style.json?key=HEALTHKEY");
     });
+
+    it("construye URL canónica cuando solo hay style + api_key", () => {
+      const cfg = {
+        ui_map: {
+          maptiler: { style: "vector-dark", api_key: "STYLEKEY" },
+        },
+      };
+      const result = buildFinalMaptilerStyleUrl(cfg, null, null);
+      expect(result).toBe("https://api.maptiler.com/maps/dataviz-dark/style.json?key=STYLEKEY");
+    });
+
+    it("retorna null cuando no hay styleUrl ni style válido", () => {
+      const cfg = { ui_map: { maptiler: { style: "" } } };
+      expect(buildFinalMaptilerStyleUrl(cfg, null, null)).toBeNull();
+    });
   });
 
   describe("containsApiKey", () => {
@@ -195,6 +211,21 @@ describe("maptilerRuntime helpers", () => {
     it("returns false for null/undefined", () => {
       expect(containsApiKey(null)).toBe(false);
       expect(containsApiKey(undefined)).toBe(false);
+    });
+  });
+
+  describe("resolveMaptilerStyleSlug", () => {
+    it("normaliza estilos legacy", () => {
+      expect(resolveMaptilerStyleSlug("vector-bright")).toBe("bright-v2");
+    });
+
+    it("acepta slugs ya normalizados", () => {
+      expect(resolveMaptilerStyleSlug("streets-v4")).toBe("streets-v4");
+    });
+
+    it("retorna null para entradas inválidas", () => {
+      expect(resolveMaptilerStyleSlug("")).toBeNull();
+      expect(resolveMaptilerStyleSlug(undefined)).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- allow the runtime to derive a signed MapTiler style URL from the configured style name when no styleUrl is present and share the normalization helper with the kiosk style utilities
- expand the MapTiler runtime unit tests to cover the new fallback behaviour and slug helper

## Testing
- `npm test` *(fails: vitest binary is not available because npm install cannot download @playwright/test – registry.npmjs.org returns HTTP 403 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919da6f60e483268b554662e5e5cd0e)