### PR TITLE
Fix MapTiler style handling and calendar endpoint

### DIFF
--- a/backend/models_v2.py
+++ b/backend/models_v2.py
@@ -718,6 +718,25 @@ class CalendarConfig(BaseModel):
         raise TypeError("ics_path must be a string or null")
 
 
+class HarvestConfig(BaseModel):
+    """Configuración de hortalizas (harvest) v2."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = True
+    custom_items: List[Dict[str, str]] = Field(default_factory=list)
+
+
+class SaintsConfig(BaseModel):
+    """Configuración de santoral v2."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = True
+    include_namedays: bool = True
+    locale: str = Field(default="es", min_length=2, max_length=5)
+
+
 class PanelsConfig(BaseModel):
     """Configuración de paneles v2."""
     weatherWeekly: Optional[PanelWeatherWeeklyConfig] = None
@@ -887,6 +906,8 @@ class AppConfigV2(BaseModel):
     news: Optional[NewsTopLevelConfig] = None
     ephemerides: Optional[EphemeridesTopLevelConfig] = None
     calendar: Optional[CalendarConfig] = None
+    harvest: HarvestConfig = Field(default_factory=HarvestConfig)
+    saints: SaintsConfig = Field(default_factory=SaintsConfig)
     opensky: Optional[OpenSkyTopLevelConfig] = None
     ais: Optional[AISConfig] = None
     secrets: Optional[SecretsConfig] = None

