### PR TITLE
Fix: harden WeatherLayer for MapTiler Weather and null-safe styling

### DIFF
--- a/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
+++ b/dash-ui/src/components/GeoScope/GeoScopeMap.tsx
@@ -1442,6 +1442,38 @@ export default function GeoScopeMap({
     };
   }, [config]);
 
+  // Configuración de la capa de alertas meteorológicas (GeoJSON)
+  useEffect(() => {
+    const weatherLayer = weatherLayerRef.current;
+    if (!weatherLayer || !config) {
+      return;
+    }
+
+    const configAsV2 = config as unknown as {
+      version?: number;
+      ui_global?: { weather_layers?: { alerts?: { enabled?: boolean; opacity?: number; provider?: string; refresh_minutes?: number } } };
+    };
+
+    const alertsConfig = configAsV2.ui_global?.weather_layers?.alerts;
+    const provider = alertsConfig?.provider ?? null;
+    const enabled = alertsConfig?.enabled ?? false;
+
+    weatherLayer.setProvider(provider);
+    weatherLayer.setEnabled(enabled);
+
+    if (typeof alertsConfig?.opacity === "number") {
+      weatherLayer.setOpacity(alertsConfig.opacity);
+    }
+
+    if (typeof alertsConfig?.refresh_minutes === "number") {
+      weatherLayer.setRefreshSeconds(alertsConfig.refresh_minutes * 60);
+    }
+
+    if (enabled && provider !== "maptiler_weather") {
+      void weatherLayer.ensureWeatherLayer();
+    }
+  }, [config]);
+
   // useEffect para gestionar la configuración del radar
   // RainViewer está deprecado: si el provider es "rainviewer", se fuerza a "maptiler_weather"
   // MapTiler Weather se gestiona directamente mediante GlobalRadarLayer cuando provider === "maptiler_weather"

--- a/dash-ui/src/components/GeoScope/layers/__tests__/WeatherLayer.test.ts
+++ b/dash-ui/src/components/GeoScope/layers/__tests__/WeatherLayer.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { FeatureCollection } from "geojson";
+
+import WeatherLayer from "../WeatherLayer";
+import { layerDiagnostics } from "../LayerDiagnostics";
+
+type MapSource = { type?: string; setData?: (data: FeatureCollection) => void };
+
+class FakeMap {
+  private source: MapSource | undefined;
+
+  asMap(): any {
+    return this as any;
+  }
+
+  getSource(): MapSource | undefined {
+    return this.source;
+  }
+
+  setSource(source: MapSource) {
+    this.source = source;
+  }
+
+  getLayer() {
+    return undefined;
+  }
+
+  addSource() {
+    // noop for tests
+  }
+
+  addLayer() {
+    // noop for tests
+  }
+}
+
+const SAMPLE_DATA: FeatureCollection = {
+  type: "FeatureCollection",
+  features: [
+    {
+      type: "Feature",
+      geometry: { type: "Point", coordinates: [0, 0] },
+      properties: {},
+    },
+  ],
+};
+
+describe("WeatherLayer defensive behaviour", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    debugSpy.mockRestore();
+  });
+
+  it("no registra errores cuando la source no existe", () => {
+    const recordErrorSpy = vi.spyOn(layerDiagnostics, "recordError");
+    const map = new FakeMap();
+    const layer = new WeatherLayer({ enabled: true, refreshSeconds: 0, provider: "cap_aemet" });
+
+    (layer as any).map = map.asMap();
+    layer.updateData(SAMPLE_DATA);
+
+    expect(recordErrorSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    recordErrorSpy.mockRestore();
+  });
+
+  it("salta updateData si la source no es GeoJSON sin disparar errores", () => {
+    const recordErrorSpy = vi.spyOn(layerDiagnostics, "recordError");
+    const map = new FakeMap();
+    map.setSource({ type: "raster" });
+
+    const layer = new WeatherLayer({ enabled: true, refreshSeconds: 0, provider: "cap_aemet" });
+    (layer as any).map = map.asMap();
+
+    layer.updateData(SAMPLE_DATA);
+
+    expect(recordErrorSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    recordErrorSpy.mockRestore();
+  });
+
+  it("desactiva comportamiento GeoJSON para provider maptiler_weather", () => {
+    const recordErrorSpy = vi.spyOn(layerDiagnostics, "recordError");
+    const layer = new WeatherLayer({ enabled: true, refreshSeconds: 0, provider: "maptiler_weather" });
+
+    layer.updateData(SAMPLE_DATA);
+
+    expect(recordErrorSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    recordErrorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add provider awareness and GeoJSON-only guards to WeatherLayer to avoid errors with MapTiler Weather
- sanitize incoming alert data and log defensively instead of erroring when sources are missing
- wire weather layer settings from config and add tests for missing/non-GeoJSON sources

## Testing
- npm test -- WeatherLayer

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367d6cff90832698856036aae24fb1)