### PR TITLE
Fix transport card event handler typing

### DIFF
--- a/dash-ui/src/components/dashboard/cards/TransportCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/TransportCard.tsx
@@ -1,4 +1,4 @@
-import type { ReactEventHandler } from "react";
+import type { SyntheticEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 
 type TransportData = {
@@ -100,7 +100,7 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
   const current = items[currentIndex];
   const iconUrl = isPlane ? "/img/icons/3d/plane.png" : "/img/icons/3d/ship.png";
 
-  const handleIconError: ReactEventHandler<HTMLImageElement> = event => {
+  const handleIconError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
     const fallback = isPlane ? "/img/icons/3d/plane.png" : "/img/icons/3d/ship.png";
     if (event.currentTarget.src !== fallback) {
       event.currentTarget.src = fallback;


### PR DESCRIPTION
## Summary
- replace the unused ReactEventHandler import with SyntheticEvent for compatibility
- type the transport card icon error handler to avoid implicit any errors

## Testing
- npm run --silent tsc -- --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367023266c8326aeb6048cc2c5b257)