### PR TITLE
Fix: ensure kiosk browser logs are writable by user and prevent Chrome startup failures

### DIFF
--- a/systemd/pantalla-kiosk-chrome@.service
+++ b/systemd/pantalla-kiosk-chrome@.service
@@ -7,6 +7,7 @@ StartLimitIntervalSec=0
 
 [Service]
 User=%i
+Group=%i
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/home/%i/.Xauthority
 Environment=GDK_BACKEND=x11
@@ -17,6 +18,7 @@ EnvironmentFile=-/var/lib/pantalla-reloj/state/kiosk.env
 # Esperar a que X11 y los servicios estén listos, luego esperar al backend
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do curl -sf --max-time 2 http://127.0.0.1:8081/api/health >/dev/null 2>&1 && break; sleep 1; done; sleep 2; xset -dpms; xset s off; xset s noblank || true'
 LogsDirectory=pantalla
+LogsDirectoryMode=0755
 # NOTA: El perfil del navegador kiosk (/var/lib/pantalla-reloj/state/chromium-kiosk) se crea
 # exclusivamente en scripts/install.sh. El wrapper pantalla-kiosk solo verifica que existe.
 # Si falta, el wrapper fallará con un mensaje claro indicando que hay que ejecutar install.sh.

--- a/systemd/pantalla-kiosk@.service
+++ b/systemd/pantalla-kiosk@.service
@@ -6,6 +6,7 @@ Wants=pantalla-xorg.service
 
 [Service]
 User=%i
+Group=%i
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/home/%i/.Xauthority
 Environment=GDK_BACKEND=x11
@@ -14,6 +15,7 @@ Environment=GIO_USE_PORTALS=0
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus
 EnvironmentFile=-/var/lib/pantalla-reloj/state/kiosk.env
 LogsDirectory=pantalla
+LogsDirectoryMode=0755
 ExecStartPre=/bin/sh -lc 'xset -dpms; xset s off; xset s noblank || true'
 ExecStart=/usr/local/bin/pantalla-kiosk
 Restart=on-failure

--- a/systemd/pantalla-openbox@.service
+++ b/systemd/pantalla-openbox@.service
@@ -6,6 +6,7 @@ BindsTo=pantalla-xorg.service
 
 [Service]
 User=%i
+Group=%i
 PermissionsStartOnly=yes
 Environment=DISPLAY=:0
 Environment=XAUTHORITY=/home/%i/.Xauthority

--- a/usr/local/bin/pantalla-kiosk
+++ b/usr/local/bin/pantalla-kiosk
@@ -6,6 +6,18 @@ DEFAULT_URL="${DEFAULT_ORIGIN}/"
 DEFAULT_STATE_DIR="/var/lib/pantalla-reloj/state"
 DEFAULT_LOG_DIR="/var/log/pantalla"
 
+LOG_DIR="/var/log/pantalla"
+LOG_FILE="$LOG_DIR/browser-kiosk.log"
+
+mkdir -p "$LOG_DIR"
+
+# Crear si no existe
+touch "$LOG_FILE"
+
+# Asegurar permisos correctos para el usuario que ejecuta el kiosk
+chown "$USER:$USER" "$LOG_FILE"
+chmod 644 "$LOG_FILE"
+
 log() {
   printf '[pantalla-kiosk] %s\n' "$*" >&2
 }


### PR DESCRIPTION
## Summary
- ensure kiosk startup script pre-creates /var/log/pantalla/browser-kiosk.log with correct ownership and permissions
- configure kiosk systemd units to set log directory permissions and include explicit group
- align openbox service to run with matching group settings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366e05bd008326b748e6db87420e9c)