### PR TITLE
Fix: robust ICS calendar upload and config update

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -760,6 +760,7 @@ class CalendarICSConfig(BaseModel):
     """Configuración de calendario ICS."""
     filename: Optional[str] = Field(default=None, max_length=256)  # nombre almacenado (solo lectura)
     stored_path: Optional[str] = Field(default=None, max_length=1024)  # ruta en disco (solo backend, no se expone)
+    path: Optional[str] = Field(default=None, max_length=1024)  # ruta del archivo ICS
     max_events: int = Field(default=50, ge=1, le=1000)
     days_ahead: int = Field(default=14, ge=1, le=90)
     # Legacy fields para retrocompatibilidad


### PR DESCRIPTION
## Summary
- safeguard calendar ICS upload when calendar or ics blocks are missing or null
- save uploaded ICS files using their provided filename and persist paths/days_ahead in config
- extend calendar ICS model to include a path field for storing the saved file location

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69369ac36c208326901630473e635d32)