### PR TITLE
Feat: overhaul weather, transport and NASA APOD panels

### DIFF
--- a/backend/services/weather_service.py
+++ b/backend/services/weather_service.py
@@ -359,6 +359,7 @@ class WeatherService:
                 "felt_temperature": current["felt_temperature"],
                 "condition": current["condition"],
                 "icon": current["icon"],
+                "pictocode": current.get("pictocode"),
                 "summary": current["condition"],
                 "daily": forecast,
                 "days": forecast,  # Alias para compatibilidad

--- a/dash-ui/src/components/dashboard/cards/ApodCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/ApodCard.tsx
@@ -29,7 +29,8 @@ export const ApodCard = ({ data }: ApodCardProps) => {
     }
 
     const isVideo = data.media_type === "video";
-    const imageUrl = isVideo ? (data.thumbnail_url || "") : data.url;
+    const isImage = data.media_type === "image";
+    const imageUrl = isImage ? data.url : data.thumbnail_url || "";
     const hasImage = Boolean(imageUrl);
 
     const embedUrl = useMemo(() => {
@@ -81,19 +82,19 @@ export const ApodCard = ({ data }: ApodCardProps) => {
                                 title={data.title}
                             />
                         </div>
-                    ) : hasImage ? (
+                    ) : isImage && hasImage ? (
                         <img src={imageUrl} alt={data.title} className="apod-card-dark__media-img" />
                     ) : (
                         <div className="apod-card-dark__media-placeholder" aria-hidden>
                             <span className="apod-card-dark__media-icon">🎞️</span>
-                            <span className="apod-card-dark__media-label">Contenido en vídeo</span>
+                            <span className="apod-card-dark__media-label">Contenido no compatible</span>
                         </div>
                     )}
                 </div>
 
                 <h1 className="apod-card-dark__title">{data.title}</h1>
 
-                <AutoScrollContainer className="apod-card-dark__desc">
+                <AutoScrollContainer className="apod-card-dark__desc" speed={8} pauseAtEndMs={3600}>
                     <p>{data.explanation}</p>
                 </AutoScrollContainer>
 

--- a/dash-ui/src/components/dashboard/cards/TransportCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/TransportCard.tsx
@@ -1,41 +1,45 @@
 import React, { useEffect, useMemo } from "react";
+import { AutoScrollContainer } from "../../common/AutoScrollContainer";
+import { PlaneIcon, ShipIcon } from "../../icons/TransportIcons";
 
 type Aircraft = {
-  id?: string;
-  callsign?: string | null;
-  origin?: string | null;
-  destination?: string | null;
-  altitude?: number | null;
-  altitude_ft?: number | null;
-  alt?: number | null;
-  speed_kts?: number | null;
-  speed?: number | null;
-  heading_deg?: number | null;
-  heading?: number | null;
-  lat?: number;
-  lon?: number;
-  distance_km?: number | null;
-  airline?: string | null;
-  aircraft_type?: string | null;
+   id?: string;
+   callsign?: string | null;
+   origin?: string | null;
+   destination?: string | null;
+   altitude?: number | null;
+   altitude_ft?: number | null;
+   alt?: number | null;
+   speed_kts?: number | null;
+   speed?: number | null;
+   heading_deg?: number | null;
+   heading?: number | null;
+   lat?: number;
+   lon?: number;
+   distance_km?: number | null;
+   airline?: string | null;
+   aircraft_type?: string | null;
 };
 
 type Ship = {
-  id?: string;
-  name?: string;
-  mmsi?: string;
-  type?: string;
-  destination?: string | null;
-  speed?: number | null;
-  heading?: number | null;
-  distance_km?: number | null;
-  lat?: number;
-  lon?: number;
+   id?: string;
+   name?: string;
+   mmsi?: string;
+   type?: string;
+   destination?: string | null;
+   speed?: number | null;
+   speed_kts?: number | null;
+   heading?: number | null;
+   heading_deg?: number | null;
+   distance_km?: number | null;
+   lat?: number;
+   lon?: number;
 };
 
 type TransportData = {
-  aircraft?: Aircraft[];
-  planes?: Aircraft[]; // Legacy key used previously
-  ships?: Ship[];
+   aircraft?: Aircraft[];
+   planes?: Aircraft[]; // Legacy key used previously
+   ships?: Ship[];
 };
 
 type TransportCardProps = {
@@ -54,56 +58,53 @@ const normalizeNumber = (value: unknown): number | null =>
   typeof value === "number" && Number.isFinite(value) ? value : null;
 
 const normalizeAircraft = (data?: TransportData | null): Aircraft[] => {
-  const items = (data?.aircraft ?? data?.planes ?? []) as Aircraft[];
-  return items
-    .filter(item => item && normalizeNumber(item.lat) !== null && normalizeNumber(item.lon) !== null)
-    .map(item => {
-      const altitudeFt = normalizeNumber(item.altitude_ft);
-      const altitudeMeters = normalizeNumber((item as any).altitude ?? (item as any).alt);
-      const computedAltitudeFt =
-        altitudeFt !== null
-          ? altitudeFt
-          : altitudeMeters !== null
-            ? altitudeMeters * 3.28084
-            : null;
-
-      const speedKts = normalizeNumber(item.speed_kts);
-      const rawSpeed = normalizeNumber((item as any).speed ?? (item as any).spd);
-      const computedSpeedKts = speedKts !== null ? speedKts : rawSpeed !== null ? rawSpeed * 1.94384 : null;
-
-      const heading = normalizeNumber(item.heading_deg ?? (item as any).heading ?? (item as any).hdg);
-
-      return {
-        id: item.id || (item as any).ic || (item as any).icao24 || item.callsign || `${item.lat}-${item.lon}`,
-        callsign: item.callsign ?? (item as any).cs ?? (item as any).flight ?? null,
-        origin: item.origin ?? (item as any).from ?? null,
-        destination: item.destination ?? (item as any).dest ?? null,
-        altitude_ft: computedAltitudeFt !== null ? Math.round(computedAltitudeFt) : null,
-        speed_kts: computedSpeedKts !== null ? Math.round(computedSpeedKts) : null,
-        heading_deg: heading !== null ? Math.round(heading) : null,
-        lat: item.lat,
-        lon: item.lon,
-        distance_km: normalizeNumber(item.distance_km ?? (item as any).distance),
-        airline: item.airline ?? (item as any).co ?? null,
-        aircraft_type: (item as any).aircraft_type ?? (item as any).type ?? null,
-      };
-    });
+   const items = (data?.aircraft ?? data?.planes ?? []) as Aircraft[];
+   return items
+     .filter(item => item && normalizeNumber(item.lat) !== null && normalizeNumber(item.lon) !== null)
+     .map(item => {
+       const altitudeFt = normalizeNumber(item.altitude_ft);
+       const altitudeMeters = normalizeNumber((item as any).altitude ?? (item as any).alt);
+       const computedAltitudeFt =
+         altitudeFt !== null
+           ? altitudeFt
+           : altitudeMeters !== null
+             ? altitudeMeters * 3.28084
+             : null;
+ 
+       const speedKts = normalizeNumber(item.speed_kts ?? item.speed);
+       const heading = normalizeNumber(item.heading_deg ?? (item as any).heading ?? (item as any).hdg);
+ 
+       return {
+         id: item.id || (item as any).ic || (item as any).icao24 || item.callsign || `${item.lat}-${item.lon}`,
+         callsign: item.callsign ?? (item as any).cs ?? (item as any).flight ?? null,
+         origin: item.origin ?? (item as any).from ?? null,
+         destination: item.destination ?? (item as any).dest ?? null,
+         altitude_ft: computedAltitudeFt !== null ? Math.round(computedAltitudeFt) : null,
+         speed_kts: speedKts !== null ? Math.round(speedKts) : null,
+         heading_deg: heading !== null ? Math.round(heading) : null,
+         lat: item.lat,
+         lon: item.lon,
+         distance_km: normalizeNumber(item.distance_km ?? (item as any).distance),
+         airline: item.airline ?? (item as any).co ?? null,
+         aircraft_type: (item as any).aircraft_type ?? (item as any).type ?? null,
+       };
+     });
 };
 
 const normalizeShips = (data?: TransportData | null): Ship[] => {
-  const items = (data?.ships ?? []) as any[];
-  return items
-    .filter(item => item && normalizeNumber(item.lat) !== null && normalizeNumber(item.lon) !== null)
-    .map(item => ({
-      id: item.id || item.mmsi || item.name || `${item.lat}-${item.lon}`,
-      name: item.name ?? item.vessel ?? item.mmsi ?? "",
-      mmsi: item.mmsi,
-      type: item.type ?? item.vessel_type ?? "",
-      destination: item.destination ?? item.dest ?? null,
-      speed: normalizeNumber(item.speed ?? item.spd),
-      heading: normalizeNumber(item.heading ?? item.hdg),
-      distance_km: normalizeNumber(item.distance_km ?? item.distance),
-    }));
+   const items = (data?.ships ?? []) as any[];
+   return items
+     .filter(item => item && normalizeNumber(item.lat) !== null && normalizeNumber(item.lon) !== null)
+     .map(item => ({
+       id: item.id || item.mmsi || item.name || `${item.lat}-${item.lon}`,
+       name: item.name ?? item.vessel ?? item.mmsi ?? "",
+       mmsi: item.mmsi,
+       type: item.type ?? item.vessel_type ?? "",
+       destination: item.destination ?? item.dest ?? null,
+       speed: normalizeNumber(item.speed_kts ?? item.speed ?? item.spd),
+       heading: normalizeNumber(item.heading_deg ?? item.heading ?? item.hdg),
+       distance_km: normalizeNumber(item.distance_km ?? item.distance),
+     }));
 };
 
 const formatNumber = (value: number | null | undefined, suffix: string) =>
@@ -118,110 +119,108 @@ const renderDetail = (label: string, value: string) => (
 
 // Panel lateral de transporte: aviones y barcos cercanos
 export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
-  const aircraft = useMemo(() => normalizeAircraft(data), [data]);
-  const ships = useMemo(() => normalizeShips(data), [data]);
-  const hasAnyTransport = aircraft.length > 0 || ships.length > 0;
-
-  useEffect(() => {
-    if (IS_DEV) {
-      console.debug("[TransportCard] ships=", ships.length, "aircraft=", aircraft.length, { ships, aircraft });
-    }
-  }, [aircraft, ships]);
-
-  return (
-    <div className="transport-card-dark" data-testid="panel-transport">
-      <div className="transport-card-dark__header">
-        <img src="/icons/transport/plane.svg" alt="" className="transport-card-dark__header-icon panel-title-icon" />
-        <span className="transport-card-dark__title panel-title-text">Transporte cercano</span>
-      </div>
-
-      <div className="transport-card-dark__sections panel-body">
-        <div className="transport-card-dark__section" data-testid="panel-flights">
-          <div className="transport-card-dark__section-header">
-            <img src="/icons/transport/plane.svg" alt="" className="transport-card-dark__section-icon panel-title-icon" />
-            <span className="transport-card-dark__section-title">Vuelos cercanos</span>
-          </div>
-          {aircraft.length === 0 ? (
-            <div className="transport-card-dark__empty">
-              <span className="transport-card-dark__empty-text">Sin vuelos cercanos</span>
-            </div>
-          ) : (
-            <div className="transport-card-dark__list">
-              {aircraft.map(flight => {
-                const route = formatRoute(flight.origin, flight.destination);
-                return (
-                  <div key={flight.id} className="transport-card-dark__item">
-                    <div className="transport-card-dark__item-header">
-                      <div className="transport-card-dark__name panel-item-title">
-                        {flight.callsign || "Vuelo desconocido"}
-                      </div>
-                      <div className="transport-card-dark__badge">
-                        {flight.distance_km !== null && flight.distance_km !== undefined
-                          ? `${flight.distance_km.toFixed(1)} km`
-                          : "--"}
-                      </div>
-                    </div>
-                    {route && <div className="transport-card-dark__subtitle panel-item-subtitle">{route}</div>}
-                    <div className="transport-card-dark__meta-grid">
-                      {renderDetail("Altitud", formatNumber(flight.altitude_ft, " ft"))}
-                      {renderDetail("Velocidad", formatNumber(flight.speed_kts, " kt"))}
-                      {renderDetail("Rumbo", formatNumber(flight.heading_deg, "°"))}
-                      {renderDetail("Modelo", flight.aircraft_type || flight.airline || "--")}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </div>
-
-        <div className="transport-card-dark__section" data-testid="panel-ships">
-          <div className="transport-card-dark__section-header">
-            <img src="/icons/transport/ship.svg" alt="" className="transport-card-dark__section-icon panel-title-icon" />
-            <span className="transport-card-dark__section-title">Barcos cercanos</span>
-          </div>
-          {ships.length === 0 ? (
-            <div className="transport-card-dark__empty">
-              <span className="transport-card-dark__empty-text">Sin barcos cercanos</span>
-            </div>
-          ) : (
-            <div className="transport-card-dark__list">
-              {ships.map(ship => (
-                <div key={ship.id} className="transport-card-dark__item">
-                  <div className="transport-card-dark__item-header">
-                    <div className="transport-card-dark__name panel-item-title">
-                      {ship.name || ship.mmsi || "Barco desconocido"}
-                    </div>
-                    <div className="transport-card-dark__badge">
-                      {ship.distance_km !== null && ship.distance_km !== undefined
-                        ? `${ship.distance_km.toFixed(1)} km`
-                        : "--"}
-                    </div>
-                  </div>
-                  {ship.destination && (
-                    <div className="transport-card-dark__subtitle panel-item-subtitle">{ship.destination}</div>
-                  )}
-                  <div className="transport-card-dark__meta-grid">
-                    {renderDetail("Velocidad", formatNumber(ship.speed, " kn"))}
-                    {renderDetail("Rumbo", formatNumber(ship.heading, "°"))}
-                    {renderDetail("Tipo", ship.type || "--")}
-                    {renderDetail("MMSI", ship.mmsi || "--")}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {!hasAnyTransport && (
-          <div className="transport-card-dark__empty-all">
-            <img src="/icons/transport/plane.svg" alt="" className="transport-card-dark__empty-icon panel-title-icon" />
-            <span className="transport-card-dark__empty-text">No hay barcos ni vuelos cercanos en este momento</span>
-          </div>
-        )}
-      </div>
-
-      <style>{`
+   const aircraft = useMemo(() => normalizeAircraft(data), [data]);
+   const ships = useMemo(() => normalizeShips(data), [data]);
+   const hasAnyTransport = aircraft.length > 0 || ships.length > 0;
+ 
+   useEffect(() => {
+     if (IS_DEV) {
+       console.debug("[TransportCard] ships=", ships.length, "aircraft=", aircraft.length, { ships, aircraft });
+     }
+   }, [aircraft, ships]);
+ 
+   const renderShips = ships.length > 0 && (
+     <section className="transport-card-dark__section" data-testid="panel-ships">
+       <div className="transport-card-dark__section-header">
+         <div className="transport-card-dark__section-icon panel-title-icon"><ShipIcon size={38} /></div>
+         <span className="transport-card-dark__section-title">Barcos cercanos</span>
+       </div>
+       <div className="transport-card-dark__list">
+         {ships.map(ship => (
+           <div key={ship.id} className="transport-card-dark__item">
+             <div className="transport-card-dark__item-header">
+               <div className="transport-card-dark__name panel-item-title">
+                 {ship.name || ship.mmsi || "Barco desconocido"}
+               </div>
+               <div className="transport-card-dark__badge">
+                 {ship.distance_km !== null && ship.distance_km !== undefined
+                   ? `${ship.distance_km.toFixed(1)} km`
+                   : "--"}
+               </div>
+             </div>
+             {ship.destination && (
+               <div className="transport-card-dark__subtitle panel-item-subtitle">{ship.destination}</div>
+             )}
+             <div className="transport-card-dark__meta-grid">
+               {renderDetail("Velocidad", formatNumber(ship.speed ?? ship.speed_kts, " kn"))}
+               {renderDetail("Rumbo", formatNumber(ship.heading, "°"))}
+               {renderDetail("Tipo", ship.type || "--")}
+               {renderDetail("MMSI", ship.mmsi || "--")}
+             </div>
+           </div>
+         ))}
+       </div>
+     </section>
+   );
+ 
+   const renderAircraft = aircraft.length > 0 && (
+     <section className="transport-card-dark__section" data-testid="panel-flights">
+       <div className="transport-card-dark__section-header">
+         <div className="transport-card-dark__section-icon panel-title-icon"><PlaneIcon size={38} /></div>
+         <span className="transport-card-dark__section-title">Vuelos cercanos</span>
+       </div>
+       <div className="transport-card-dark__list">
+         {aircraft.map(flight => {
+           const route = formatRoute(flight.origin, flight.destination);
+           return (
+             <div key={flight.id} className="transport-card-dark__item">
+               <div className="transport-card-dark__item-header">
+                 <div className="transport-card-dark__name panel-item-title">
+                   {flight.callsign || "Vuelo desconocido"}
+                 </div>
+                 <div className="transport-card-dark__badge">
+                   {flight.distance_km !== null && flight.distance_km !== undefined
+                     ? `${flight.distance_km.toFixed(1)} km`
+                     : "--"}
+                 </div>
+               </div>
+               {route && <div className="transport-card-dark__subtitle panel-item-subtitle">{route}</div>}
+               <div className="transport-card-dark__meta-grid">
+                 {renderDetail("Altitud", formatNumber(flight.altitude_ft, " ft"))}
+                 {renderDetail("Velocidad", formatNumber(flight.speed_kts, " kt"))}
+                 {renderDetail("Rumbo", formatNumber(flight.heading_deg, "°"))}
+                 {renderDetail("Info", flight.aircraft_type || flight.airline || "--")}
+               </div>
+             </div>
+           );
+         })}
+       </div>
+     </section>
+   );
+ 
+   return (
+     <div className="transport-card-dark" data-testid="panel-transport">
+       <div className="transport-card-dark__header">
+         <div className="transport-card-dark__header-icon panel-title-icon">
+           <PlaneIcon size={54} />
+         </div>
+         <span className="transport-card-dark__title panel-title-text">Transporte cercano</span>
+       </div>
+ 
+       <AutoScrollContainer speed={8} pauseAtEndMs={4000} className="transport-card-dark__scroller">
+         <div className="transport-card-dark__stack">
+           {renderShips}
+           {renderAircraft}
+           {!hasAnyTransport && (
+             <div className="transport-card-dark__empty-all">
+               <PlaneIcon size={72} className="transport-card-dark__empty-icon panel-title-icon" />
+               <span className="transport-card-dark__empty-text">No hay barcos ni vuelos cercanos en este momento</span>
+             </div>
+           )}
+         </div>
+       </AutoScrollContainer>
+ 
+       <style>{`
         .transport-card-dark {
           display: flex;
           flex-direction: column;
@@ -229,10 +228,13 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
           width: 100%;
           padding: 1rem;
           box-sizing: border-box;
-          background: linear-gradient(135deg, #1e3a5f 0%, #0f172a 100%);
+          background: linear-gradient(135deg, rgba(15, 23, 42, 0.9), rgba(14, 165, 233, 0.1));
           color: white;
           border-radius: 1rem;
-          gap: 1rem;
+          border: 1px solid rgba(255,255,255,0.08);
+          backdrop-filter: blur(12px);
+          box-shadow: 0 18px 45px rgba(0, 0, 0, 0.45);
+          gap: 0.5rem;
         }
         .transport-card-dark__header {
           display: flex;
@@ -240,27 +242,34 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
           gap: 1rem;
           margin-bottom: 0.25rem;
           padding-bottom: 0.5rem;
-          border-bottom: 1px solid rgba(255,255,255,0.1);
+          border-bottom: 1px solid rgba(255,255,255,0.12);
         }
         .transport-card-dark__header-icon {
           width: 64px;
           height: 64px;
-          object-fit: contain;
-          filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+          display: grid;
+          place-items: center;
+          background: rgba(255,255,255,0.06);
+          border-radius: 16px;
+          border: 1px solid rgba(255,255,255,0.12);
+          box-shadow: inset 0 0 0 1px rgba(255,255,255,0.06);
         }
         .transport-card-dark__title {
           font-size: 1.8rem;
           font-weight: 800;
           text-transform: uppercase;
-          letter-spacing: 0.1em;
+          letter-spacing: 0.08em;
           text-shadow: 0 2px 4px rgba(0,0,0,0.5);
         }
-        .transport-card-dark__sections {
+        .transport-card-dark__scroller {
           flex: 1;
+          width: 100%;
+        }
+        .transport-card-dark__stack {
           display: flex;
           flex-direction: column;
-          gap: 1rem;
-          overflow: hidden;
+          gap: 0.75rem;
+          padding-right: 0.25rem;
         }
         .transport-card-dark__section {
           background: rgba(255,255,255,0.05);
@@ -270,6 +279,7 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
           display: flex;
           flex-direction: column;
           gap: 0.75rem;
+          box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
         }
         .transport-card-dark__section-header {
           display: flex;
@@ -279,10 +289,14 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
         .transport-card-dark__section-icon {
           width: 40px;
           height: 40px;
-          object-fit: contain;
+          display: grid;
+          place-items: center;
+          background: rgba(255,255,255,0.08);
+          border-radius: 12px;
+          border: 1px solid rgba(255,255,255,0.12);
         }
         .transport-card-dark__section-title {
-          font-size: 1.3rem;
+          font-size: 1.2rem;
           font-weight: 800;
           text-transform: uppercase;
           letter-spacing: 0.05em;
@@ -291,8 +305,6 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
           display: flex;
           flex-direction: column;
           gap: 0.75rem;
-          max-height: 18rem;
-          overflow: hidden;
         }
         .transport-card-dark__item {
           display: flex;
@@ -311,7 +323,7 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
           gap: 0.5rem;
         }
         .transport-card-dark__name {
-          font-size: 1.4rem;
+          font-size: 1.25rem;
           font-weight: 800;
           text-transform: uppercase;
         }
@@ -319,10 +331,10 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
           background: rgba(56,189,248,0.18);
           border: 1px solid rgba(56,189,248,0.35);
           color: #9ae6ff;
-          padding: 0.3rem 0.6rem;
+          padding: 0.25rem 0.55rem;
           border-radius: 999px;
           font-weight: 700;
-          min-width: 80px;
+          min-width: 74px;
           text-align: center;
         }
         .transport-card-dark__subtitle {
@@ -343,6 +355,7 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
           border-radius: 0.6rem;
           border: 1px solid rgba(255,255,255,0.08);
           font-size: 1rem;
+          box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
         }
         .transport-card-dark__detail-label {
           font-size: 0.75rem;
@@ -353,24 +366,15 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
         }
         .transport-card-dark__detail-value {
           font-weight: 800;
-          font-size: 1.15rem;
+          font-size: 1.05rem;
         }
-        .transport-card-dark__empty,
         .transport-card-dark__empty-all {
           display: flex;
           align-items: center;
           justify-content: center;
-          gap: 0.5rem;
-          opacity: 0.8;
-          text-align: center;
-        }
-        .transport-card-dark__empty-text {
-          font-size: 1.1rem;
-          font-weight: 700;
-        }
-        .transport-card-dark__empty-all {
           flex-direction: column;
-          padding: 0.75rem;
+          gap: 0.5rem;
+          padding: 1rem;
           border-radius: 0.75rem;
           background: rgba(255,255,255,0.06);
           border: 1px solid rgba(255,255,255,0.1);
@@ -381,13 +385,19 @@ export const TransportCard = ({ data }: TransportCardProps): JSX.Element => {
           object-fit: contain;
           animation: pulse-dark 2s ease-in-out infinite;
         }
+        .transport-card-dark__empty-text {
+          font-size: 1.1rem;
+          font-weight: 700;
+          text-align: center;
+          opacity: 0.9;
+        }
         @keyframes pulse-dark {
           0%, 100% { opacity: 0.7; transform: scale(1); }
           50% { opacity: 1; transform: scale(1.04); }
         }
       `}</style>
-    </div>
-  );
-};
-
-export default TransportCard;
+     </div>
+   );
+ };
+ 
+ export default TransportCard;

--- a/dash-ui/src/components/dashboard/cards/WeatherCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/WeatherCard.tsx
@@ -1,10 +1,14 @@
 import { useMemo } from "react";
-import { resolveWeatherIcon, sanitizeWeatherCondition } from "../../../utils/weather";
+import { formatWeatherKindLabel, sanitizeWeatherCondition } from "../../../utils/weather";
+import type { WeatherKind } from "../../../types/weather";
+import { WeatherIcon } from "../../weather/WeatherIcon";
+import { getPanelTimeOfDay, getWeatherBackgroundClass } from "../../../theme/panelTheme";
 
 type WeatherCardProps = {
   temperatureLabel: string;
   feelsLikeLabel: string | null;
   condition: string | null;
+  kind?: WeatherKind;
   humidity: number | null;
   wind: number | null;
   rain: number | null;
@@ -17,6 +21,7 @@ export const WeatherCard = ({
   temperatureLabel,
   feelsLikeLabel,
   condition,
+  kind,
   humidity,
   wind,
   rain
@@ -28,20 +33,23 @@ export const WeatherCard = ({
     [condition, numericTemp]
   );
   const now = new Date();
-  const isNight = now.getHours() < 6 || now.getHours() >= 21;
-  const iconUrl = resolveWeatherIcon(normalizedCondition, { isNight });
+  const timeOfDay = getPanelTimeOfDay(now);
+  const backgroundClass = getWeatherBackgroundClass(kind, timeOfDay);
+  const label = formatWeatherKindLabel(kind || "unknown", normalizedCondition);
 
   return (
-    <div className="weather-card-dark" data-testid="panel-weather-current">
+    <div className={`weather-card-dark ${backgroundClass}`} data-testid="panel-weather-current">
       <div className="weather-card-dark__header">
-        <img src={iconUrl} alt="" className="weather-card-dark__header-icon panel-title-icon" />
+        <div className="weather-card-dark__header-icon panel-title-icon">
+          <WeatherIcon kind={kind || "unknown"} size={48} />
+        </div>
         <span className="weather-card-dark__title panel-title-text">Tiempo Actual</span>
       </div>
 
       <div className="weather-card-dark__body panel-body">
         <div className="weather-card-dark__main">
           <div className="weather-card-dark__icon-container">
-            <img src={iconUrl} alt={normalizedCondition || "weather"} className="weather-card-dark__main-icon" />
+            <WeatherIcon kind={kind || "unknown"} size={110} className="weather-card-dark__main-icon" />
           </div>
           <div className="weather-card-dark__temp-block">
             <span className="weather-card-dark__temp panel-item-title">{tempValue}°</span>
@@ -51,7 +59,7 @@ export const WeatherCard = ({
           </div>
         </div>
 
-        <div className="weather-card-dark__condition panel-item-title">{normalizedCondition || "Sin datos"}</div>
+        <div className="weather-card-dark__condition panel-item-title">{label}</div>
 
         <div className="weather-card-dark__metrics">
           <div className="weather-card-dark__metric">
@@ -77,10 +85,13 @@ export const WeatherCard = ({
           flex-direction: column;
           height: 100%;
           width: 100%;
-          padding: 0.5rem;
+          padding: 0.75rem;
           box-sizing: border-box;
-          background: linear-gradient(135deg, #0c4a6e 0%, #0f172a 100%);
           color: white;
+          border-radius: 1rem;
+          border: 1px solid rgba(255,255,255,0.08);
+          box-shadow: 0 18px 40px rgba(0,0,0,0.35);
+          backdrop-filter: blur(10px);
         }
         .weather-card-dark__header {
           display: flex;
@@ -89,10 +100,14 @@ export const WeatherCard = ({
           margin-bottom: 0.25rem;
         }
         .weather-card-dark__header-icon {
-          width: 48px;
-          height: 48px;
-          object-fit: contain;
-          filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+          width: 52px;
+          height: 52px;
+          display: grid;
+          place-items: center;
+          background: rgba(255,255,255,0.08);
+          border-radius: 14px;
+          border: 1px solid rgba(255,255,255,0.14);
+          box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
         }
         .weather-card-dark__title {
           font-size: 1.4rem;
@@ -108,7 +123,7 @@ export const WeatherCard = ({
           align-items: center;
           justify-content: center;
           gap: 0.35rem;
-          padding: 0.25rem 0.5rem;
+          padding: 0.35rem 0.5rem;
         }
         .weather-card-dark__main {
           display: flex;
@@ -119,6 +134,7 @@ export const WeatherCard = ({
         .weather-card-dark__icon-container {
           width: 110px;
           height: 110px;
+          filter: drop-shadow(0 10px 28px rgba(0,0,0,0.35));
         }
         .weather-card-dark__main-icon {
           width: 100%;
@@ -147,6 +163,7 @@ export const WeatherCard = ({
           font-weight: 700;
           text-transform: capitalize;
           text-align: center;
+          text-shadow: 0 6px 20px rgba(0,0,0,0.28);
         }
         .weather-card-dark__metrics {
           display: flex;
@@ -163,6 +180,7 @@ export const WeatherCard = ({
           background: rgba(255,255,255,0.1);
           border-radius: 0.4rem;
           min-width: 60px;
+          box-shadow: inset 0 1px 0 rgba(255,255,255,0.08);
         }
         .weather-card-dark__metric-label {
           font-size: 0.7rem;

--- a/dash-ui/src/components/icons/TransportIcons.tsx
+++ b/dash-ui/src/components/icons/TransportIcons.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+
+const baseProps = (size = 40, className?: string) => ({
+  width: size,
+  height: size,
+  viewBox: "0 0 160 160",
+  fill: "none",
+  xmlns: "http://www.w3.org/2000/svg",
+  className,
+});
+
+export const PlaneIcon: React.FC<{ size?: number; className?: string }> = ({ size = 40, className }) => (
+  <svg {...baseProps(size, className)}>
+    <defs>
+      <linearGradient id="planeBody" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="#9ce1ff" />
+        <stop offset="100%" stopColor="#2563eb" />
+      </linearGradient>
+      <linearGradient id="planeWing" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="#eff6ff" />
+        <stop offset="100%" stopColor="#c7d2fe" />
+      </linearGradient>
+    </defs>
+    <g filter="url(#shadow-plane)">
+      <path d="M70 14c6-4 14-4 20 0l10 92-40-2 10-90z" fill="url(#planeBody)" />
+      <path d="M40 104l36-12 12 0 32 12-44 12z" fill="url(#planeWing)" />
+      <path d="M70 108l-20 34c-1 2 0 4 2 4h12l18-36-12-2z" fill="#bfdbfe" />
+      <path d="M90 110l20 34c1 2 4 2 5 0l6-10c1-2 0-4-2-5l-27-21-2 2z" fill="#bfdbfe" />
+      <circle cx="80" cy="30" r="10" fill="#1d4ed8" opacity="0.8" />
+    </g>
+    <filter id="shadow-plane" x="-30" y="-20" width="220" height="220" colorInterpolationFilters="sRGB">
+      <feGaussianBlur stdDeviation="6" result="blur" />
+      <feOffset dx="0" dy="6" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </svg>
+);
+
+export const ShipIcon: React.FC<{ size?: number; className?: string }> = ({ size = 40, className }) => (
+  <svg {...baseProps(size, className)}>
+    <defs>
+      <linearGradient id="shipHull" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="#60a5fa" />
+        <stop offset="100%" stopColor="#1e40af" />
+      </linearGradient>
+      <linearGradient id="shipDeck" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stopColor="#f8fafc" />
+        <stop offset="100%" stopColor="#cbd5e1" />
+      </linearGradient>
+    </defs>
+    <g filter="url(#shadow-ship)">
+      <path d="M36 100h88l-10 34c-1 4-5 6-9 6H55c-4 0-8-2-9-6l-10-34z" fill="url(#shipHull)" />
+      <path d="M50 72h60l-6 24H56l-6-24z" fill="url(#shipDeck)" />
+      <rect x="68" y="48" width="24" height="20" rx="4" fill="#0ea5e9" />
+      <rect x="76" y="32" width="8" height="18" rx="4" fill="#e2e8f0" />
+      <path d="M80 20c3 0 6 2 6 5s-3 5-6 5-6-2-6-5 3-5 6-5z" fill="#bae6fd" />
+      <path d="M40 108h80c-12 10-26 16-40 16s-28-6-40-16z" fill="#0ea5e9" opacity="0.85" />
+    </g>
+    <filter id="shadow-ship" x="-20" y="-10" width="200" height="200" colorInterpolationFilters="sRGB">
+      <feGaussianBlur stdDeviation="5" result="blur" />
+      <feOffset dx="0" dy="4" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </svg>
+);
+
+export default PlaneIcon;

--- a/dash-ui/src/components/weather/WeatherIcon.tsx
+++ b/dash-ui/src/components/weather/WeatherIcon.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import type { WeatherKind } from "../../types/weather";
+
+interface WeatherIconProps {
+  kind: WeatherKind;
+  animated?: boolean;
+  size?: number;
+  className?: string;
+}
+
+const sharedProps = (size: number, className?: string) => ({
+  width: size,
+  height: size,
+  className,
+  viewBox: "0 0 160 160",
+  fill: "none",
+  xmlns: "http://www.w3.org/2000/svg",
+});
+
+const Glow = () => (
+  <defs>
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%" colorInterpolationFilters="sRGB">
+      <feGaussianBlur stdDeviation="6" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+    <linearGradient id="sunGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stopColor="#FFE07D" />
+      <stop offset="100%" stopColor="#FFB347" />
+    </linearGradient>
+    <linearGradient id="cloudGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stopColor="#FFFFFF" stopOpacity="0.95" />
+      <stop offset="100%" stopColor="#C7D2FE" stopOpacity="0.95" />
+    </linearGradient>
+    <linearGradient id="rainGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stopColor="#7DD3FC" />
+      <stop offset="100%" stopColor="#2563EB" />
+    </linearGradient>
+    <linearGradient id="stormGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stopColor="#FDE68A" />
+      <stop offset="100%" stopColor="#F59E0B" />
+    </linearGradient>
+    <linearGradient id="snowGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stopColor="#E0F2FE" />
+      <stop offset="100%" stopColor="#A5B4FC" />
+    </linearGradient>
+  </defs>
+);
+
+const SunnyIcon = ({ size = 96, animated = true, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <g filter="url(#shadow)">
+      <circle cx="80" cy="80" r="38" fill="url(#sunGradient)" className={animated ? "wi-spin" : ""} />
+      {animated && (
+        <g className="wi-pulse" stroke="#FFD166" strokeWidth="4" strokeLinecap="round">
+          {Array.from({ length: 8 }).map((_, idx) => {
+            const angle = (idx * Math.PI) / 4;
+            const x1 = 80 + Math.cos(angle) * 56;
+            const y1 = 80 + Math.sin(angle) * 56;
+            const x2 = 80 + Math.cos(angle) * 70;
+            const y2 = 80 + Math.sin(angle) * 70;
+            return <line key={idx} x1={x1} y1={y1} x2={x2} y2={y2} />;
+          })}
+        </g>
+      )}
+    </g>
+  </svg>
+);
+
+const CloudLayers = ({ opacity = 1, offsetY = 0 }: { opacity?: number; offsetY?: number }) => (
+  <g opacity={opacity} transform={`translate(0 ${offsetY})`}>
+    <path
+      d="M40 100c-10 0-18 8-18 18s8 18 18 18h76c12 0 22-10 22-22s-10-22-22-22c-2 0-4 0-6 1-2-16-16-29-32-29-14 0-27 9-31 23-1-1-3-1-5-1z"
+      fill="url(#cloudGradient)"
+    />
+  </g>
+);
+
+const PartlyCloudyIcon = ({ size = 96, animated = true, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <SunnyIcon size={60} animated={animated} />
+    <CloudLayers opacity={1} offsetY={18} />
+  </svg>
+);
+
+const CloudyIcon = ({ size = 96, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <CloudLayers opacity={0.85} offsetY={-4} />
+    <CloudLayers opacity={0.95} offsetY={16} />
+  </svg>
+);
+
+const FogIcon = ({ size = 96, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <CloudLayers opacity={0.7} offsetY={8} />
+    <g stroke="#C7D2FE" strokeWidth="6" strokeLinecap="round" opacity={0.8}>
+      <line x1="40" y1="116" x2="120" y2="116" />
+      <line x1="32" y1="130" x2="112" y2="130" />
+      <line x1="48" y1="144" x2="128" y2="144" />
+    </g>
+  </svg>
+);
+
+const RainIcon = ({ size = 96, animated = true, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <CloudLayers opacity={0.95} />
+    <g className={animated ? "wi-fall" : ""}>
+      {Array.from({ length: 6 }).map((_, idx) => (
+        <rect
+          key={idx}
+          x={46 + idx * 14}
+          y={110 + (idx % 2) * 4}
+          width="6"
+          height="18"
+          rx="3"
+          fill="url(#rainGradient)"
+          opacity={0.8}
+        />
+      ))}
+    </g>
+  </svg>
+);
+
+const SleetIcon = ({ size = 96, animated = true, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <CloudLayers opacity={0.95} />
+    <g className={animated ? "wi-fall" : ""}>
+      {Array.from({ length: 3 }).map((_, idx) => (
+        <rect key={`r-${idx}`} x={46 + idx * 22} y={110} width="6" height="18" rx="3" fill="url(#rainGradient)" />
+      ))}
+      {Array.from({ length: 3 }).map((_, idx) => (
+        <circle key={`s-${idx}`} cx={60 + idx * 18} cy={136} r="6" fill="url(#snowGradient)" />
+      ))}
+    </g>
+  </svg>
+);
+
+const SnowIcon = ({ size = 96, animated = true, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <CloudLayers opacity={0.92} />
+    <g className={animated ? "wi-fall" : ""}>
+      {Array.from({ length: 6 }).map((_, idx) => (
+        <path
+          key={idx}
+          d="M0 -8 L4 0 L0 8 L-4 0Z"
+          transform={`translate(${52 + idx * 14} ${126 + (idx % 2) * 6}) rotate(45)`}
+          fill="url(#snowGradient)"
+          opacity={0.92}
+        />
+      ))}
+    </g>
+  </svg>
+);
+
+const ThunderIcon = ({ size = 96, animated = true, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <CloudLayers opacity={0.9} />
+    <polygon
+      points="88,102 104,104 86,134 98,132 74,164 82,134 68,134"
+      fill="url(#stormGradient)"
+      className={animated ? "wi-bounce" : ""}
+    />
+  </svg>
+);
+
+const UnknownIcon = ({ size = 96, className }: WeatherIconProps) => (
+  <svg {...sharedProps(size, className)}>
+    <Glow />
+    <circle cx="80" cy="80" r="42" fill="#1F2937" opacity="0.9" />
+    <text x="80" y="94" textAnchor="middle" fontSize="56" fill="#E5E7EB" fontWeight="800">?</text>
+  </svg>
+);
+
+export const WeatherIcon: React.FC<WeatherIconProps> = ({ kind, animated = true, size = 64, className }) => {
+  switch (kind) {
+    case "clear":
+      return <SunnyIcon kind={kind} animated={animated} size={size} className={className} />;
+    case "partly_cloudy":
+      return <PartlyCloudyIcon kind={kind} animated={animated} size={size} className={className} />;
+    case "cloudy":
+      return <CloudyIcon kind={kind} animated={animated} size={size} className={className} />;
+    case "fog":
+      return <FogIcon kind={kind} animated={animated} size={size} className={className} />;
+    case "rain":
+      return <RainIcon kind={kind} animated={animated} size={size} className={className} />;
+    case "sleet":
+      return <SleetIcon kind={kind} animated={animated} size={size} className={className} />;
+    case "snow":
+      return <SnowIcon kind={kind} animated={animated} size={size} className={className} />;
+    case "thunderstorm":
+      return <ThunderIcon kind={kind} animated={animated} size={size} className={className} />;
+    default:
+      return <UnknownIcon kind={kind} animated={animated} size={size} className={className} />;
+  }
+};
+
+export default WeatherIcon;

--- a/dash-ui/src/styles/panels.css
+++ b/dash-ui/src/styles/panels.css
@@ -19,6 +19,50 @@
     linear-gradient(135deg, #0f172a, #7c3aed);
 }
 
+.panel-bg-weather-clear-day {
+  background: radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.18), transparent 50%),
+    linear-gradient(135deg, #fcd34d, #60a5fa);
+}
+
+.panel-bg-weather-clear-night {
+  background: radial-gradient(circle at 15% 20%, rgba(94, 234, 212, 0.24), transparent 55%),
+    linear-gradient(135deg, #0b1021, #111827);
+}
+
+.panel-bg-weather-partly-day {
+  background: radial-gradient(circle at 70% 0%, rgba(255, 255, 255, 0.3), transparent 55%),
+    linear-gradient(135deg, #9ae6b4, #60a5fa);
+}
+
+.panel-bg-weather-partly-night {
+  background: radial-gradient(circle at 10% 0%, rgba(165, 180, 252, 0.3), transparent 55%),
+    linear-gradient(135deg, #0f172a, #312e81);
+}
+
+.panel-bg-weather-cloudy {
+  background: radial-gradient(circle at 50% 10%, rgba(226, 232, 240, 0.32), transparent 50%),
+    linear-gradient(135deg, #334155, #1e293b);
+}
+
+.panel-bg-weather-fog {
+  background: linear-gradient(135deg, #cbd5e1, #94a3b8);
+}
+
+.panel-bg-weather-rain {
+  background: radial-gradient(circle at 80% 20%, rgba(96, 165, 250, 0.35), transparent 45%),
+    linear-gradient(145deg, #0ea5e9, #0f172a);
+}
+
+.panel-bg-weather-snow {
+  background: radial-gradient(circle at 30% 10%, rgba(226, 232, 240, 0.45), transparent 50%),
+    linear-gradient(145deg, #e0f2fe, #94a3b8);
+}
+
+.panel-bg-weather-storm {
+  background: radial-gradient(circle at 20% 0%, rgba(250, 204, 21, 0.3), transparent 50%),
+    linear-gradient(135deg, #1e293b, #0f172a 55%, #111827);
+}
+
 .panel-bg-night,
 .panel-bg-dawn,
 .panel-bg-day,
@@ -49,4 +93,42 @@
 
 .auto-scroll-container::-webkit-scrollbar {
   display: none;
+}
+
+.wi-spin {
+  animation: wiSpin 18s linear infinite;
+  transform-origin: center;
+}
+
+.wi-pulse {
+  animation: wiPulse 6s ease-in-out infinite;
+}
+
+.wi-fall {
+  animation: wiFall 2.8s linear infinite;
+}
+
+.wi-bounce {
+  animation: wiBounce 1.4s ease-in-out infinite;
+}
+
+@keyframes wiSpin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@keyframes wiPulse {
+  0%, 100% { opacity: 0.6; transform: scale(0.95); }
+  50% { opacity: 1; transform: scale(1.05); }
+}
+
+@keyframes wiFall {
+  0% { transform: translateY(0); opacity: 0.95; }
+  90% { opacity: 1; }
+  100% { transform: translateY(18px); opacity: 0; }
+}
+
+@keyframes wiBounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(6px); }
 }

--- a/dash-ui/src/theme/panelTheme.ts
+++ b/dash-ui/src/theme/panelTheme.ts
@@ -1,3 +1,5 @@
+import type { WeatherKind } from "../types/weather";
+
 export type PanelTimeOfDay = 'night' | 'dawn' | 'day' | 'dusk';
 
 export function getPanelTimeOfDay(now: Date): PanelTimeOfDay {
@@ -21,5 +23,27 @@ export function getPanelBackgroundClass(timeOfDay: PanelTimeOfDay): string {
       return 'panel-bg-dusk';
     default:
       return 'panel-bg-night';
+  }
+}
+
+export function getWeatherBackgroundClass(kind: WeatherKind | null | undefined, timeOfDay: PanelTimeOfDay): string {
+  switch (kind) {
+    case 'clear':
+      return timeOfDay === 'night' ? 'panel-bg-weather-clear-night' : 'panel-bg-weather-clear-day';
+    case 'partly_cloudy':
+      return timeOfDay === 'night' ? 'panel-bg-weather-partly-night' : 'panel-bg-weather-partly-day';
+    case 'cloudy':
+      return 'panel-bg-weather-cloudy';
+    case 'fog':
+      return 'panel-bg-weather-fog';
+    case 'rain':
+      return 'panel-bg-weather-rain';
+    case 'sleet':
+    case 'snow':
+      return 'panel-bg-weather-snow';
+    case 'thunderstorm':
+      return 'panel-bg-weather-storm';
+    default:
+      return getPanelBackgroundClass(timeOfDay);
   }
 }

--- a/dash-ui/src/types/weather.ts
+++ b/dash-ui/src/types/weather.ts
@@ -1,0 +1,60 @@
+export type WeatherKind =
+  | 'clear'
+  | 'partly_cloudy'
+  | 'cloudy'
+  | 'fog'
+  | 'rain'
+  | 'snow'
+  | 'sleet'
+  | 'thunderstorm'
+  | 'unknown';
+
+export const METEOBLUE_SYMBOL_TO_KIND: Record<number, WeatherKind> = {
+  1: 'clear',
+  2: 'clear',
+  3: 'clear',
+  4: 'clear',
+  5: 'clear',
+  6: 'partly_cloudy',
+  7: 'partly_cloudy',
+  8: 'cloudy',
+  9: 'rain',
+  10: 'rain',
+  11: 'thunderstorm',
+  12: 'thunderstorm',
+  13: 'sleet',
+  14: 'sleet',
+  15: 'snow',
+  16: 'snow',
+  17: 'rain',
+  18: 'rain',
+  19: 'thunderstorm',
+  20: 'thunderstorm',
+  21: 'sleet',
+  22: 'sleet',
+  23: 'snow',
+  24: 'snow',
+  25: 'fog',
+  26: 'fog',
+  27: 'clear',
+  28: 'partly_cloudy',
+  29: 'rain',
+  30: 'sleet',
+  31: 'snow',
+  32: 'thunderstorm',
+  33: 'cloudy',
+  34: 'rain',
+  35: 'snow',
+};
+
+export const WEATHER_KIND_LABEL: Record<WeatherKind, string> = {
+  clear: 'Despejado',
+  partly_cloudy: 'Parcialmente nublado',
+  cloudy: 'Nublado',
+  fog: 'Niebla',
+  rain: 'Lluvia',
+  snow: 'Nieve',
+  sleet: 'Aguanieve',
+  thunderstorm: 'Tormenta',
+  unknown: 'Sin datos',
+};

--- a/dash-ui/src/utils/weather.ts
+++ b/dash-ui/src/utils/weather.ts
@@ -1,16 +1,9 @@
+import { METEOBLUE_SYMBOL_TO_KIND, WEATHER_KIND_LABEL, type WeatherKind } from "../types/weather";
+
 export const capitalize = (value: string): string => {
   if (!value) return "";
   return value.charAt(0).toUpperCase() + value.slice(1);
 };
-
-const frozenKeywords = [
-  "snow",
-  "sleet",
-  "hail",
-  "aguanieve",
-  "nieve",
-  "granizo",
-];
 
 const normalize = (value: string | null | undefined): string => {
   return (value || "").trim();
@@ -18,53 +11,55 @@ const normalize = (value: string | null | undefined): string => {
 
 export const sanitizeWeatherCondition = (
   rawCondition: string | null,
-  temperatureC?: number | null
+  _temperatureC?: number | null
 ): string => {
   const condition = normalize(rawCondition);
-  const lower = condition.toLowerCase();
-  const hasFrozenKeyword = frozenKeywords.some((kw) => lower.includes(kw));
-  const temp = typeof temperatureC === "number" && Number.isFinite(temperatureC)
-    ? temperatureC
-    : null;
-
-  let result = condition || "Sin datos";
-  if (temp !== null && temp > 11.5 && hasFrozenKeyword) {
-    if (lower.includes("tormenta") || lower.includes("storm")) {
-      result = "Tormenta";
-    } else if (lower.includes("lluv")) {
-      result = "Lluvia";
-    } else if (lower.includes("niebla")) {
-      result = "Niebla";
-    } else {
-      result = "Nublado";
-    }
-  }
-
+  const result = condition || "Sin datos";
   return capitalize(result);
 };
 
-const pickIconName = (condition: string): string => {
-  const c = condition.toLowerCase();
+export const guessWeatherKindFromCondition = (condition: string | null | undefined): WeatherKind => {
+  const lower = (condition || "").toLowerCase();
+  if (!lower) return "unknown";
 
-  if (c.includes("tormenta") || c.includes("thunder") || c.includes("storm")) return "thunderstorm";
-  if (c.includes("lluvia") || c.includes("rain") || c.includes("shower")) return "rain";
-  if (c.includes("llovizna") || c.includes("drizzle")) return "drizzle";
-  if (c.includes("nieve") || c.includes("snow") || c.includes("sleet") || c.includes("hail")) return "snow";
-  if (c.includes("niebla") || c.includes("fog") || c.includes("bruma") || c.includes("mist")) return "fog";
-  if (c.includes("cubierto") || c.includes("overcast")) return "overcast";
-  if (c.includes("parcial") || c.includes("partly")) return "partly-cloudy";
-  if (c.includes("nublado") || c.includes("cloud")) return "cloudy";
-  if (c.includes("sol") || c.includes("sunny") || c.includes("clear") || c.includes("despejado")) return "sunny";
+  if (lower.includes("tormenta") || lower.includes("thunder")) return "thunderstorm";
+  if (lower.includes("lluv")) return "rain";
+  if (lower.includes("llovizna") || lower.includes("drizzle")) return "rain";
+  if (lower.includes("nieve")) return "snow";
+  if (lower.includes("aguanieve") || lower.includes("sleet") || lower.includes("granizo")) return "sleet";
+  if (lower.includes("niebla") || lower.includes("fog") || lower.includes("bruma") || lower.includes("mist")) return "fog";
+  if (lower.includes("nublado") || lower.includes("cloud")) return "cloudy";
+  if (lower.includes("parcial") || lower.includes("partly")) return "partly_cloudy";
+  if (lower.includes("soleado") || lower.includes("despejado") || lower.includes("sunny") || lower.includes("clear")) return "clear";
 
   return "unknown";
 };
 
-export const resolveWeatherIcon = (
-  condition: string | null,
-  options?: { isNight?: boolean }
-): string => {
-  const iconName = pickIconName(condition || "");
-  const isNight = options?.isNight ?? false;
-  const bucket = isNight ? "night" : "day";
-  return `/icons/weather/${bucket}/${iconName}.svg`;
+export const mapMeteoblueSymbolToKind = (symbol?: number | null): WeatherKind => {
+  if (symbol === null || symbol === undefined) return "unknown";
+  return METEOBLUE_SYMBOL_TO_KIND[symbol] ?? "unknown";
+};
+
+export const resolveWeatherKind = (options: {
+  symbol?: number | null;
+  condition?: string | null;
+  precipitation?: number | null;
+}): WeatherKind => {
+  const { symbol, condition, precipitation } = options;
+  const symbolKind = mapMeteoblueSymbolToKind(symbol);
+  if (symbolKind !== "unknown") return symbolKind;
+
+  const conditionKind = guessWeatherKindFromCondition(condition);
+  if (conditionKind !== "unknown") return conditionKind;
+
+  if (typeof precipitation === "number" && precipitation > 0) {
+    return "rain";
+  }
+
+  return "clear";
+};
+
+export const formatWeatherKindLabel = (kind: WeatherKind, fallback?: string | null): string => {
+  if (kind in WEATHER_KIND_LABEL) return WEATHER_KIND_LABEL[kind];
+  return fallback || WEATHER_KIND_LABEL.unknown;
 };


### PR DESCRIPTION
## Summary
- map Meteoblue pictocodes to explicit weather kinds, add new animated icons, and refresh weather card backgrounds
- fix transport backend payload and redesign transport card with new icons and smooth auto-scrolling for ships and flights
- adjust APOD handling for image vs video and slow looping description scroll

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936984b97b483268e9748ab03b880eb)