### PR TITLE
Fix TransportCard icon error handler typing

### DIFF
--- a/dash-ui/src/components/dashboard/cards/TransportCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/TransportCard.tsx
@@ -1,4 +1,4 @@
-import type { SyntheticEvent } from "react";
+import type { ReactEventHandler } from "react";
 import { useEffect, useMemo, useState } from "react";
 
 type TransportData = {
@@ -100,7 +100,7 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
   const current = items[currentIndex];
   const iconUrl = isPlane ? "/img/icons/3d/plane.png" : "/img/icons/3d/ship.png";
 
-  const handleIconError = (event: SyntheticEvent<HTMLImageElement>) => {
+  const handleIconError: ReactEventHandler<HTMLImageElement> = event => {
     const fallback = isPlane ? "/img/icons/3d/plane.png" : "/img/icons/3d/ship.png";
     if (event.currentTarget.src !== fallback) {
       event.currentTarget.src = fallback;


### PR DESCRIPTION
## Summary
- update TransportCard image onError handler to use ReactEventHandler typing

## Testing
- npm run test (fails: existing playwright suite location expectation and missing local services)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69366f8bb50c83269755dc15d6546d75)