### PR TITLE
Handle null offset ref in auto scroll container

### DIFF
--- a/dash-ui/src/components/common/AutoScrollContainer.tsx
+++ b/dash-ui/src/components/common/AutoScrollContainer.tsx
@@ -48,7 +48,8 @@ export const AutoScrollContainer: React.FC<AutoScrollContainerProps> = ({
       }
 
       const deltaPx = (speed * delta) / 1000;
-      const nextOffset = offsetRef.current + deltaPx;
+      const currentOffset = offsetRef.current ?? 0;
+      const nextOffset = currentOffset + deltaPx;
 
       if (nextOffset >= maxOffset) {
         offsetRef.current = 0;


### PR DESCRIPTION
## Summary
- add null-safe handling when computing the next offset in AutoScrollContainer

## Testing
- npm run build:full

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693693766fa48326a44779b40bde18d8)