### PR TITLE
Add SyntheticEvent to React type shim

### DIFF
--- a/dash-ui/types/react/index.d.ts
+++ b/dash-ui/types/react/index.d.ts
@@ -45,6 +45,13 @@ declare module "react" {
   }
   export type Ref<T> = MutableRefObject<T> | ((instance: T | null) => void) | null;
   export type RefCallback<T> = (instance: T | null) => void;
+  export interface SyntheticEvent<T = Element, E = Event> {
+    nativeEvent: E;
+    target: T;
+    currentTarget: T;
+    preventDefault(): void;
+    stopPropagation(): void;
+  }
   export function createElement(type: any, props?: any, ...children: ReactNode[]): ReactNode;
   export function cloneElement(element: ReactNode, props?: any, ...children: ReactNode[]): ReactNode;
   export function createContext<T>(defaultValue: T): Context<T>;


### PR DESCRIPTION
## Summary
- add a SyntheticEvent interface to the React type shim used for offline builds
- ensure TransportCard can import SyntheticEvent without TypeScript errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366eeb605c83269c6d09ed3c51439c)