### PR TITLE
Ensure colored ship icons and overlay rotation defaults

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -56,6 +56,18 @@
     "radar": {
       "enabled": false,
       "provider": "rainviewer"
+    },
+    "overlay": {
+      "rotator": {
+        "enabled": true,
+        "order": ["clock", "santoral"],
+        "durations_sec": {
+          "clock": 10,
+          "santoral": 10
+        },
+        "transition_ms": 400,
+        "pause_on_alert": false
+      }
     }
   },
   "opensky": {

--- a/config.hybrid.example.json
+++ b/config.hybrid.example.json
@@ -47,7 +47,19 @@
   },
   "ui_global": {
     "satellite": { "enabled": true, "provider": "gibs", "opacity": 1.0 },
-    "radar": { "enabled": true, "provider": "rainviewer", "opacity": 0.7, "layer_type": "precipitation_new" }
+    "radar": { "enabled": true, "provider": "rainviewer", "opacity": 0.7, "layer_type": "precipitation_new" },
+    "overlay": {
+      "rotator": {
+        "enabled": true,
+        "order": ["clock", "santoral"],
+        "durations_sec": {
+          "clock": 10,
+          "santoral": 10
+        },
+        "transition_ms": 400,
+        "pause_on_alert": false
+      }
+    }
   },
   "layers": {
     "global": {

--- a/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/ShipsLayer.ts
@@ -578,6 +578,9 @@ export default class ShipsLayer implements Layer {
               "visibility": this.enabled ? "visible" : "none",
             },
             paint: {
+              "icon-color": this.circleOptions.color,
+              "icon-halo-color": this.circleOptions.strokeColor,
+              "icon-halo-width": 0.4,
               "icon-opacity": [
                 "interpolate",
                 ["linear"],
@@ -677,6 +680,9 @@ export default class ShipsLayer implements Layer {
               : this.getIconSizeExpression()
           );
           map.setLayoutProperty(this.id, "icon-allow-overlap", this.symbolOptions?.allow_overlap ?? true);
+          map.setPaintProperty(this.id, "icon-color", this.circleOptions.color);
+          map.setPaintProperty(this.id, "icon-halo-color", this.circleOptions.strokeColor);
+          map.setPaintProperty(this.id, "icon-halo-width", 0.4);
         } else {
           map.setPaintProperty(this.id, "circle-radius", this.getCircleRadiusExpression());
           map.setPaintProperty(this.id, "circle-color", this.circleOptions.color);


### PR DESCRIPTION
## Summary
- add overlay rotator defaults to the example configuration files so the rotating panel works out of the box
- tint the ships map layer icons with the project’s colored palette even when using sprite icons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692035680930832680d4fab55b369e49)