### PR TITLE
Add radar overlay focus channel and highlights

### DIFF
--- a/dash-ui/src/components/OverlayRotator.tsx
+++ b/dash-ui/src/components/OverlayRotator.tsx
@@ -1196,6 +1196,12 @@ export const OverlayRotator: React.FC = () => {
   const [displayPanel, setDisplayPanel] = useState<RotatingCardItem | null>(null);
   const [nextPanelBuffer, setNextPanelBuffer] = useState<RotatingCardItem | null>(null);
 
+  useEffect(() => {
+    window.dispatchEvent(new CustomEvent("pantalla:overlay:active", {
+      detail: { id: displayPanel?.id ?? null },
+    }));
+  }, [displayPanel?.id]);
+
   // Sync display panel with current index logic
   useEffect(() => {
     // Initial load


### PR DESCRIPTION
## Summary
- emit overlay activation and transport selection/target events from UI panels
- add GeoScope map listener to focus on radar targets, restore camera, and highlight current selection with pulse
- add highlight layers for aircraft and ships and recenter selection when out of view

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c463e08bc832693f8279ad9a54aee)