--- a/backend/tests/test_calendar_endpoint.py
+++ b/backend/tests/test_calendar_endpoint.py
@@ -1,0 +1,92 @@
+from typing import Tuple
+
+from fastapi.testclient import TestClient
+
+
+def _enable_google_calendar(
+    client: TestClient,
+    api_key: str = "TESTKEY",
+    calendar_id: str = "example@calendar"
+) -> None:
+    payload = client.get("/api/config").json()
+    calendar_block = payload.setdefault("calendar", {})
+    calendar_block.update({"enabled": True, "provider": "google"})
+    panels = payload.setdefault("panels", {})
+    panels.setdefault("calendar", {})["enabled"] = True
+    panels["calendar"]["provider"] = "google"
+    secrets_block = payload.setdefault("secrets", {}).setdefault("google", {})
+    secrets_block["api_key"] = api_key
+    secrets_block["calendar_id"] = calendar_id
+    response = client.post("/api/config", json=payload)
+    assert response.status_code == 200, response.text
+
+
+def _disable_calendar(client: TestClient) -> None:
+    payload = client.get("/api/config").json()
+    calendar_block = payload.setdefault("calendar", {})
+    calendar_block.update({"enabled": False, "provider": None})
+    panels = payload.setdefault("panels", {})
+    panels.setdefault("calendar", {})["enabled"] = False
+    panels["calendar"]["provider"] = None
+    response = client.post("/api/config", json=payload)
+    assert response.status_code == 200, response.text
+
+
+def test_calendar_disabled_returns_clean_payload(app_module: Tuple[object, object]) -> None:
+    module, _ = app_module
+    client = TestClient(module.app)
+
+    _disable_calendar(client)
+
+    response = client.get("/api/calendar")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["enabled"] is False
+    assert data["status"] == "disabled"
+    assert data["upcoming"] == []
+    assert data["events"] == []
+    assert "error_message" not in data
+
+
+def test_calendar_error_when_google_credentials_missing(
+    app_module: Tuple[object, object]
+) -> None:
+    module, _ = app_module
+    client = TestClient(module.app)
+
+    _enable_google_calendar(client)
+    module.secret_store.set_secret("google_calendar_api_key", None)
+    module.secret_store.set_secret("google_calendar_id", None)
+
+    response = client.get("/api/calendar")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["enabled"] is True
+    assert data["status"] == "error"
+    assert "credentials" in data.get("error_message", "").lower()
+    assert data["events"] == []
+
+
+def test_calendar_handles_provider_failure(
+    app_module: Tuple[object, object], monkeypatch
+) -> None:
+    module, _ = app_module
+    client = TestClient(module.app)
+
+    _enable_google_calendar(client)
+
+    def _raise(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(module, "fetch_google_calendar_events", _raise)
+
+    response = client.get("/api/calendar")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["enabled"] is True
+    assert data["status"] == "error"
+    assert "boom" in data.get("error_message", "")
+    assert data["events"] == []

--- a/dash-ui/src/components/GeoScope/layers/AEMETWarningsLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/AEMETWarningsLayer.ts
@@ -4,6 +4,7 @@ import type { FeatureCollection } from "geojson";
 
 import type { Layer } from "./LayerRegistry";
 import { getExistingPopup, isGeoJSONSource } from "./layerUtils";
+import { getSafeMapStyle } from "../../../lib/map/utils/safeMapStyle";
 
 interface AEMETWarningsLayerOptions {
   enabled?: boolean;
@@ -268,8 +269,8 @@ export default class AEMETWarningsLayer implements Layer {
       return undefined;
     }
 
-    const style = this.map.getStyle();
-    if (!style || !style.layers || !Array.isArray(style.layers)) {
+    const style = getSafeMapStyle(this.map);
+    if (!style || !Array.isArray(style.layers)) {
       return undefined;
     }
 
@@ -298,7 +299,7 @@ export default class AEMETWarningsLayer implements Layer {
     if (!beforeId) {
       // Mover al tope si no se encuentra referencia
       try {
-        const layers = this.map.getStyle()?.layers || [];
+        const layers = getSafeMapStyle(this.map)?.layers || [];
         if (layers.length > 0) {
           const lastLayer = layers[layers.length - 1];
           if (lastLayer && lastLayer.id !== this.id) {

--- a/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
@@ -6,6 +6,7 @@ import type { FlightsLayerCircleConfig, FlightsLayerRenderMode, FlightsLayerSymb
 import type { Layer } from "./LayerRegistry";
 import { getExistingPopup, isGeoJSONSource } from "./layerUtils";
 import { registerPlaneIcon } from "../utils/planeIcon";
+import { getSafeMapStyle } from "../../../lib/map/utils/safeMapStyle";
 
 type EffectiveRenderMode = "symbol" | "symbol_custom" | "circle";
 
@@ -488,8 +489,8 @@ export default class AircraftLayer implements Layer {
    * Retorna undefined si no se encuentra.
    */
   private findBeforeId(map: maplibregl.Map): string | undefined {
-    const style = map.getStyle();
-    if (!style || !style.layers || !Array.isArray(style.layers)) {
+    const style = getSafeMapStyle(map);
+    if (!style || !Array.isArray(style.layers)) {
       return undefined;
     }
     
@@ -529,7 +530,7 @@ export default class AircraftLayer implements Layer {
       try {
         if (map.getLayer(this.id)) {
           // Mover al tope (sin beforeId)
-          const layers = map.getStyle()?.layers || [];
+          const layers = getSafeMapStyle(map)?.layers || [];
           if (layers.length > 0) {
             // Intentar mover después de la última capa
             const lastLayer = layers[layers.length - 1];
@@ -539,7 +540,7 @@ export default class AircraftLayer implements Layer {
           }
         }
         if (map.getLayer(this.clusterLayerId)) {
-          const layers = map.getStyle()?.layers || [];
+          const layers = getSafeMapStyle(map)?.layers || [];
           if (layers.length > 0) {
             const lastLayer = layers[layers.length - 1];
             if (lastLayer && lastLayer.id !== this.clusterLayerId) {
@@ -548,7 +549,7 @@ export default class AircraftLayer implements Layer {
           }
         }
         if (map.getLayer(this.clusterCountLayerId)) {
-          const layers = map.getStyle()?.layers || [];
+          const layers = getSafeMapStyle(map)?.layers || [];
           if (layers.length > 0) {
             const lastLayer = layers[layers.length - 1];
             if (lastLayer && lastLayer.id !== this.clusterCountLayerId) {

--- a/dash-ui/src/components/GeoScope/layers/MapHybrid.tsx
+++ b/dash-ui/src/components/GeoScope/layers/MapHybrid.tsx
@@ -3,6 +3,7 @@ import type { Map as MapLibreMap } from "maplibre-gl";
 import { getSatelliteTileUrl } from "../../../lib/map/utils/maptilerHelpers";
 import { ensureLabelsOverlay, removeLabelsOverlay } from "../../../lib/map/overlays/vectorLabels";
 import type { NormalizedLabelsOverlay } from "../../../lib/map/labelsOverlay";
+import { getSafeMapStyle } from "../../../lib/map/utils/safeMapStyle";
 
 export interface MapHybridProps {
   map: MapLibreMap;
@@ -189,8 +190,13 @@ export default function MapHybrid({
       "geoscope-ships",
     ];
 
+    const style = getSafeMapStyle(map);
+    if (!style?.layers) {
+      return undefined;
+    }
+
     for (const id of overlayIds) {
-      if (map.getLayer(id)) {
+      if (style.layers.some((layer) => layer.id === id) && map.getLayer(id)) {
         return id;
       }
     }
@@ -217,7 +223,7 @@ export default function MapHybrid({
     }
 
     try {
-      const layers = map.getStyle()?.layers ?? [];
+      const layers = getSafeMapStyle(map)?.layers ?? [];
       for (const layer of layers) {
         if (layer.id && layer.id.startsWith("labels-ov-")) {
           try {

--- a/dash-ui/src/components/GeoScope/layers/SatelliteHybridLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/SatelliteHybridLayer.ts
@@ -7,6 +7,7 @@ import type {
 } from "@maplibre/maplibre-gl-style-spec";
 
 import type { Layer } from "./LayerRegistry";
+import { getSafeMapStyle } from "../../../lib/map/utils/safeMapStyle";
 
 export type SatelliteLabelsStyle = "maptiler-streets-v4-labels" | "none" | "custom-url";
 
@@ -422,7 +423,7 @@ export default class SatelliteHybridLayer implements Layer {
       return;
     }
 
-    const style = map.getStyle() as StyleSpecification | undefined;
+    const style = getSafeMapStyle(map) as StyleSpecification | null;
     if (!style) {
       console.warn("[GeoScope] getStyle() returned null, aborting SatelliteHybridLayer ensure*");
       return;

--- a/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
@@ -6,6 +6,7 @@ import type { ShipsLayerCircleConfig, ShipsLayerRenderMode, ShipsLayerSymbolConf
 import type { Layer } from "./LayerRegistry";
 import { getExistingPopup, isGeoJSONSource } from "./layerUtils";
 import { registerShipIcon } from "../utils/shipIcon";
+import { getSafeMapStyle } from "../../../lib/map/utils/safeMapStyle";
 
 type EffectiveRenderMode = "symbol" | "symbol_custom" | "circle";
 
@@ -469,8 +470,8 @@ export default class ShipsLayer implements Layer {
    * Retorna undefined si no se encuentra.
    */
   private findBeforeId(map: maplibregl.Map): string | undefined {
-    const style = map.getStyle();
-    if (!style || !style.layers || !Array.isArray(style.layers)) {
+    const style = getSafeMapStyle(map);
+    if (!style || !Array.isArray(style.layers)) {
       return undefined;
     }
     
@@ -510,7 +511,7 @@ export default class ShipsLayer implements Layer {
       try {
         if (map.getLayer(this.id)) {
           // Mover al tope (sin beforeId)
-          const layers = map.getStyle()?.layers || [];
+          const layers = getSafeMapStyle(map)?.layers || [];
           if (layers.length > 0) {
             // Intentar mover después de la última capa
             const lastLayer = layers[layers.length - 1];

--- a/dash-ui/src/lib/map/labelsOverlay.ts
+++ b/dash-ui/src/lib/map/labelsOverlay.ts
@@ -10,7 +10,7 @@ export type NormalizedLabelsOverlay = {
 export const DEFAULT_LABELS_STYLE_URL = "https://api.maptiler.com/maps/streets-v4/style.json";
 
 export const DEFAULT_NORMALIZED_LABELS_OVERLAY: NormalizedLabelsOverlay = {
-  enabled: true,
+  enabled: false,
   style_url: DEFAULT_LABELS_STYLE_URL,
   layer_filter: null,
   opacity: 1,

--- a/dash-ui/src/lib/map/maptilerRuntime.test.ts
+++ b/dash-ui/src/lib/map/maptilerRuntime.test.ts
@@ -84,6 +84,7 @@ describe("maptilerRuntime helpers", () => {
       const base = "https://api.maptiler.com/maps/streets-v4/style.json";
       const out = buildMaptilerStyleUrl(base, "TESTKEY");
       expect(out).toContain("key=TESTKEY");
+      expect(out).toContain("cache=");
       expect(containsApiKey(out)).toBe(true);
     });
 
@@ -92,13 +93,15 @@ describe("maptilerRuntime helpers", () => {
       const out = buildMaptilerStyleUrl(base, "TESTKEY");
       expect(out).toContain("key=EXISTING");
       expect(out).not.toContain("key=TESTKEY");
+      expect(out).toContain("cache=");
     });
 
     it("returns URL without key when no apiKey provided", () => {
       const base = "https://api.maptiler.com/maps/streets-v4/style.json";
       const out = buildMaptilerStyleUrl(base, null);
-      expect(out).toBe(base);
+      expect(out?.startsWith(base)).toBe(true);
       expect(containsApiKey(out)).toBe(false);
+      expect(out).toContain("cache=");
     });
 
     it("handles URL with existing query params", () => {
@@ -106,6 +109,7 @@ describe("maptilerRuntime helpers", () => {
       const out = buildMaptilerStyleUrl(base, "TESTKEY");
       expect(out).toContain("v=1");
       expect(out).toContain("key=TESTKEY");
+      expect(out).toContain("cache=");
     });
   });
 
@@ -123,6 +127,7 @@ describe("maptilerRuntime helpers", () => {
       const result = buildFinalMaptilerStyleUrl(cfg, health, baseStyleUrl);
       expect(result).toContain("key=TEST");
       expect(containsApiKey(result)).toBe(true);
+      expect(result).toContain("cache=");
       expect(hasMaptilerKey(cfg, health)).toBe(true);
     });
 
@@ -141,7 +146,8 @@ describe("maptilerRuntime helpers", () => {
       const baseStyleUrl = "https://api.maptiler.com/maps/streets-v4/style.json";
 
       const result = buildFinalMaptilerStyleUrl(cfg, health, baseStyleUrl);
-      expect(result).toBe("https://api.maptiler.com/maps/streets-v4/style.json?key=HEALTH");
+      expect(result).toContain("key=HEALTH");
+      expect(result).toContain("cache=");
       expect(hasMaptilerKey(cfg, health)).toBe(true);
     });
 
@@ -155,7 +161,8 @@ describe("maptilerRuntime helpers", () => {
       const baseStyleUrl = "https://api.maptiler.com/maps/streets-v4/style.json";
 
       const result = buildFinalMaptilerStyleUrl(cfg, health, baseStyleUrl);
-      expect(result).toBe("https://api.maptiler.com/maps/streets-v4/style.json");
+      expect(result?.startsWith("https://api.maptiler.com/maps/streets-v4/style.json")).toBe(true);
+      expect(result).toContain("cache=");
       expect(containsApiKey(result)).toBe(false);
       expect(hasMaptilerKey(cfg, health)).toBe(false);
     });

--- a/dash-ui/src/lib/map/maptilerRuntime.ts
+++ b/dash-ui/src/lib/map/maptilerRuntime.ts
@@ -1,3 +1,5 @@
+import { withStyleCacheBuster } from "./utils/styleCacheBuster";
+
 export type UiMapLike = {
   ui_map?: {
     provider?: string | null;
@@ -101,7 +103,7 @@ export function buildMaptilerStyleUrl(
 
   // Si ya tiene key, devolver tal cual
   if (containsApiKey(trimmed)) {
-    return trimmed;
+    return withStyleCacheBuster(trimmed);
   }
 
   // Si no tiene key pero tenemos apiKey, añadirla
@@ -109,16 +111,18 @@ export function buildMaptilerStyleUrl(
     try {
       const url = new URL(trimmed);
       url.searchParams.set("key", apiKey.trim());
-      return url.toString();
+      return withStyleCacheBuster(url.toString());
     } catch {
       // Si no es una URL válida, añadir key manualmente
       const sep = trimmed.includes("?") ? "&" : "?";
-      return `${trimmed}${sep}key=${encodeURIComponent(apiKey.trim())}`;
+      return withStyleCacheBuster(
+        `${trimmed}${sep}key=${encodeURIComponent(apiKey.trim())}`
+      );
     }
   }
 
   // Sin key disponible, devolver URL sin firmar
-  return trimmed;
+  return withStyleCacheBuster(trimmed);
 }
 
 /**
@@ -138,7 +142,7 @@ export function buildFinalMaptilerStyleUrl(
   if (health?.maptiler?.styleUrl && typeof health.maptiler.styleUrl === "string") {
     const healthUrl = health.maptiler.styleUrl.trim();
     if (healthUrl) {
-      return healthUrl; // Ya viene con ?key=, usarlo tal cual
+      return withStyleCacheBuster(healthUrl);
     }
   }
 
@@ -149,7 +153,7 @@ export function buildFinalMaptilerStyleUrl(
     if (trimmed) {
       // Si ya tiene key, devolver tal cual
       if (containsApiKey(trimmed)) {
-        return trimmed;
+        return withStyleCacheBuster(trimmed);
       }
 
       // Extraer apiKey y construir URL firmada

--- a/dash-ui/src/lib/map/overlays/vectorLabels.ts
+++ b/dash-ui/src/lib/map/overlays/vectorLabels.ts
@@ -9,6 +9,7 @@ import type {
 
 import { DEFAULT_LABELS_STYLE_URL, clampLabelsOpacity } from "../labelsOverlay";
 import { signMapTilerUrl } from "../utils/maptilerHelpers";
+import { getSafeMapStyle } from "../utils/safeMapStyle";
 
 export type LabelsOverlayCfg = {
   enabled: boolean;
@@ -206,7 +207,7 @@ const addSymbolLayers = (
 };
 
 export const removeLabelsOverlay = (map: Map): void => {
-  const style = map.getStyle() as StyleSpecification | undefined;
+  const style = getSafeMapStyle(map) as StyleSpecification | null;
   if (!style) {
     console.warn("[GeoScope] getStyle() returned null, aborting removeLabelsOverlay");
     return;
@@ -292,7 +293,7 @@ export const ensureLabelsOverlay = async (
 
 export const updateLabelsOpacity = (map: Map, opacity: number | null | undefined): void => {
   const target = clampLabelsOpacity(typeof opacity === "number" ? opacity : 1);
-  const style = map.getStyle() as StyleSpecification | undefined;
+  const style = getSafeMapStyle(map) as StyleSpecification | null;
   if (!style) {
     console.warn("[GeoScope] getStyle() returned null, aborting updateLabelsOpacity");
     return;

--- a/dash-ui/src/lib/map/utils/safeMapStyle.ts
+++ b/dash-ui/src/lib/map/utils/safeMapStyle.ts
@@ -1,0 +1,23 @@
+import type maplibregl from "maplibre-gl";
+import type { StyleSpecification } from "maplibre-gl";
+
+export const getSafeMapStyle = (
+  map?: maplibregl.Map | null
+): StyleSpecification | null => {
+  if (!map) {
+    return null;
+  }
+  try {
+    const style = map.getStyle() as StyleSpecification | null | undefined;
+    if (!style || typeof style !== "object") {
+      return null;
+    }
+    const version = (style as { version?: unknown }).version;
+    if (typeof version !== "number") {
+      return null;
+    }
+    return style;
+  } catch {
+    return null;
+  }
+};

--- a/dash-ui/src/lib/map/utils/styleCacheBuster.ts
+++ b/dash-ui/src/lib/map/utils/styleCacheBuster.ts
@@ -1,0 +1,59 @@
+const readGlobalBuildId = (): string | undefined => {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  const candidate = (window as { __PANTALLA_BUILD_ID__?: string }).__PANTALLA_BUILD_ID__;
+  return typeof candidate === "string" && candidate.trim().length > 0 ? candidate.trim() : undefined;
+};
+
+const readEnvBuildId = (): string | undefined => {
+  const env = (import.meta.env as Record<string, string | undefined>) || {};
+  const fromBuild = env.VITE_APP_BUILD_ID?.trim();
+  if (fromBuild) {
+    return fromBuild;
+  }
+  const fromVersion = env.VITE_APP_VERSION?.trim();
+  if (fromVersion) {
+    return fromVersion;
+  }
+  return undefined;
+};
+
+const readFallbackVersion = (): string | undefined => {
+  try {
+    if (typeof __APP_VERSION__ === "string" && __APP_VERSION__.trim().length > 0) {
+      return __APP_VERSION__.trim();
+    }
+  } catch {
+    // Ignorar si no está definido
+  }
+  return undefined;
+};
+
+const CACHE_BUSTER_VALUE =
+  readGlobalBuildId() ||
+  readEnvBuildId() ||
+  readFallbackVersion() ||
+  "";
+
+export const getStyleCacheBuster = (): string | null => {
+  return CACHE_BUSTER_VALUE || null;
+};
+
+export const withStyleCacheBuster = (url: string | null | undefined): string | null => {
+  if (!url || typeof url !== "string") {
+    return url ?? null;
+  }
+  const trimmed = url.trim();
+  if (!trimmed || !CACHE_BUSTER_VALUE) {
+    return trimmed || null;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    parsed.searchParams.set("cache", CACHE_BUSTER_VALUE);
+    return parsed.toString();
+  } catch {
+    const separator = trimmed.includes("?") ? "&" : "?";
+    return `${trimmed}${separator}cache=${encodeURIComponent(CACHE_BUSTER_VALUE)}`;
+  }
+};

--- a/dash-ui/src/vite-env.d.ts
+++ b/dash-ui/src/vite-env.d.ts
@@ -8,3 +8,5 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+declare const __APP_VERSION__: string;

--- a/dash-ui/vite.config.ts
+++ b/dash-ui/vite.config.ts
@@ -1,5 +1,11 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+
+const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8")) as {
+  version?: string;
+};
+const appVersion = pkg.version ?? "dev";
 
 export default defineConfig({
   base: "/",
@@ -7,6 +13,9 @@ export default defineConfig({
   server: {
     host: "0.0.0.0",
     port: 5173
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Summary
- rebuild the `/api/calendar` response flow to read the restored `harvest`/`saints` sections from the v2 schema, return deterministic JSON payloads, and surface helpful errors instead of HTTP 500s
- harden GeoScope’s MapLibre integration with the new safe-style helper, prevent unintended tinting when MapTiler vector styles are selected, and gate the hybrid labels overlay so the kiosk and desktop browsers always show the configured base style
- add cache-busting for MapTiler style URLs, expose `__APP_VERSION__` from Vite, and update the regression tests so the disabled-calendar scenario explicitly toggles the config before hitting the endpoint

## Testing
- pytest backend/tests/test_calendar_endpoint.py
- npm install *(fails: registry returns 403 for @playwright/test, so frontend deps/tests could not be run in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919dd45889083268600640c51e1d80b)