### PR TITLE
Ajustar detección de lluvia en pronóstico semanal

### DIFF
--- a/dash-ui/src/components/OverlayRotator.tsx
+++ b/dash-ui/src/components/OverlayRotator.tsx
@@ -813,6 +813,7 @@ export const OverlayRotator: React.FC = () => {
           symbol: pictocode,
           condition,
           precipitation,
+          icon: typeof day.icon === "string" ? day.icon : null,
         });
 
         return {

--- a/dash-ui/src/components/dashboard/cards/WeatherForecastCard.tsx
+++ b/dash-ui/src/components/dashboard/cards/WeatherForecastCard.tsx
@@ -40,6 +40,7 @@ export const WeatherForecastCard = ({ forecast }: WeatherForecastCardProps): JSX
           symbol: day.pictocode,
           condition: day.condition,
           precipitation: typeof day.precipitation === "number" ? day.precipitation : null,
+          icon: day.icon ?? null,
         });
 
         return {

--- a/dash-ui/src/utils/weather.ts
+++ b/dash-ui/src/utils/weather.ts
@@ -40,12 +40,43 @@ export const mapMeteoblueSymbolToKind = (symbol?: number | null): WeatherKind =>
   return METEOBLUE_SYMBOL_TO_KIND[symbol] ?? "unknown";
 };
 
+const mapOpenWeatherIconToKind = (icon?: string | null): WeatherKind => {
+  if (!icon) return "unknown";
+  const code = icon.slice(0, 2);
+
+  switch (code) {
+    case "01":
+      return "clear";
+    case "02":
+      return "partly_cloudy";
+    case "03":
+    case "04":
+      return "cloudy";
+    case "09":
+    case "10":
+      return "rain";
+    case "11":
+      return "thunderstorm";
+    case "13":
+      return "snow";
+    case "50":
+      return "fog";
+    default:
+      return "unknown";
+  }
+};
+
 export const resolveWeatherKind = (options: {
   symbol?: number | null;
   condition?: string | null;
   precipitation?: number | null;
+  icon?: string | null;
 }): WeatherKind => {
-  const { symbol, condition, precipitation } = options;
+  const { symbol, condition, precipitation, icon } = options;
+
+  const iconKind = mapOpenWeatherIconToKind(icon);
+  if (iconKind !== "unknown") return iconKind;
+
   const symbolKind = mapMeteoblueSymbolToKind(symbol);
   if (symbolKind !== "unknown") return symbolKind;
 


### PR DESCRIPTION
## Summary
- mapear códigos de iconos de OpenWeather al tipo de clima interno
- usar el código de icono en la resolución del tipo meteorológico en el pronóstico semanal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c43c3fb8c832687b48f9c46ef4d44)