### PR TITLE
Fix: use configured Vila-real location for Meteoblue and add weather debug endpoint

### DIFF
--- a/backend/default_config.json
+++ b/backend/default_config.json
@@ -278,6 +278,15 @@
     "longitude": -0.1014,
     "timezone": "Europe/Madrid"
   },
+  "location": {
+    "name": "Vila-real",
+    "lat": 39.9378,
+    "lon": -0.1014
+  },
+  "weather": {
+    "enabled": true,
+    "provider": "meteoblue"
+  },
   "calendar": {
     "enabled": true,
     "source": "ics",

--- a/backend/models.py
+++ b/backend/models.py
@@ -947,6 +947,21 @@ class EphemeridesTopLevelConfig(BaseModel):
     timezone: str = Field(default="Europe/Madrid", min_length=1)
 
 
+class LocationConfig(BaseModel):
+    """Ubicación principal configurada para el dispositivo."""
+
+    name: Optional[str] = None
+    lat: float
+    lon: float
+
+
+class WeatherConfig(BaseModel):
+    """Configuración global de clima."""
+
+    enabled: bool = True
+    provider: Literal["meteoblue", "openweathermap"] = "meteoblue"
+
+
 class OpenSkyOAuth2Config(BaseModel):
     """Configuración OAuth2 para OpenSky."""
     client_id: Optional[str] = Field(default=None, max_length=512)
@@ -1015,6 +1030,8 @@ class AppConfig(BaseModel):
     news: Optional[NewsTopLevelConfig] = None
     ephemerides: Optional[EphemeridesTopLevelConfig] = None
     calendar: Optional[CalendarConfig] = None
+    location: Optional[LocationConfig] = None
+    weather: Optional[WeatherConfig] = None
     harvest: HarvestConfig = Field(default_factory=HarvestConfig)
     saints: SaintsConfig = Field(default_factory=SaintsConfig)
     opensky: Optional[OpenSkyTopLevelConfig] = None


### PR DESCRIPTION
## Summary
- add location and weather configuration blocks with defaults derived from ephemerides and expose them via the AppConfig schema
- update weather routing to resolve coordinates safely, respect configured provider, and add a Meteoblue debug endpoint with trimmed raw output
- refresh the default configuration to include Vila-real location/weather defaults and persist migrations automatically

## Testing
- python -m compileall backend/routers/weather.py backend/config_manager.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936914ead908326bfe903c519018740)