### PR TITLE
Ensure AircraftLayer initializes before flight polling

### DIFF
--- a/dash-ui/src/components/GeoScope/layers/LayerRegistry.ts
+++ b/dash-ui/src/components/GeoScope/layers/LayerRegistry.ts
@@ -18,6 +18,23 @@ export class LayerRegistry {
     this.map = map;
   }
 
+  get(layerId: string): Layer | undefined {
+    return this.layers.find((layer) => layer.id === layerId);
+  }
+
+  register(layerId: string, layer: Layer): boolean {
+    if (layer.id !== layerId) {
+      console.warn(`[LayerRegistry] Layer id mismatch (expected ${layerId}, got ${layer.id}), continuing with provided id`);
+    }
+
+    if (this.get(layerId)) {
+      console.warn(`[LayerRegistry] Layer ${layerId} already exists in registry, skipping register`);
+      return false;
+    }
+
+    return this.add(layer);
+  }
+
   /**
    * Espera a que el estilo del mapa esté disponible.
    * Si ya está disponible, resuelve inmediatamente.


### PR DESCRIPTION
## Summary
- add a dedicated helper to initialize or reuse the AircraftLayer through the LayerRegistry with clearer logging
- gate flights polling on the aircraft layer availability and log received data before updating the layer
- extend LayerRegistry with get/register helpers for reuse of registered layers

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692346a038248326a2b63b866add1daa)