### PR TITLE
Fortify kiosk startup prechecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ Pantalla_reloj/
 
 Antes del primer arranque revisa `docs/CONFIG_SETUP.md`; resume cómo clonar la plantilla de `config.json`, qué claves/API keys son obligatorias y cómo verificar que mapa y panel funcionan sin errores.
 
-### Verificación de arranque en frío del kiosk
+### Cold boot test
 
 - Apaga completamente el mini-PC (`sudo shutdown -h now`) y deja la alimentación desconectada al menos 60 segundos para simular un arranque en frío.
-- Enciende el equipo y espera que el kiosk levante en menos de 90 segundos.
+- Enciende el equipo y espera < 90 segundos.
 - Comprueba el estado con `scripts/verify_kiosk.sh` (usa `sudo` y pasa el usuario si no es `dani`):
   ```bash
   sudo scripts/verify_kiosk.sh dani
   ```
+- El autostart de Openbox solo gestiona DPMS/unclutter/DBus; el navegador kiosk lo arranca `pantalla-kiosk-chrome@<usuario>.service` desde systemd, por lo que el arranque no depende del timing del autostart.
 - Valida que el comando muestre servicios activos, logs recientes y que `xdpyinfo` y `/api/health` respondan correctamente.
 
 ### Backend (FastAPI)

--- a/opt/pantalla/bin/pantalla-kiosk-prestart
+++ b/opt/pantalla/bin/pantalla-kiosk-prestart
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set +e
+
+log() {
+  printf '[prestart] %s\n' "$*"
+}
+
+DISPLAY="${DISPLAY:-:0}"
+XAUTHORITY="${XAUTHORITY:-}" 
+BACKEND_HEALTH_URL="http://127.0.0.1:8081/api/health"
+
+log "Iniciando prestart para DISPLAY=${DISPLAY} XAUTHORITY=${XAUTHORITY}"
+
+if [[ -z "$XAUTHORITY" ]]; then
+  log "WARN: XAUTHORITY no está definido"
+fi
+
+log "Esperando XAUTHORITY legible..."
+for i in $(seq 1 60); do
+  if [[ -n "$XAUTHORITY" && -r "$XAUTHORITY" ]]; then
+    log "XAUTHORITY disponible tras ${i}s"
+    break
+  fi
+  sleep 1
+done
+if [[ -n "$XAUTHORITY" && ! -r "$XAUTHORITY" ]]; then
+  log "WARN: XAUTHORITY no disponible tras 60s"
+fi
+
+CHECK_CMD="xdpyinfo -display ${DISPLAY}"
+if ! command -v xdpyinfo >/dev/null 2>&1; then
+  CHECK_CMD="xset q"
+fi
+log "Verificando disponibilidad de X con: ${CHECK_CMD}"
+display_ready=0
+for i in $(seq 1 60); do
+  if eval "$CHECK_CMD" >/dev/null 2>&1; then
+    log "Display listo tras ${i}s"
+    display_ready=1
+    break
+  fi
+  sleep 1
+done
+if [[ "$display_ready" -ne 1 ]]; then
+  log "WARN: Display no respondió tras 60s"
+fi
+
+log "Esperando backend ${BACKEND_HEALTH_URL}" 
+backend_ready=0
+for i in $(seq 1 60); do
+  if curl -sf --max-time 2 "$BACKEND_HEALTH_URL" >/dev/null 2>&1; then
+    log "Backend disponible tras ${i}s"
+    backend_ready=1
+    break
+  fi
+  sleep 1
+done
+if [[ "$backend_ready" -ne 1 ]]; then
+  log "WARN: Backend no respondió tras 60s"
+fi
+
+xset -dpms >/dev/null 2>&1 || true
+xset s off >/dev/null 2>&1 || true
+xset s noblank >/dev/null 2>&1 || true
+
+log "Prestart finalizado"
+exit 0

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -127,6 +127,12 @@ for unit in "${EXTRA_KIOSK_UNITS[@]:-}"; do
   fi
 done
 
+log_info "Deshabilitando plantilla pantalla-kiosk-chrome@*.service"
+mapfile -t EXTRA_KIOSK_UNIT_FILES < <(systemctl list-unit-files 'pantalla-kiosk-chrome@*.service' --no-legend 2>/dev/null | awk '{print $1}' | sed '/^$/d')
+for unit in "${EXTRA_KIOSK_UNIT_FILES[@]:-}"; do
+  systemctl disable --now "$unit" >/dev/null 2>&1 || true
+done
+
 log_info "Stopping systemd units, timers and paths"
 # Detener timers primero
 for timer in "${SYSTEMD_TIMERS[@]}"; do
