### PR TITLE
Fix flights layer initialization & polling (Opensky) + add diagnostics

### DIFF
--- a/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
+++ b/dash-ui/src/components/GeoScope/layers/AircraftLayer.ts
@@ -193,16 +193,18 @@ export default class AircraftLayer implements Layer {
           const error = iconError instanceof Error ? iconError : new Error(String(iconError));
           layerDiagnostics.recordError(layerId, error, {
             phase: "icon_registration",
-          });
-          console.warn("[AircraftLayer] Failed to register plane icon:", iconError);
-        }
+        });
+        console.warn("[AircraftLayer] Failed to register plane icon:", iconError);
       }
+    }
 
-      // Asegurar que el source existe (idempotente)
-      try {
-        this.ensureSource();
-      } catch (sourceError) {
-        const error = sourceError instanceof Error ? sourceError : new Error(String(sourceError));
+    console.log("[AircraftLayer] ensureFlightsLayer - creating/updating source+layers");
+
+    // Asegurar que el source existe (idempotente)
+    try {
+      this.ensureSource();
+    } catch (sourceError) {
+      const error = sourceError instanceof Error ? sourceError : new Error(String(sourceError));
         layerDiagnostics.recordError(layerId, error, {
           phase: "ensure_source",
         });
@@ -361,7 +363,7 @@ export default class AircraftLayer implements Layer {
   updateData(data: FeatureCollection): void {
     const layerId: LayerId = "flights";
 
-    console.log("[AircraftLayer] updateData called with features:", Array.isArray((data as any)?.features)
+    console.log("[AircraftLayer] updateData called, features:", Array.isArray((data as any)?.features)
       ? (data as any).features.length
       : 0);
 


### PR DESCRIPTION
## Summary
- add map readiness tracking and ensure AircraftLayer waits for a loaded style before initializing
- update flights polling to always run when flights/opensky are enabled, log diagnostics, and handle FeatureCollection responses from the backend
- enhance AircraftLayer logging for ensureFlightsLayer and data updates

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923342bad2883268b68ce208bc7d26e)