### PR TITLE
Fix vitest typings and globals in RightPanel tests

### DIFF
--- a/dash-ui/src/components/RightPanel/right-panel.test.tsx
+++ b/dash-ui/src/components/RightPanel/right-panel.test.tsx
@@ -12,18 +12,18 @@ import { NewsCard } from "../dashboard/cards/NewsCard";
 import { HistoricalEventsCard } from "../dashboard/cards/HistoricalEventsCard";
 import "../../test/setup";
 
-const originalFetch = global.fetch;
-const originalRaf = global.requestAnimationFrame;
-const originalCancelRaf = global.cancelAnimationFrame;
+const originalFetch = globalThis.fetch;
+const originalRaf = globalThis.requestAnimationFrame;
+const originalCancelRaf = globalThis.cancelAnimationFrame;
 
 describe("Right panel components", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.stubGlobal("fetch", vi.fn(async () => ({ ok: false, json: async () => ({}) })) as any);
-    global.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
       return setTimeout(() => cb(performance.now()), 0) as unknown as number;
     }) as any;
-    global.cancelAnimationFrame = ((id: number) => clearTimeout(id)) as any;
+    globalThis.cancelAnimationFrame = ((id: number) => clearTimeout(id)) as any;
   });
 
   afterEach(() => {
@@ -34,10 +34,10 @@ describe("Right panel components", () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
     if (originalRaf) {
-      global.requestAnimationFrame = originalRaf;
+      globalThis.requestAnimationFrame = originalRaf;
     }
     if (originalCancelRaf) {
-      global.cancelAnimationFrame = originalCancelRaf;
+      globalThis.cancelAnimationFrame = originalCancelRaf;
     }
   });
 

--- a/dash-ui/types/vitest/index.d.ts
+++ b/dash-ui/types/vitest/index.d.ts
@@ -24,6 +24,11 @@ declare module "vitest" {
     mocked<T>(item: T, options?: { shallow?: boolean }): T;
     useFakeTimers(): void;
     useRealTimers(): void;
+    isFakeTimers(): boolean;
+    runOnlyPendingTimers(): void;
+    advanceTimersByTime(ms: number): void;
+    stubGlobal(name: string, value: unknown): void;
+    unstubAllGlobals(): void;
     setSystemTime(time: unknown): void;
     clearAllMocks(): void;
     resetAllMocks(): void;


### PR DESCRIPTION
## Summary
- add missing Vitest helper typings for timer and global stubbing utilities
- update RightPanel test to use globalThis helpers for fetch and animation frame setup

## Testing
- npm run test:right-panel


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69367ed7fcd08326bb5b594b8c65196f)