@@ -181,6 +187,7 @@ rm -f /etc/systemd/system/pantalla-portal@.service
 rm -f /etc/systemd/system/pantalla-kiosk-chromium@${USER_NAME}.service.d/override.conf
 rm -f /etc/systemd/system/pantalla-kiosk-chrome@${USER_NAME}.service.d/override.conf
 rm -rf /etc/systemd/system/pantalla-kiosk@.service.d /etc/systemd/system/pantalla-openbox@.service.d /etc/systemd/system/pantalla-dash-backend@.service.d
+find /etc/systemd/system -maxdepth 2 -type d -name "pantalla-kiosk-chrome@*.service.d" -exec rm -rf {} + >/dev/null 2>&1 || true
 
 # Eliminar todos los servicios watchdog y autorefresh
 rm -f /etc/systemd/system/pantalla-kiosk-watchdog@.service
@@ -249,6 +256,7 @@ rm -f /usr/local/bin/pantalla-kiosk
 rm -f /usr/local/bin/pantalla-kiosk-verify
 rm -f /usr/local/bin/pantalla-kiosk-chromium
 rm -f /usr/local/bin/pantalla-backend-launch
+rm -f /usr/local/bin/pantalla-kiosk-prestart
 rm -f /usr/local/bin/pantalla-kiosk-autorefresh
 rm -f /usr/local/bin/diag_kiosk.sh
 rm -f /usr/local/bin/kiosk-ui /usr/local/bin/kiosk-diag

--- a/systemd/pantalla-kiosk-chrome@.service
+++ b/systemd/pantalla-kiosk-chrome@.service
@@ -16,59 +16,7 @@ Environment=GTK_USE_PORTAL=0
 Environment=GIO_USE_PORTALS=0
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/%U/bus
 EnvironmentFile=-/var/lib/pantalla-reloj/state/kiosk.env
-# Esperar a que X11 y los servicios estén listos, luego esperar al backend
-ExecStartPre=/bin/sh -lc '
-set +e
-log() { printf "[prestart] %s\\n" "$*"; }
-export DISPLAY=:0
-export XAUTHORITY=/home/%i/.Xauthority
-log "Esperando XAUTHORITY en ${XAUTHORITY}"
-for i in $(seq 1 60); do
-  if [ -r "$XAUTHORITY" ]; then
-    log "XAUTHORITY disponible tras ${i}s"
-    break
-  fi
-  sleep 1
-done
-if [ ! -r "$XAUTHORITY" ]; then
-  log "WARN: XAUTHORITY no encontrado tras 60s"
-fi
-CHECK_CMD="xdpyinfo -display ${DISPLAY}"
-if ! command -v xdpyinfo >/dev/null 2>&1; then
-  CHECK_CMD="xset q"
-fi
-log "Verificando display ${DISPLAY} con: ${CHECK_CMD}"
-display_ready=0
-for i in $(seq 1 60); do
-  if eval "$CHECK_CMD" >/dev/null 2>&1; then
-    log "Display listo tras ${i}s"
-    display_ready=1
-    break
-  fi
-  sleep 1
-done
-if [ "$display_ready" -ne 1 ]; then
-  log "WARN: Display no respondió tras 60s"
-fi
-HEALTH_URL="http://127.0.0.1:8081/api/health"
-log "Esperando backend ${HEALTH_URL}"
-backend_ready=0
-for i in $(seq 1 60); do
-  if curl -sf --max-time 2 "$HEALTH_URL" >/dev/null 2>&1; then
-    log "Backend disponible tras ${i}s"
-    backend_ready=1
-    break
-  fi
-  sleep 1
-done
-if [ "$backend_ready" -ne 1 ]; then
-  log "WARN: Backend no respondió tras 60s"
-fi
-xset -dpms >/dev/null 2>&1 || true
-xset s off >/dev/null 2>&1 || true
-xset s noblank >/dev/null 2>&1 || true
-exit 0
-'
+ExecStartPre=/usr/local/bin/pantalla-kiosk-prestart
 LogsDirectory=pantalla
 LogsDirectoryMode=0755
 # NOTA: El perfil del navegador kiosk (/var/lib/pantalla-reloj/state/chromium-kiosk) se crea


### PR DESCRIPTION
## Summary
- add a dedicated prestart helper that waits for X/.Xauthority/backend and wire pantalla-kiosk-chrome@.service to use it
- harden install/uninstall flows: deploy prestart, protect user overrides, enable kiosk service, and add clearer verification utilities and logging
- document the cold boot test and make verify_kiosk.sh report concise OK/FAIL output

## Testing
- bash -n scripts/install.sh scripts/uninstall.sh scripts/verify_kiosk.sh opt/pantalla/bin/pantalla-kiosk-prestart

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c3d47bd108326907c1dcceebffa4d)