### PR TITLE
Fix TransportCard icon error handler type

### DIFF
--- a/dash-ui/src/components/dashboard/cards/TransportCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/TransportCard.tsx
@@ -1,5 +1,4 @@
-import type { SyntheticEvent } from "react";
-import { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 
 type TransportData = {
   planes?: Array<{
@@ -100,7 +99,7 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
   const current = items[currentIndex];
   const iconUrl = isPlane ? "/img/icons/3d/plane.png" : "/img/icons/3d/ship.png";
 
-  const handleIconError = (event: SyntheticEvent<HTMLImageElement, Event>) => {
+  const handleIconError: React.ReactEventHandler<HTMLImageElement> = event => {
     const fallback = isPlane ? "/img/icons/3d/plane.png" : "/img/icons/3d/ship.png";
     if (event.currentTarget.src !== fallback) {
       event.currentTarget.src = fallback;


### PR DESCRIPTION
## Summary
- update TransportCard icon error handler to use React-provided event handler typing
- ensure error handler works with image onError callbacks without type conflicts

## Testing
- npm run build:full

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367359458083268915506c4c0993f4)