### PR TITLE
Add right panel validation hooks and tests

### DIFF
--- a/dash-ui/DEV_PANEL_CHECKS.md
+++ b/dash-ui/DEV_PANEL_CHECKS.md
@@ -1,0 +1,59 @@
+# Validación rápida del panel lateral derecho
+
+Este paquete verifica que el panel lateral (1920×480) renderiza correctamente los bloques de reloj, tiempo, predicción, AIS/barcos, aviones, astronomía, NASA APOD, santoral, noticias y efemérides.
+
+## Cómo ejecutar los tests automáticos
+
+1. Instala dependencias en `dash-ui` si es necesario: `npm install`.
+2. Lanza solo las pruebas del panel derecho:
+
+```bash
+npm run test:right-panel
+```
+
+Los tests validan iconos, textos clave, presencia de data-testid y ausencia de scrollbars visibles en los contenedores auto-scroll.
+
+## Qué comprobar manualmente (Dani)
+
+Checklist visual a ejecutar por Dani:
+
+### Reloj
+- Panel sin icono de sol ni título “Reloj”.
+- Hora y fecha completa visibles, sin cortar.
+
+### Tiempo actual
+- Icono de clima visible.
+- Estado coherente (nada de “aguanieve” con 15–20°C).
+
+### Predicción semanal
+- Iconos por día visibles.
+- Nada de nieve rara si hace buena temperatura.
+
+### Barcos
+- Icono del panel sin cuadro blanco.
+- Se ve el nombre del barco, velocidad y rumbo claramente.
+
+### Astronomía
+- Iconos para sol, luna, amanecer/atardecer correctos y uniformes.
+
+### NASA APOD
+- Si es foto → se ve la imagen.
+- Si es vídeo → se ve icono/thumbnail, el panel no queda vacío.
+- El texto se desplaza solo; no hay barra de scroll visible.
+
+### Santoral
+- Sin icono de sol.
+- Lista se desplaza sola si hay muchos nombres.
+
+### Noticias
+- Texto legible, sin URLs largas.
+- Si hay muchas, el contenido se mueve solo.
+
+### Efemérides
+- Hay icono en el título.
+- Cada frase empieza por mayúscula.
+
+### Aviones
+- Si hay vuelos cerca → se muestra al menos uno.
+- Si no hay, aparece el mensaje “Sin vuelos cercanos” o similar.
+

--- a/dash-ui/package.json
+++ b/dash-ui/package.json
@@ -13,6 +13,7 @@
     "build:full": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:right-panel": "vitest run src/components/RightPanel/right-panel.test.tsx",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "clean": "rimraf node_modules dist .vite .parcel-cache || true",

