### PR TITLE
Restore flights layer endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -10617,6 +10617,7 @@ async def get_ships_preview(limit: int = 20) -> Dict[str, Any]:
         }
 
 
+@app.get("/api/layers/flights")
 def get_flights(request: Request, bbox: Optional[str] = None, extended: Optional[int] = None) -> JSONResponse:
     config = config_manager.read()
     opensky_cfg = config.opensky


### PR DESCRIPTION
## Summary
- expose the flights layer handler at `/api/layers/flights` so the frontend can load aircraft data

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936f3b9cfcc832696bbc897ae429e5e)