### PR TITLE
Fix weather_service indentation and add syntax safeguards

### DIFF
--- a/backend/services/weather_service.py
+++ b/backend/services/weather_service.py
@@ -52,6 +52,44 @@ PICTOCODE_TO_ICON = {
     35: "snow",                  # Mostly cloudy with snow shower
 }
 
+conditions = {
+    1: "Soleado",
+    2: "Soleado",
+    3: "Soleado",
+    4: "Soleado",
+    5: "Soleado",
+    6: "Parcialmente nublado",
+    7: "Parcialmente nublado",
+    8: "Nublado",
+    9: "Lluvia",
+    10: "Lluvia ligera",
+    11: "Lluvia con tormenta",
+    12: "Lluvia intensa",
+    13: "Nieve",
+    14: "Nieve",
+    15: "Nieve",
+    16: "Nieve",
+    17: "Chubasco",
+    18: "Chubasco ligero",
+    19: "Chubasco con tormenta",
+    20: "Chubasco intenso con tormenta",
+    21: "Nieve",
+    22: "Nieve",
+    23: "Nieve",
+    24: "Nieve ligera",
+    25: "Niebla",
+    26: "Niebla",
+    27: "Soleado",
+    28: "Claro",
+    29: "Lluvia",
+    30: "Nieve",
+    31: "Nieve",
+    32: "Tormenta",
+    33: "Nublado",
+    34: "Lluvia",
+    35: "Nieve",
+}
+
 
 def map_pictocode_to_icon(pictocode: int, is_night: bool = False) -> str:
     """
@@ -86,43 +124,6 @@ def map_pictocode_to_condition(pictocode: int) -> str:
     Returns:
         Descripción del clima en español
     """
-        conditions = {
-        1: "Soleado",
-        2: "Soleado",
-        3: "Soleado",
-        4: "Soleado",
-        5: "Soleado",
-        6: "Parcialmente nublado",
-        7: "Parcialmente nublado",
-        8: "Nublado",
-        9: "Lluvia",
-        10: "Lluvia ligera",
-        11: "Lluvia con tormenta",
-        12: "Lluvia intensa",
-        13: "Nieve",
-        14: "Nieve",
-        15: "Nieve",
-        16: "Nieve",
-        17: "Chubasco",
-        18: "Chubasco ligero",
-        19: "Chubasco con tormenta",
-        20: "Chubasco intenso con tormenta",
-        21: "Nieve",
-        22: "Nieve",
-        23: "Nieve",
-        24: "Nieve ligera",
-        25: "Niebla",
-        26: "Niebla",
-        27: "Soleado",
-        28: "Claro",
-        29: "Lluvia",
-        30: "Nieve",
-        31: "Nieve",
-        32: "Tormenta",
-        33: "Nublado",
-        34: "Lluvia",
-        35: "Nieve",
-    }
     return conditions.get(pictocode, "Desconocido")
 
 

--- a/backend/tests/test_weather_service_syntax.py
+++ b/backend/tests/test_weather_service_syntax.py
@@ -1,0 +1,3 @@
+def test_weather_service_import():
+    import importlib
+    importlib.import_module("backend.services.weather_service")

--- a/usr/local/bin/pantalla-backend-launch
+++ b/usr/local/bin/pantalla-backend-launch
@@ -95,6 +95,8 @@ PREFLIGHT_ERROR=0
   echo "[backend-launch] ERROR: icalendar no importable" >&2
   PREFLIGHT_ERROR=1
 }
+python3 -m py_compile /opt/pantalla-reloj/backend/services/weather_service.py \
+  || { echo "[ERROR] weather_service.py tiene errores de sintaxis"; exit 4; }
 "$VENV_PYTHON" -c "import backend.main" 2>&1 || {
   echo "[backend-launch] ERROR: backend.main no importable" >&2
   echo "[backend-launch] Intentando mostrar el error completo:" >&2


### PR DESCRIPTION
## Summary
- Fix the indentation of the weather condition mapping in `backend/services/weather_service.py`
- Add a pre-flight syntax compilation check for `weather_service.py` in the backend launcher script
- Introduce a lightweight test ensuring `backend.services.weather_service` remains importable

## Testing
- `python3 -m py_compile backend/services/weather_service.py`
- `pytest -q` *(fails in repository due to pre-existing test collection errors unrelated to this change)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f07466848326803cf082c8e5c0cc)