--- a/dash-ui/src/components/RightPanel/right-panel.test.tsx
+++ b/dash-ui/src/components/RightPanel/right-panel.test.tsx
@@ -1,0 +1,215 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { TimeCard } from "../dashboard/cards/TimeCard";
+import { WeatherCard } from "../dashboard/cards/WeatherCard";
+import { WeatherForecastCard } from "../dashboard/cards/WeatherForecastCard";
+import { TransportCard } from "../dashboard/cards/TransportCard";
+import { EphemeridesCard } from "../dashboard/cards/EphemeridesCard";
+import { ApodCard } from "../dashboard/cards/ApodCard";
+import SaintsCard from "../dashboard/cards/SaintsCard";
+import { NewsCard } from "../dashboard/cards/NewsCard";
+import { HistoricalEventsCard } from "../dashboard/cards/HistoricalEventsCard";
+import "../../test/setup";
+
+const originalFetch = global.fetch;
+const originalRaf = global.requestAnimationFrame;
+const originalCancelRaf = global.cancelAnimationFrame;
+
+describe("Right panel components", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, json: async () => ({}) })) as any);
+    global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      return setTimeout(() => cb(performance.now()), 0) as unknown as number;
+    }) as any;
+    global.cancelAnimationFrame = ((id: number) => clearTimeout(id)) as any;
+  });
+
+  afterEach(() => {
+    if (vi.isFakeTimers()) {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    if (originalRaf) {
+      global.requestAnimationFrame = originalRaf;
+    }
+    if (originalCancelRaf) {
+      global.cancelAnimationFrame = originalCancelRaf;
+    }
+  });
+
+  it("renders the clock panel without icons and shows current date", () => {
+    vi.setSystemTime(new Date("2024-05-10T10:30:15Z"));
+    render(<TimeCard timezone="UTC" />);
+
+    const panel = screen.getByTestId("panel-clock");
+    expect(panel.querySelectorAll("img").length).toBe(0);
+    expect(screen.getByText(/viernes/i)).toBeInTheDocument();
+    expect(screen.getByText(/10 de mayo/i)).toBeInTheDocument();
+  });
+
+  it("renders current weather with icon and description", () => {
+    render(
+      <WeatherCard
+        temperatureLabel="18°C"
+        feelsLikeLabel="17°C"
+        condition="Nublado"
+        humidity={40}
+        wind={12}
+        rain={0}
+        unit="C"
+      />
+    );
+
+    const panel = screen.getByTestId("panel-weather-current");
+    expect(panel.querySelector(".panel-title-icon")).toBeInTheDocument();
+    expect(screen.getByText(/18/)).toBeInTheDocument();
+    expect(screen.getByText(/Nublado/i)).toBeInTheDocument();
+  });
+
+  it("renders forecast items with icons and min/max values", () => {
+    render(
+      <WeatherForecastCard
+        unit="C"
+        forecast={[
+          { date: "Lun", condition: "Soleado", temperature: { min: 10, max: 20 } },
+          { date: "Mar", condition: "Nublado", temperature: { min: 11, max: 21 } },
+          { date: "Mié", condition: "Lluvia", temperature: { min: 12, max: 22 } }
+        ]}
+      />
+    );
+
+    const panel = screen.getByTestId("panel-weather-forecast");
+    expect(panel.querySelectorAll(".forecast-card-dark__dot").length).toBeGreaterThanOrEqual(3);
+    expect(panel.querySelector(".forecast-card-dark__main-icon")).toBeInTheDocument();
+    expect(screen.getByText(/máx/i)).toBeInTheDocument();
+    expect(screen.getByText(/mín/i)).toBeInTheDocument();
+  });
+
+  it("renders ships data with name, speed and heading", async () => {
+    vi.useRealTimers();
+    render(
+      <TransportCard
+        data={{
+          ships: [
+            { name: "Ferry Valencia", speed: 12.3, heading: 180, distance_km: 5.2, destination: "Castelló" }
+          ]
+        }}
+      />
+    );
+
+    const shipsPanel = await screen.findByTestId("panel-ships");
+    expect(shipsPanel).toBeInTheDocument();
+    expect(screen.getByText(/Ferry Valencia/)).toBeInTheDocument();
+    expect(screen.getByText(/12\.3 kn/)).toBeInTheDocument();
+    expect(screen.getByText(/180°/)).toBeInTheDocument();
+  });
+
+  it("renders flights with callsign and altitude/speed", () => {
+    render(
+      <TransportCard
+        data={{
+          planes: [
+            { callsign: "VLG123", altitude: 10234, speed: 60, heading: 270, distance_km: 15.4, aircraft_type: "A320" }
+          ]
+        }}
+      />
+    );
+
+    const panel = screen.getByTestId("panel-flights");
+    expect(screen.getByText(/VLG123/)).toBeInTheDocument();
+    expect(screen.getByText(/10234 m/)).toBeInTheDocument();
+    expect(screen.getByText(/216 km\/h/)).toBeInTheDocument();
+    expect(screen.getByText(/A320/)).toBeInTheDocument();
+  });
+
+  it("cycles astronomy states and shows expected icons", () => {
+    render(<EphemeridesCard sunrise="07:10" sunset="20:55" moonPhase="Luna llena" illumination={0.75} events={[]} />);
+
+    const panel = screen.getByTestId("panel-astronomy");
+    expect(panel.querySelector("img[src*='sunrise']")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(panel.querySelector("img[src*='moon']")).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(panel.querySelector("img[src*='sunset']")).toBeInTheDocument();
+  });
+
+  it("renders NASA APOD image and handles video placeholders", () => {
+    render(
+      <ApodCard
+        data={{
+          title: "Nebulosa",
+          url: "https://example.com/image.jpg",
+          media_type: "image",
+          explanation: "Exploración espacial",
+          date: "2024-05-10"
+        }}
+      />
+    );
+    expect(screen.getByTestId("panel-nasa-apod").querySelector("img")).toBeInTheDocument();
+
+    render(
+      <ApodCard
+        data={{
+          title: "Vídeo del espacio",
+          url: "",
+          media_type: "video",
+          explanation: "Contenido en vídeo",
+          date: "2024-05-11"
+        }}
+      />
+    );
+    expect(screen.getAllByTestId("panel-nasa-apod")[1].textContent).toMatch(/Contenido en vídeo|Foto del día no disponible/);
+  });
+
+  it("renders santoral list without sun icons", () => {
+    render(<SaintsCard saints={[{ name: "San Pedro", bio: "Apóstol", image: "/icons/misc/santoral.svg" }, "Santa Marta"]} />);
+    const panel = screen.getByTestId("panel-santoral");
+    expect(panel.querySelector("img[src*='santoral']")).toBeInTheDocument();
+    expect(screen.getByText(/San Pedro/)).toBeInTheDocument();
+  });
+
+  it("renders news without long urls", () => {
+    render(
+      <NewsCard
+        items={[
+          { title: "Titular sin http", summary: "Resumen breve" },
+          { title: "Otra noticia", summary: "Más texto" }
+        ]}
+      />
+    );
+
+    const panel = screen.getByTestId("panel-news");
+    expect(panel.textContent ?? "").not.toMatch(/https?:\/\//i);
+    expect(screen.getByText(/Titular sin http/)).toBeInTheDocument();
+  });
+
+  it("renders history items with capitalized sentences", () => {
+    render(<HistoricalEventsCard items={["1492: descubrimiento de América", "1992: expo de sevilla"]} rotationSeconds={2} />);
+
+    const panel = screen.getByTestId("panel-history");
+    expect(screen.getByText(/Descubrimiento/)).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.getByText(/Expo de sevilla/)).toBeInTheDocument();
+  });
+
+  it("exposes auto-scroll class to hide scrollbars", () => {
+    render(
+      <NewsCard
+        items={[{ title: "Noticia", summary: "Contenido para probar scroll" }]}
+      />
+    );
+    const scrollable = screen.getByTestId("panel-news").querySelector(".panel-scroll-auto");
+    expect(scrollable).toBeInTheDocument();
+    expect(scrollable?.classList.contains("panel-scroll-auto")).toBe(true);
+  });
+});

