### PR TITLE
Fix transport card typing and scroll ref

### DIFF
--- a/dash-ui/src/components/common/AutoScrollContainer.tsx
+++ b/dash-ui/src/components/common/AutoScrollContainer.tsx
@@ -16,7 +16,7 @@ export const AutoScrollContainer: React.FC<AutoScrollContainerProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const [offset, setOffset] = useState(0);
-  const offsetRef = useRef(0);
+  const offsetRef = useRef<number>(0);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/dash-ui/src/components/dashboard/cards/TransportCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/TransportCard.tsx
@@ -5,9 +5,13 @@ type Aircraft = {
   callsign?: string | null;
   origin?: string | null;
   destination?: string | null;
+  altitude?: number | null;
   altitude_ft?: number | null;
+  alt?: number | null;
   speed_kts?: number | null;
+  speed?: number | null;
   heading_deg?: number | null;
+  heading?: number | null;
   lat?: number;
   lon?: number;
   distance_km?: number | null;


### PR DESCRIPTION
## Summary
- allow transport aircraft data to include raw altitude, speed, and heading fields used in tests
- type the auto scroll offset ref explicitly to avoid nullability errors

## Testing
- npm run test:right-panel

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693692d292e88326b181bb5540098774)