--- a/dash-ui/src/components/dashboard/cards/ApodCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/ApodCard.tsx
@@ -14,6 +14,7 @@ interface ApodCardProps {
     data: ApodData | null;
 }
 
+// Panel lateral de la imagen/vídeo del día de NASA APOD
 export const ApodCard = ({ data }: ApodCardProps) => {
 
     const scrollRef = useRef<HTMLDivElement>(null);
@@ -38,9 +39,9 @@ export const ApodCard = ({ data }: ApodCardProps) => {
 
     if (!data || data.error) {
         return (
-            <div className="apod-card-dark apod-card-dark--empty">
+            <div className="apod-card-dark apod-card-dark--empty" data-testid="panel-nasa-apod">
                 <span className="apod-card-dark__icon">🔭</span>
-                <span>Foto del día no disponible</span>
+                <span className="panel-item-title">Foto del día no disponible</span>
             </div>
         );
     }
@@ -50,7 +51,7 @@ export const ApodCard = ({ data }: ApodCardProps) => {
     const hasImage = Boolean(imageUrl);
 
     return (
-        <div className="apod-card-dark">
+        <div className="apod-card-dark" data-testid="panel-nasa-apod">
             {/* Background Image */}
             {hasImage && (
                 <div className="apod-card-dark__bg">
@@ -61,7 +62,7 @@ export const ApodCard = ({ data }: ApodCardProps) => {
 
             {/* Content */}
             <div className="apod-card-dark__content">
-                <div className="apod-card-dark__badge">
+                <div className="apod-card-dark__badge panel-title-text">
                     <span>🔭</span>
                     <span>NASA APOD</span>
                     {isVideo && <span className="apod-card-dark__video-tag">📹 Video</span>}
@@ -80,7 +81,7 @@ export const ApodCard = ({ data }: ApodCardProps) => {
 
                 <h1 className="apod-card-dark__title">{data.title}</h1>
 
-                <div ref={scrollRef} className="apod-card-dark__desc no-scrollbar">
+                <div ref={scrollRef} className="apod-card-dark__desc no-scrollbar panel-scroll-auto">
                     <p>{data.explanation}</p>
                 </div>
 

--- a/dash-ui/src/components/dashboard/cards/EphemeridesCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/EphemeridesCard.tsx
@@ -30,6 +30,7 @@ const getMoonPhaseIcon = (illumination: number | null): string => {
   return "/icons/astronomy/moon/waning-crescent-1.svg";
 };
 
+// Panel lateral de astronomía (amanecer, atardecer y luna)
 export const EphemeridesCard = ({ sunrise, sunset, moonPhase, illumination }: EphemeridesCardProps): JSX.Element => {
   const [currentState, setCurrentState] = useState<AstroState>("sunrise");
 
@@ -73,14 +74,14 @@ export const EphemeridesCard = ({ sunrise, sunset, moonPhase, illumination }: Ep
   const iconUrl = getIcon();
 
   return (
-    <div className="ephemerides-card-dark">
+    <div className="ephemerides-card-dark" data-testid="panel-astronomy">
       <div className="ephemerides-card-dark__header">
-        <img src={iconUrl} alt="" className="ephemerides-card-dark__header-icon" />
-        <span className="ephemerides-card-dark__title">Astronomía</span>
+        <img src={iconUrl} alt="" className="ephemerides-card-dark__header-icon panel-title-icon" />
+        <span className="ephemerides-card-dark__title panel-title-text">Astronomía</span>
       </div>
 
-      <div className="ephemerides-card-dark__body">
-        <div className="ephemerides-card-dark__label">{getLabel()}</div>
+      <div className="ephemerides-card-dark__body panel-body">
+        <div className="ephemerides-card-dark__label panel-item-title">{getLabel()}</div>
 
         <div className="ephemerides-card-dark__icon-container">
           <img
@@ -90,7 +91,7 @@ export const EphemeridesCard = ({ sunrise, sunset, moonPhase, illumination }: Ep
           />
         </div>
 
-        <div className="ephemerides-card-dark__value">{getValue()}</div>
+        <div className="ephemerides-card-dark__value panel-item-title">{getValue()}</div>
 
         {currentState === "moon" && illuminationPercent !== null && (
           <div className="ephemerides-card-dark__illumination">{illuminationPercent}% iluminación</div>

--- a/dash-ui/src/components/dashboard/cards/HistoricalEventsCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/HistoricalEventsCard.tsx
@@ -19,6 +19,7 @@ const capitalizeText = (value: string): string => {
   return value.charAt(0).toUpperCase() + value.slice(1);
 };
 
+// Panel lateral de efemérides históricas
 export const HistoricalEventsCard = ({ items, rotationSeconds = 12 }: HistoricalEventsCardProps): JSX.Element => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -58,18 +59,18 @@ export const HistoricalEventsCard = ({ items, rotationSeconds = 12 }: Historical
   const current = parsedEvents[currentIndex];
 
   return (
-    <div className="historical-card-dark">
+    <div className="historical-card-dark" data-testid="panel-history">
       <div className="historical-card-dark__header">
-        <img src="/icons/misc/efemerides.svg" alt="" className="historical-card-dark__icon" />
-        <span className="historical-card-dark__title">Efemérides Históricas</span>
+        <img src="/icons/misc/efemerides.svg" alt="" className="historical-card-dark__icon panel-title-icon" />
+        <span className="historical-card-dark__title panel-title-text">Efemérides Históricas</span>
       </div>
 
-      <div className="historical-card-dark__body" key={currentIndex}>
+      <div className="historical-card-dark__body panel-body" key={currentIndex}>
         {current.year && (
-          <div className="historical-card-dark__year">{current.year}</div>
+          <div className="historical-card-dark__year panel-item-title">{current.year}</div>
         )}
-        <div ref={scrollRef} className="historical-card-dark__text no-scrollbar">
-          <p>{capitalizeText(current.text)}</p>
+        <div ref={scrollRef} className="historical-card-dark__text no-scrollbar panel-scroll-auto">
+          <p className="panel-item-subtitle">{capitalizeText(current.text)}</p>
         </div>
       </div>
 

--- a/dash-ui/src/components/dashboard/cards/NewsCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/NewsCard.tsx
@@ -19,6 +19,7 @@ const stripHtml = (html: string) => {
   return (tmp.textContent || tmp.innerText || "").trim();
 };
 
+// Panel lateral de noticias
 export const NewsCard = ({ items }: NewsCardProps): JSX.Element => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -54,18 +55,18 @@ export const NewsCard = ({ items }: NewsCardProps): JSX.Element => {
   }, [currentIndex, current.summary, current.title]);
 
   return (
-    <div className="news-card-dark">
+    <div className="news-card-dark" data-testid="panel-news">
       <div className="news-card-dark__header">
-        <img src="/icons/misc/news.svg" alt="" className="news-card-dark__header-icon" />
-        <span className="news-card-dark__title">Noticias</span>
+        <img src="/icons/misc/news.svg" alt="" className="news-card-dark__header-icon panel-title-icon" />
+        <span className="news-card-dark__title panel-title-text">Noticias</span>
       </div>
 
-      <div className="news-card-dark__body" key={currentIndex}>
-        <div className="news-card-dark__source">Fuente: {sourceLabel}</div>
-        <div ref={scrollRef} className="news-card-dark__content no-scrollbar">
-          <h2 className="news-card-dark__headline">{stripHtml(current.title)}</h2>
+      <div className="news-card-dark__body panel-body" key={currentIndex}>
+        <div className="news-card-dark__source panel-item-subtitle">Fuente: {sourceLabel}</div>
+        <div ref={scrollRef} className="news-card-dark__content no-scrollbar panel-scroll-auto">
+          <h2 className="news-card-dark__headline panel-item-title">{stripHtml(current.title)}</h2>
           {current.summary && (
-            <p className="news-card-dark__summary">{stripHtml(current.summary)}</p>
+            <p className="news-card-dark__summary panel-item-subtitle">{stripHtml(current.summary)}</p>
           )}
         </div>
       </div>

--- a/dash-ui/src/components/dashboard/cards/SaintsCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/SaintsCard.tsx
@@ -26,6 +26,7 @@ const SAINT_NAME_VARIATIONS: Record<string, string[]> = {
   "pablo": ["San Pablo", "Pablo de Tarso"],
 };
 
+// Panel lateral de santoral
 export default function SaintsCard({ saints }: SaintsCardProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [saintInfo, setSaintInfo] = useState<SaintInfo | null>(null);
@@ -125,8 +126,8 @@ export default function SaintsCard({ saints }: SaintsCardProps) {
 
   if (!saints || saints.length === 0) {
     return (
-      <div className="saints-card-dark saints-card-dark__empty">
-        <span className="saints-card-dark__empty-text">Hoy no hay santos destacados</span>
+      <div className="saints-card-dark saints-card-dark__empty" data-testid="panel-santoral">
+        <span className="saints-card-dark__empty-text panel-item-title">Hoy no hay santos destacados</span>
       </div>
     );
   }
@@ -135,20 +136,20 @@ export default function SaintsCard({ saints }: SaintsCardProps) {
   const imageUrl = saintInfo?.originalimage?.source || saintInfo?.thumbnail?.source || "/icons/misc/santoral.svg";
 
   return (
-    <div className="saints-card-dark">
+    <div className="saints-card-dark" data-testid="panel-santoral">
       <div className="saints-card-dark__header">
-        <img src="/icons/misc/santoral.svg" alt="" className="saints-card-dark__header-icon" />
-        <span className="saints-card-dark__title">Santoral</span>
+        <img src="/icons/misc/santoral.svg" alt="" className="saints-card-dark__header-icon panel-title-icon" />
+        <span className="saints-card-dark__title panel-title-text">Santoral</span>
       </div>
 
-      <div className="saints-card-dark__body">
+      <div className="saints-card-dark__body panel-body">
         <div className="saints-card-dark__image-container">
           <img src={imageUrl} alt={fullName} className="saints-card-dark__image" />
         </div>
 
         <div className="saints-card-dark__info">
-          <h2 className="saints-card-dark__name">{fullName}</h2>
-          <div ref={scrollRef} className="saints-card-dark__bio no-scrollbar">
+          <h2 className="saints-card-dark__name panel-item-title">{fullName}</h2>
+          <div ref={scrollRef} className="saints-card-dark__bio no-scrollbar panel-scroll-auto">
             {loading ? (
               <p className="saints-card-dark__loading">Buscando información...</p>
             ) : saintInfo?.extract ? (

--- a/dash-ui/src/components/dashboard/cards/TimeCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/TimeCard.tsx
@@ -4,6 +4,7 @@ type TimeCardProps = {
   timezone: string;
 };
 
+// Panel lateral de reloj principal
 export const TimeCard = ({ timezone }: TimeCardProps): JSX.Element => {
   const [time, setTime] = useState(new Date());
 
@@ -24,19 +25,19 @@ export const TimeCard = ({ timezone }: TimeCardProps): JSX.Element => {
   const greeting = hour >= 6 && hour < 12 ? "Buenos días" : hour >= 12 && hour < 21 ? "Buenas tardes" : "Buenas noches";
 
   return (
-    <div className="time-card-dark">
-      <div className="time-card-dark__body">
-        <div className="time-card-dark__eyebrow">Hora</div>
-        <div className="time-card-dark__greeting">{greeting}</div>
+    <div className="time-card-dark" data-testid="panel-clock">
+      <div className="time-card-dark__body panel-body">
+        <div className="time-card-dark__eyebrow panel-title-text">Hora</div>
+        <div className="time-card-dark__greeting panel-item-title">{greeting}</div>
         <div className="time-card-dark__clock">
-          <span className="time-card-dark__hours">{hours}</span>
+          <span className="time-card-dark__hours panel-item-title">{hours}</span>
           <span className="time-card-dark__sep">:</span>
-          <span className="time-card-dark__minutes">{minutes}</span>
-          <span className="time-card-dark__seconds">{seconds}</span>
+          <span className="time-card-dark__minutes panel-item-title">{minutes}</span>
+          <span className="time-card-dark__seconds panel-item-subtitle">{seconds}</span>
         </div>
         <div className="time-card-dark__date">
-          <div className="time-card-dark__dayname">{dayName}</div>
-          <div className="time-card-dark__fulldate">{fullDate}</div>
+          <div className="time-card-dark__dayname panel-item-title">{dayName}</div>
+          <div className="time-card-dark__fulldate panel-item-subtitle">{fullDate}</div>
         </div>
       </div>
 

--- a/dash-ui/src/components/dashboard/cards/TransportCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/TransportCard.tsx
@@ -35,6 +35,7 @@ type TransportCardProps = {
 
 type TransportType = "plane" | "ship";
 
+// Panel lateral de transporte: aviones y barcos cercanos
 export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
   const [activeTab, setActiveTab] = useState<TransportType>("plane");
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -125,9 +126,9 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
   const renderEmpty = () => {
     const label = isPlane ? "Sin vuelos cercanos" : "Sin barcos cercanos";
     return (
-      <div className="transport-card-dark__empty">
-        <img src={iconUrl} alt="" className="transport-card-dark__empty-icon" />
-        <span className="transport-card-dark__empty-text">{label}</span>
+      <div className="transport-card-dark__empty" data-testid={isPlane ? "panel-flights" : "panel-ships"}>
+        <img src={iconUrl} alt="" className="transport-card-dark__empty-icon panel-title-icon" />
+        <span className="transport-card-dark__empty-text panel-item-title">{label}</span>
       </div>
     );
   };
@@ -140,35 +141,40 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
   );
 
   return (
-    <div className="transport-card-dark">
+    <div className="transport-card-dark" data-testid="panel-transport">
       <div className="transport-card-dark__header">
-        <img src={iconUrl} alt="" className="transport-card-dark__header-icon" />
-        <span className="transport-card-dark__title">{isPlane ? "Aviones Cercanos" : "Barcos Cercanos"}</span>
+        <img src={iconUrl} alt="" className="transport-card-dark__header-icon panel-title-icon" />
+        <span className="transport-card-dark__title panel-title-text">{isPlane ? "Aviones Cercanos" : "Barcos Cercanos"}</span>
       </div>
 
-      <div className="transport-card-dark__body">
+      <div className="transport-card-dark__body panel-body">
         {items.length === 0 ? (
           renderEmpty()
         ) : (
-          <div className="transport-card-dark__content" key={`${activeTab}-${currentIndex}`}>
+          <div
+            className="transport-card-dark__content"
+            key={`${activeTab}-${currentIndex}`}
+            data-testid={isPlane ? "panel-flights" : "panel-ships"}
+          >
             <div className="transport-card-dark__icon-container">
               <img
                 src={iconUrl}
                 alt={isPlane ? "avión" : "barco"}
-                className="transport-card-dark__main-icon"
+                className="transport-card-dark__main-icon panel-title-icon"
               />
             </div>
 
             <div className="transport-card-dark__info">
-              <div className="transport-card-dark__name">
+              <div className="transport-card-dark__name panel-item-title">
                 {isPlane ? (current as any).callsign || "Vuelo Desconocido" : (current as any).name || "Barco Desconocido"}
               </div>
 
               {(current as any).destination && (
-                <div className="transport-card-dark__destination">{(current as any).destination}</div>
+                <div className="transport-card-dark__destination panel-item-subtitle">{(current as any).destination}</div>
               )}
 
               <div className="transport-card-dark__meta-grid">
+                {renderDetail("Altitud", (current as any).altitude ? `${Math.round((current as any).altitude)} m` : "--")}
                 {renderDetail("Distancia", (current as any).distance_km ? `${(current as any).distance_km.toFixed(1)} km` : "--", true)}
                 {renderDetail("Velocidad", getSpeed(current) || "--")}
                 {renderDetail("Rumbo", getHeading(current) !== null ? `${getHeading(current)}°` : "--")}

--- a/dash-ui/src/components/dashboard/cards/WeatherCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/WeatherCard.tsx
@@ -12,6 +12,7 @@ type WeatherCardProps = {
   timezone?: string;
 };
 
+// Panel lateral de tiempo actual
 export const WeatherCard = ({
   temperatureLabel,
   feelsLikeLabel,
@@ -31,26 +32,26 @@ export const WeatherCard = ({
   const iconUrl = resolveWeatherIcon(normalizedCondition, { isNight });
 
   return (
-    <div className="weather-card-dark">
+    <div className="weather-card-dark" data-testid="panel-weather-current">
       <div className="weather-card-dark__header">
-        <img src={iconUrl} alt="" className="weather-card-dark__header-icon" />
-        <span className="weather-card-dark__title">Tiempo Actual</span>
+        <img src={iconUrl} alt="" className="weather-card-dark__header-icon panel-title-icon" />
+        <span className="weather-card-dark__title panel-title-text">Tiempo Actual</span>
       </div>
 
-      <div className="weather-card-dark__body">
+      <div className="weather-card-dark__body panel-body">
         <div className="weather-card-dark__main">
           <div className="weather-card-dark__icon-container">
             <img src={iconUrl} alt={normalizedCondition || "weather"} className="weather-card-dark__main-icon" />
           </div>
           <div className="weather-card-dark__temp-block">
-            <span className="weather-card-dark__temp">{tempValue}°</span>
+            <span className="weather-card-dark__temp panel-item-title">{tempValue}°</span>
             {feelsLikeLabel && (
-              <span className="weather-card-dark__feels">Sensación: {feelsLikeLabel}</span>
+              <span className="weather-card-dark__feels panel-item-subtitle">Sensación: {feelsLikeLabel}</span>
             )}
           </div>
         </div>
 
-        <div className="weather-card-dark__condition">{normalizedCondition || "Sin datos"}</div>
+        <div className="weather-card-dark__condition panel-item-title">{normalizedCondition || "Sin datos"}</div>
 
         <div className="weather-card-dark__metrics">
           <div className="weather-card-dark__metric">

--- a/dash-ui/src/components/dashboard/cards/WeatherForecastCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/WeatherForecastCard.tsx
@@ -18,6 +18,7 @@ type WeatherForecastCardProps = {
   unit: string;
 };
 
+// Panel lateral de predicción meteorológica
 export const WeatherForecastCard = ({ forecast }: WeatherForecastCardProps): JSX.Element | null => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -52,16 +53,16 @@ export const WeatherForecastCard = ({ forecast }: WeatherForecastCardProps): JSX
     : resolveWeatherIcon(day.condition, { isNight: false });
 
   return (
-    <div className="forecast-card-dark">
+    <div className="forecast-card-dark" data-testid="panel-weather-forecast">
       <div className="forecast-card-dark__header">
-        <img src="/icons/weather/day/partly-cloudy.svg" alt="" className="forecast-card-dark__header-icon" />
-        <span className="forecast-card-dark__title">Tiempo 7 Días</span>
+        <img src="/icons/weather/day/partly-cloudy.svg" alt="" className="forecast-card-dark__header-icon panel-title-icon" />
+        <span className="forecast-card-dark__title panel-title-text">Tiempo 7 Días</span>
       </div>
 
-      <div className="forecast-card-dark__body">
+      <div className="forecast-card-dark__body panel-body">
         <div className="forecast-card-dark__day">
-          <span className="forecast-card-dark__dayname">{day.dayName || "Hoy"}</span>
-          <span className="forecast-card-dark__date">{day.date}</span>
+          <span className="forecast-card-dark__dayname panel-item-title">{day.dayName || "Hoy"}</span>
+          <span className="forecast-card-dark__date panel-item-subtitle">{day.date}</span>
         </div>
 
         <div className="forecast-card-dark__icon-container">
@@ -69,17 +70,17 @@ export const WeatherForecastCard = ({ forecast }: WeatherForecastCardProps): JSX
         </div>
 
         <div className="forecast-card-dark__temps">
-          <span className="forecast-card-dark__max">
+          <span className="forecast-card-dark__max panel-item-title">
             {day.temperature.max !== null ? Math.round(day.temperature.max) : "--"}°
             <small>máx</small>
           </span>
-          <span className="forecast-card-dark__min">
+          <span className="forecast-card-dark__min panel-item-subtitle">
             {day.temperature.min !== null ? Math.round(day.temperature.min) : "--"}°
             <small>mín</small>
           </span>
         </div>
 
-        <div className="forecast-card-dark__condition">{day.condition}</div>
+        <div className="forecast-card-dark__condition panel-item-title">{day.condition}</div>
 
         {days.length > 1 && (
           <div className="forecast-card-dark__dots">

--- a/dash-ui/src/styles/global.css
+++ b/dash-ui/src/styles/global.css
@@ -56,6 +56,17 @@ body {
   display: none;
 }
 
+.auto-scroll-container,
+.panel-scroll-auto {
+  overflow-y: hidden;
+  position: relative;
+}
+
+.auto-scroll-container::-webkit-scrollbar,
+.panel-scroll-auto::-webkit-scrollbar {
+  display: none;
+}
+
 
 .app-shell {
   min-height: 100svh;


### PR DESCRIPTION
## Summary
- add stable data-testid hooks and panel classes across right-panel cards (clock, weather, forecast, transport, astronomy, APOD, santoral, news, history)
- implement focused Vitest coverage to validate expected icons, texts, and auto-scroll behaviors
- document manual checklist and add npm script for quick right-panel validation, hiding scrollbars for auto-scrolling areas

## Testing
- npm run test:right-panel

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367b3381d0832682ab0aa990d06f18)