### PR TITLE
Improve kiosk chrome resilience and verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Antes del primer arranque revisa `docs/CONFIG_SETUP.md`; resume cómo clonar la 
 
 - Apaga completamente el mini-PC (`sudo shutdown -h now`) y deja la alimentación desconectada al menos 60 segundos para simular un arranque en frío.
 - Enciende el equipo y espera < 90 segundos.
-- Comprueba el estado con `scripts/verify_kiosk.sh` (usa `sudo` y pasa el usuario si no es `dani`):
+- Comprueba el estado con `scripts/verify_kiosk.sh` (usa `sudo` y pasa el usuario si no es `dani`). El script valida servicios, salud del backend, locks huérfanos en `/var/lib/pantalla-reloj/state/chromium-kiosk` y muestra `chrome_debug.log` si existe:
   ```bash
   sudo scripts/verify_kiosk.sh dani
   ```
 - El autostart de Openbox solo gestiona DPMS/unclutter/DBus; el navegador kiosk lo arranca `pantalla-kiosk-chrome@<usuario>.service` desde systemd, por lo que el arranque no depende del timing del autostart.
-- Valida que el comando muestre servicios activos, logs recientes y que `xdpyinfo` y `/api/health` respondan correctamente.
+- Valida que el comando muestre servicios activos, logs recientes, respuesta de `xdpyinfo` y `/api/health`, y que el perfil no tenga locks huérfanos si no hay Chrome en ejecución.
 
 ### Backend (FastAPI)
 - Endpoints: `/api/health`, `/api/config` (GET/PATCH), `/api/weather`, `/api/news`,

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,10 +43,11 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-log_info() { printf '[INFO] %s\n' "$*"; }
-log_warn() { printf '[WARN] %s\n' "$*"; }
-log_ok()   { printf '[OK] %s\n' "$*"; }
-log_error(){ printf '[ERROR] %s\n' "$*" >&2; }
+timestamp() { date '+%Y-%m-%dT%H:%M:%S%z'; }
+log_info() { printf '[%s] [INFO] %s\n' "$(timestamp)" "$*"; }
+log_warn() { printf '[%s] [WARN] %s\n' "$(timestamp)" "$*"; }
+log_ok()   { printf '[%s] [OK] %s\n' "$(timestamp)" "$*"; }
+log_error(){ printf '[%s] [ERROR] %s\n' "$(timestamp)" "$*" >&2; }
 
 wait_for_backend_ready() {
   local max_wait=60
@@ -617,17 +618,12 @@ if ! bash -n /usr/local/bin/pantalla-kiosk-verify; then
 fi
 SUMMARY+=("[install] verificador de kiosk instalado en /usr/local/bin/pantalla-kiosk-verify")
 
-# Instalar script de verificación completo del kiosk
-if [[ -f "$REPO_ROOT/opt/pantalla-reloj/verify_kiosk.sh" ]]; then
-  install -D -m 0755 "$REPO_ROOT/opt/pantalla-reloj/verify_kiosk.sh" /opt/pantalla-reloj/verify_kiosk.sh
-  if ! bash -n /opt/pantalla-reloj/verify_kiosk.sh; then
-    echo "[ERROR] Syntax check failed for verify_kiosk.sh" >&2
-    exit 1
-  fi
-  SUMMARY+=("[install] script de verificación completo instalado en /opt/pantalla-reloj/verify_kiosk.sh")
-else
-  log_warn "verify_kiosk.sh no encontrado en $REPO_ROOT/opt/pantalla-reloj/verify_kiosk.sh"
+install -D -m 0755 "$REPO_ROOT/scripts/verify_kiosk.sh" /usr/local/bin/pantalla-verify-kiosk
+if ! bash -n /usr/local/bin/pantalla-verify-kiosk; then
+  echo "[ERROR] Syntax check failed for pantalla-verify-kiosk" >&2
+  exit 1
 fi
+SUMMARY+=("[install] script de verificación rápida instalado en /usr/local/bin/pantalla-verify-kiosk")
 
 install -D -m 0755 "$REPO_ROOT/scripts/diag_kiosk.sh" /usr/local/bin/diag_kiosk.sh
 if ! bash -n /usr/local/bin/diag_kiosk.sh; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -71,9 +71,10 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-log_info() { printf '[INFO] %s\n' "$*"; }
-log_warn() { printf '[WARN] %s\n' "$*"; }
-log_ok()   { printf '[OK] %s\n' "$*"; }
+timestamp() { date '+%Y-%m-%dT%H:%M:%S%z'; }
+log_info() { printf '[%s] [INFO] %s\n' "$(timestamp)" "$*"; }
+log_warn() { printf '[%s] [WARN] %s\n' "$(timestamp)" "$*"; }
+log_ok()   { printf '[%s] [OK] %s\n' "$(timestamp)" "$*"; }
 
 USER_NAME="dani"
 PANTALLA_PREFIX=/opt/pantalla-reloj
@@ -254,6 +255,7 @@ restore_nginx_default
 log_info "Eliminando binarios instalados"
 rm -f /usr/local/bin/pantalla-kiosk
 rm -f /usr/local/bin/pantalla-kiosk-verify
+rm -f /usr/local/bin/pantalla-verify-kiosk
 rm -f /usr/local/bin/pantalla-kiosk-chromium
 rm -f /usr/local/bin/pantalla-backend-launch
 rm -f /usr/local/bin/pantalla-kiosk-prestart

--- a/scripts/verify_kiosk.sh
+++ b/scripts/verify_kiosk.sh
@@ -5,11 +5,29 @@ USER_NAME="${1:-dani}"
 DISPLAY=":0"
 XAUTHORITY="/home/${USER_NAME}/.Xauthority"
 HEALTH_URL="http://127.0.0.1:8081/api/health"
+PROFILE_DIR="/var/lib/pantalla-reloj/state/chromium-kiosk"
 
 status_ok=1
 
-log() { printf '%s\n' "$*"; }
+timestamp() { date '+%Y-%m-%dT%H:%M:%S%z'; }
+log() { local level="$1"; shift; printf '[%s] [%s] %s\n' "$(timestamp)" "$level" "$*"; }
+log_info() { log INFO "$@"; }
+log_warn() { log WARN "$@"; }
+log_fail() { log FAIL "$@"; status_ok=0; }
 section() { printf '\n== %s ==\n' "$*"; }
+
+list_locks() {
+  local dir="$1"
+  local -a locks=(SingletonLock SingletonCookie SingletonSocket)
+  local existing=()
+  local lock
+  for lock in "${locks[@]}"; do
+    if [[ -e "${dir}/${lock}" ]]; then
+      existing+=("${dir}/${lock}")
+    fi
+  done
+  printf '%s\n' "${existing[@]:-}"
+}
 
 section "Estado de servicios"
 services=(
@@ -20,17 +38,15 @@ services=(
 )
 for svc in "${services[@]}"; do
   if systemctl is-active --quiet "$svc"; then
-    log "[OK] ${svc} activo"
+    log_info "[OK] ${svc} activo"
   else
-    log "[FAIL] ${svc} no está activo"
-    status_ok=0
+    log_fail "${svc} no está activo"
   fi
 done
 
 section "Últimos logs de pantalla-kiosk-chrome@${USER_NAME}.service"
 if ! journalctl -u pantalla-kiosk-chrome@"${USER_NAME}".service -n 120 --no-pager; then
-  log "[FAIL] No se pudieron obtener logs"
-  status_ok=0
+  log_warn "No se pudieron obtener logs"
 fi
 
 section "Verificación de DISPLAY"
@@ -39,31 +55,55 @@ if ! command -v xdpyinfo >/dev/null 2>&1; then
   CHECK_CMD="xset q"
 fi
 if DISPLAY="$DISPLAY" XAUTHORITY="$XAUTHORITY" bash -c "$CHECK_CMD" >/dev/null 2>&1; then
-  log "[OK] X responde con ${CHECK_CMD}"
+  log_info "[OK] X responde con ${CHECK_CMD}"
 else
-  log "[FAIL] X no respondió con ${CHECK_CMD}"
-  status_ok=0
+  log_fail "X no respondió con ${CHECK_CMD}"
 fi
 
 section "Health del backend"
 if curl -sf "$HEALTH_URL" >/dev/null 2>&1; then
-  log "[OK] Backend responde en ${HEALTH_URL}"
+  log_info "[OK] Backend responde en ${HEALTH_URL}"
 else
-  log "[FAIL] Backend no responde en ${HEALTH_URL}"
-  status_ok=0
+  log_fail "Backend no responde en ${HEALTH_URL}"
 fi
 
 section "Proceso de Chrome"
-if pgrep -u "$USER_NAME" -f "chrome.*--class=pantalla-kiosk" >/dev/null 2>&1; then
-  log "[OK] Chrome kiosk en ejecución"
+if pgrep -u "$USER_NAME" -f "chrome.*--user-data-dir=${PROFILE_DIR}" >/dev/null 2>&1; then
+  log_info "[OK] Chrome kiosk en ejecución con perfil ${PROFILE_DIR}"
 else
-  log "[WARN] Chrome kiosk no se detecta (puede estar arrancando)"
+  log_warn "Chrome kiosk no se detecta (puede estar arrancando)"
 fi
 
+section "Locks del perfil kiosk"
+if [[ -d "$PROFILE_DIR" ]]; then
+  mapfile -t locks < <(list_locks "$PROFILE_DIR") || true
+  if [[ ${#locks[@]} -eq 0 ]]; then
+    log_info "[OK] Sin locks Singleton en ${PROFILE_DIR}"
+  else
+    if pgrep -u "$USER_NAME" -f "chrome.*--user-data-dir=${PROFILE_DIR}" >/dev/null 2>&1; then
+      log_info "Locks presentes pero Chrome está en ejecución: ${locks[*]}"
+    else
+      log_fail "Locks huérfanos detectados en ${PROFILE_DIR}: ${locks[*]}"
+    fi
+  fi
+else
+  log_fail "El perfil ${PROFILE_DIR} no existe"
+fi
+
+section "chrome_debug.log"
+for candidate in "${PROFILE_DIR}/chrome_debug.log" \
+  "/home/${USER_NAME}/.config/google-chrome/chrome_debug.log"; do
+  if [[ -f "$candidate" ]]; then
+    log_info "Mostrando últimas 40 líneas de ${candidate}:"
+    tail -n 40 "$candidate"
+    break
+  fi
+done
+
 if [[ $status_ok -eq 1 ]]; then
-  log "\nRESULTADO: OK"
+  log_info "\nRESULTADO: OK"
   exit 0
 else
-  log "\nRESULTADO: FAIL"
+  log_fail "\nRESULTADO: FAIL"
   exit 1
 fi

--- a/systemd/pantalla-kiosk-chrome@.service
+++ b/systemd/pantalla-kiosk-chrome@.service
@@ -23,11 +23,10 @@ LogsDirectoryMode=0755
 # exclusivamente en scripts/install.sh. El wrapper pantalla-kiosk solo verifica que existe.
 # Si falta, el wrapper fallará con un mensaje claro indicando que hay que ejecutar install.sh.
 ExecStart=/usr/local/bin/pantalla-kiosk
-Restart=always
+Restart=on-failure
 RestartSec=10
 StandardOutput=journal
 StandardError=journal
 
 [Install]
 WantedBy=multi-user.target
-

--- a/usr/local/bin/pantalla-kiosk
+++ b/usr/local/bin/pantalla-kiosk
@@ -9,22 +9,21 @@ DEFAULT_LOG_DIR="/var/log/pantalla"
 MAX_RETRIES="${CHROME_MAX_RETRIES:-10}"
 SUCCESS_THRESHOLD="${CHROME_SUCCESS_THRESHOLD:-15}"
 MAX_BACKOFF="${CHROME_MAX_BACKOFF:-15}"
+EARLY_EXIT_THRESHOLD=10
 
 LOG_DIR="/var/log/pantalla"
 LOG_FILE="$LOG_DIR/browser-kiosk.log"
 
 mkdir -p "$LOG_DIR"
-
-# Crear si no existe
 touch "$LOG_FILE"
-
-# Asegurar permisos correctos para el usuario que ejecuta el kiosk
 chown "$USER:$USER" "$LOG_FILE"
 chmod 644 "$LOG_FILE"
 
-log() {
-  printf '[pantalla-kiosk] %s\n' "$*" >&2
-}
+timestamp() { date '+%Y-%m-%dT%H:%M:%S%z'; }
+log() { local level="$1"; shift; printf '[%s] [pantalla-kiosk] [%s] %s\n' "$(timestamp)" "$level" "$*" >&2; }
+log_info() { log INFO "$@"; }
+log_warn() { log WARN "$@"; }
+log_error() { log ERROR "$@"; }
 
 resolve_url() {
   local candidate="$1"
@@ -68,10 +67,9 @@ find_chromium() {
       printf '%s\n' "$resolved_bin"
       return 0
     fi
-    log "WARN: CHROME_BIN_OVERRIDE inválido (${override})"
+    log_warn "CHROME_BIN_OVERRIDE inválido (${override})"
   fi
 
-  # Priorizar binarios normales de Chromium (sin Snap)
   local -a candidates=(
     /usr/local/bin/chromium-kiosk-bin
     google-chrome-stable
@@ -84,10 +82,9 @@ find_chromium() {
   for candidate in "${candidates[@]}"; do
     if resolved="$(resolve_binary "$candidate" 2>/dev/null)"; then
       if [[ "$resolved" == "/usr/bin/chromium-browser" ]]; then
-        log "INFO: Ignorando shim de chromium-browser en ${resolved}"
+        log_info "Ignorando shim de chromium-browser en ${resolved}"
         continue
       fi
-      # Evitar Snap si es posible
       if [[ "$resolved" != *"/snap/"* ]]; then
         printf '%s\n' "$resolved"
         return 0
@@ -95,16 +92,15 @@ find_chromium() {
     fi
   done
 
-  # Fallback a Snap solo si no se encuentra ninguna alternativa
   local snap_candidate="/snap/chromium/current/usr/lib/chromium-browser/chrome"
   if [[ -x "$snap_candidate" ]]; then
-    log "WARN: Usando Chromium desde Snap (no recomendado, instala Chromium normal)" >&2
+    log_warn "Usando Chromium desde Snap (no recomendado, instala Chromium normal)"
     printf '%s\n' "$snap_candidate"
     return 0
   fi
-  
+
   if [[ -x /snap/bin/chromium ]]; then
-    log "WARN: Usando Chromium desde Snap (no recomendado, instala Chromium normal)" >&2
+    log_warn "Usando Chromium desde Snap (no recomendado, instala Chromium normal)"
     printf '%s\n' "/snap/bin/chromium"
     return 0
   fi
@@ -119,7 +115,7 @@ find_firefox() {
     if resolve_binary "$override"; then
       return 0
     fi
-    log "WARN: FIREFOX_BIN_OVERRIDE inválido (${override})"
+    log_warn "FIREFOX_BIN_OVERRIDE inválido (${override})"
   fi
 
   local -a candidates=(firefox firefox-esr)
@@ -133,33 +129,28 @@ find_firefox() {
   return 1
 }
 
-# Verificar que el directorio del perfil existe y es accesible
-# NO crear ni modificar permisos aquí - eso se hace solo en scripts/install.sh
 verify_profile_dir() {
-  local dir="$1"
-  local profile_name="$2"
-  
+  local dir="$1" profile_name="$2"
+
   if [[ ! -d "$dir" ]]; then
-    log "ERROR: El directorio del perfil ${profile_name} no existe: $dir"
-    log "ERROR: Ejecuta scripts/install.sh para crear el perfil correctamente"
-    exit 1
-  fi
-  
-  # Verificar que es accesible (lectura)
-  if [[ ! -r "$dir" ]] || [[ ! -x "$dir" ]]; then
-    log "ERROR: El directorio del perfil ${profile_name} no es accesible: $dir"
-    log "ERROR: Ejecuta scripts/install.sh para corregir los permisos"
+    log_error "El directorio del perfil ${profile_name} no existe: $dir"
+    log_error "Ejecuta scripts/install.sh para crear el perfil correctamente"
     exit 1
   fi
 
-  # Log informativo sobre el estado (sin modificar nada)
+  if [[ ! -r "$dir" ]] || [[ ! -x "$dir" ]]; then
+    log_error "El directorio del perfil ${profile_name} no es accesible: $dir"
+    log_error "Ejecuta scripts/install.sh para corregir los permisos"
+    exit 1
+  fi
+
   local owner perms
   owner="$(stat -c '%U:%G' "$dir" 2>/dev/null || echo "unknown")"
   perms="$(stat -c '%a' "$dir" 2>/dev/null || echo "unknown")"
   if [[ "$owner" != "${USER}:${USER}" ]] || [[ "$perms" != "700" ]]; then
-    log "WARN: Perfil ${profile_name} con owner/perms inesperados (owner=$owner, perms=$perms, esperado=${USER}:${USER} 700)"
+    log_warn "Perfil ${profile_name} con owner/perms inesperados (owner=$owner, perms=$perms, esperado=${USER}:${USER} 700)"
   else
-    log "Perfil ${profile_name}: $dir (owner=$owner, perms=$perms)"
+    log_info "Perfil ${profile_name}: $dir (owner=$owner, perms=$perms)"
   fi
 }
 
@@ -168,64 +159,76 @@ prepare_log_dir() {
   install -d -m 0755 "$dir" >/dev/null 2>&1 || true
 }
 
-kill_existing() {
-  command -v pkill >/dev/null 2>&1 || return 0
-  local -a names=(
-    chromium
-    chromium-browser
-    chrome
-    google-chrome
-    google-chrome-stable
-    firefox
-    firefox-esr
-  )
-  local name
-  for name in "${names[@]}"; do
-    pkill -u "$(id -u)" -x "$name" >/dev/null 2>&1 || true
-  done
+is_chrome_running_for_profile() {
+  local profile_dir="$1"
+  local pattern="--user-data-dir=${profile_dir}"
+  if pgrep -u "$(id -u)" -f "chrome.*${pattern}" >/dev/null 2>&1; then
+    return 0
+  fi
+  if pgrep -u "$(id -u)" -f "chromium.*${pattern}" >/dev/null 2>&1; then
+    return 0
+  fi
+  return 1
 }
 
-cleanup_profile_locks() {
+list_profile_locks() {
   local dir="$1"
   local -a locks=(SingletonLock SingletonCookie SingletonSocket)
+  local existing=()
+  local lock
+  for lock in "${locks[@]}"; do
+    if [[ -e "${dir}/${lock}" ]]; then
+      existing+=("${dir}/${lock}")
+    fi
+  done
+  printf '%s\n' "${existing[@]:-}"
+}
 
+cleanup_orphan_profile_locks() {
+  local dir="$1"
   local running=0
-  if pgrep -u "$(id -u)" -f "chrome.*--class=pantalla-kiosk" >/dev/null 2>&1; then
+  if is_chrome_running_for_profile "$dir"; then
     running=1
+  fi
+
+  local -a locks_to_remove
+  mapfile -t locks_to_remove < <(list_profile_locks "$dir") || true
+
+  if [[ ${#locks_to_remove[@]} -eq 0 ]]; then
+    log_info "Perfil sin locks pendientes en ${dir}"
+    return 0
+  fi
+
+  if [[ $running -eq 1 ]]; then
+    log_info "Locks presentes en ${dir} pero Chrome sigue activo; no se tocan"
+    return 1
   fi
 
   local removed=0
   local lock
-  for lock in "${locks[@]}"; do
-    if [[ -e "${dir}/${lock}" ]]; then
-      if [[ $running -eq 0 ]]; then
-        rm -f "${dir}/${lock}" || true
-        removed=1
-        log "INFO: Eliminado lock de perfil ${dir}/${lock} (sin Chrome activo)"
-      else
-        log "INFO: Lock ${lock} presente pero Chrome sigue activo; se mantiene"
-      fi
-    fi
+  for lock in "${locks_to_remove[@]}"; do
+    rm -f -- "$lock" || true
+    log_warn "Lock huérfano eliminado: ${lock}"
+    removed=1
   done
-
   if [[ $removed -eq 0 ]]; then
-    log "Perfil sin locks pendientes en ${dir}"
+    log_info "No se eliminaron locks en ${dir}"
   fi
+  return 0
 }
 
 print_chrome_logs() {
   local profile_dir="$1"
   local -a candidates=(
     "${profile_dir}/chrome_debug.log"
-    "$HOME/.cache/google-chrome/chrome_debug.log"
     "$HOME/.config/google-chrome/chrome_debug.log"
-    "$HOME/.cache/pantalla-reloj/chromium/chrome_debug.log"
+    "$HOME/.cache/google-chrome/chrome_debug.log"
   )
 
   local candidate printed=0
   for candidate in "${candidates[@]}"; do
     if [[ -f "$candidate" ]]; then
-      log "Últimas líneas de ${candidate}:"
+      log_info "Últimas líneas de ${candidate}:"
       tail -n 50 "$candidate" >&2 || true
       printed=1
       break
@@ -233,50 +236,49 @@ print_chrome_logs() {
   done
 
   if [[ $printed -eq 0 ]]; then
-    log "No se encontró chrome_debug.log para inspeccionar"
+    log_info "No se encontró chrome_debug.log para inspeccionar"
   fi
 }
 
 wait_for_backend() {
   local max_attempts="${1:-60}"
   local attempt=0
-  log "Esperando a que el backend esté listo (máx ${max_attempts}s)..."
-  
+  log_info "Esperando a que el backend esté listo (máx ${max_attempts}s)..."
+
   while [[ $attempt -lt $max_attempts ]]; do
     if curl -sf --max-time 2 http://127.0.0.1:8081/api/health >/dev/null 2>&1; then
-      log "Backend listo en el intento $((attempt + 1))"
+      log_info "Backend listo en el intento $((attempt + 1))"
       return 0
     fi
     sleep 1
     attempt=$((attempt + 1))
   done
-  
-  log "WARN: Backend no responde después de ${max_attempts}s, continuando de todos modos..."
+
+  log_warn "Backend no responde después de ${max_attempts}s, continuando de todos modos..."
   return 1
 }
 
 wait_for_frontend() {
   local max_attempts="${1:-30}"
   local attempt=0
-  log "Esperando a que el frontend esté listo (máx ${max_attempts}s)..."
-  
+  log_info "Esperando a que el frontend esté listo (máx ${max_attempts}s)..."
+
   while [[ $attempt -lt $max_attempts ]]; do
     if curl -sf --max-time 2 http://127.0.0.1/ >/dev/null 2>&1; then
-      log "Frontend listo en el intento $((attempt + 1))"
+      log_info "Frontend listo en el intento $((attempt + 1))"
       return 0
     fi
     sleep 1
     attempt=$((attempt + 1))
   done
-  
-  log "WARN: Frontend no responde después de ${max_attempts}s, continuando de todos modos..."
+
+  log_warn "Frontend no responde después de ${max_attempts}s, continuando de todos modos..."
   return 1
 }
 
 launch_chromium() {
   local binary="$1" url="$2" profile_dir="$3" log_file="$4"
-  local -a cmd
-  cmd=(
+  local -a cmd=(
     "$binary"
     --class=pantalla-kiosk
     --kiosk
@@ -293,50 +295,48 @@ launch_chromium() {
     cmd+=("--ozone-platform=${CHROME_OZONE_PLATFORM}")
   fi
   if [[ "${CHROME_NO_SANDBOX:-0}" == "1" ]]; then
-    log "WARN: CHROME_NO_SANDBOX=1 habilitado; --no-sandbox reduce la seguridad"
+    log_warn "CHROME_NO_SANDBOX=1 habilitado; --no-sandbox reduce la seguridad"
     cmd+=(--no-sandbox)
   fi
   if [[ "${CHROME_DISABLE_CRASH_REPORTER:-0}" == "1" ]]; then
     cmd+=(--disable-crash-reporter --disable-breakpad)
   fi
-
   if [[ -n "${CHROME_EXTRA_FLAGS:-}" ]]; then
     # shellcheck disable=SC2206
     local extra_flags=( ${CHROME_EXTRA_FLAGS} )
     cmd+=("${extra_flags[@]}")
   fi
-
   cmd+=("${url}")
 
-  log "chromium_bin: ${binary}"
-  log "profile_dir: ${profile_dir}"
-  log "launch: ${cmd[*]}"
-  log "url: ${url}"
+  log_info "chromium_bin: ${binary}"
+  log_info "profile_dir: ${profile_dir}"
+  log_info "launch: ${cmd[*]}"
+  log_info "url: ${url}"
 
-  # Verificar que el perfil existe (no modificar permisos aquí)
   verify_profile_dir "$profile_dir" "Chrome"
-  cleanup_profile_locks "$profile_dir"
 
-  # Esperar a que el backend y frontend estén listos antes de lanzar Chrome
-  # Esto evita la pantalla negra al arrancar desde un estado "frío"
+  if is_chrome_running_for_profile "$profile_dir"; then
+    log_warn "Chrome ya está en ejecución con ${profile_dir}; no se lanzará otra instancia"
+    return 0
+  fi
+
+  cleanup_orphan_profile_locks "$profile_dir"
+
   wait_for_backend 60
   wait_for_frontend 30
-
-  # Dar tiempo adicional para que todo se estabilice después de un arranque frío
   sleep 3
 
   local retry=0
-  local chrome_pid
-  local exit_code
   local -a backoffs=(2 3 5 8 10 12 15)
   local backoff_index=0
+  local early_zero_without_locks=0
 
   while [[ $retry -lt $MAX_RETRIES ]]; do
     local start_time end_time duration
     start_time=$(date +%s)
 
     "${cmd[@]}" >>"$log_file" 2>&1 &
-    chrome_pid=$!
+    local chrome_pid=$!
 
     local elapsed=0
     while [[ $elapsed -lt $SUCCESS_THRESHOLD ]]; do
@@ -347,51 +347,78 @@ launch_chromium() {
       elapsed=$((elapsed + 1))
     done
 
+    local exit_code=0
     if kill -0 "$chrome_pid" 2>/dev/null; then
-      log "Chrome arrancó correctamente (PID: $chrome_pid, viva > ${SUCCESS_THRESHOLD}s)"
+      log_info "Chrome arrancó correctamente (PID: $chrome_pid, viva > ${SUCCESS_THRESHOLD}s)"
       wait "$chrome_pid"
       exit_code=$?
-      log "Chrome terminó con código ${exit_code}"
-      if [[ $exit_code -ne 0 ]]; then
-        print_chrome_logs "$profile_dir"
-      fi
-      exit "$exit_code"
+    else
+      wait "$chrome_pid"
+      exit_code=$?
     fi
 
-    wait "$chrome_pid"
-    exit_code=$?
     end_time=$(date +%s)
     duration=$((end_time - start_time))
-    retry=$((retry + 1))
-    log "WARN: Chrome terminó en ${duration}s (código ${exit_code}) intento ${retry}/${MAX_RETRIES}"
-    print_chrome_logs "$profile_dir"
 
-    if command -v pkill >/dev/null 2>&1; then
-      pkill -u "$(id -u)" -f "chrome.*--class=pantalla-kiosk" >/dev/null 2>&1 || true
-    fi
-    cleanup_profile_locks "$profile_dir"
+    local -a locks_after
+    mapfile -t locks_after < <(list_profile_locks "$profile_dir") || true
 
-    if [[ $retry -lt $MAX_RETRIES ]]; then
-      local sleep_time=${backoffs[$backoff_index]:-$MAX_BACKOFF}
-      if [[ $sleep_time -gt $MAX_BACKOFF ]]; then
-        sleep_time=$MAX_BACKOFF
-      fi
-      log "Reintentando en ${sleep_time}s (backoff)"
-      sleep "$sleep_time"
-      if [[ $backoff_index -lt ${#backoffs[@]}-1 ]]; then
-        backoff_index=$((backoff_index + 1))
-      fi
+    log_info "Intento $((retry + 1))/${MAX_RETRIES}: Chrome terminó en ${duration}s con código ${exit_code}"
+    if [[ ${#locks_after[@]} -gt 0 ]]; then
+      log_info "Locks tras salida: ${locks_after[*]}"
     else
-      log "ERROR: Chrome falló después de ${MAX_RETRIES} intentos"
-      exit 1
+      log_info "Locks tras salida: ninguno"
+    fi
+
+    if [[ $exit_code -eq 0 && $duration -lt $EARLY_EXIT_THRESHOLD ]]; then
+      if [[ ${#locks_after[@]} -gt 0 ]]; then
+        log_warn "Salida temprana con código 0 y locks presentes; limpiando perfil y reintentando"
+        cleanup_orphan_profile_locks "$profile_dir"
+        print_chrome_logs "$profile_dir"
+      else
+        if [[ $early_zero_without_locks -ge 1 ]]; then
+          log_error "Chrome salió en <${EARLY_EXIT_THRESHOLD}s con código 0 sin locks por segunda vez; abortando para evitar bucle"
+          print_chrome_logs "$profile_dir"
+          return 10
+        fi
+        early_zero_without_locks=$((early_zero_without_locks + 1))
+        log_warn "Chrome salió en <${EARLY_EXIT_THRESHOLD}s con código 0 sin locks; se reintentará una vez"
+      fi
+    elif [[ $exit_code -ne 0 ]]; then
+      log_warn "Chrome terminó con error (código ${exit_code}); se reintentará si quedan intentos"
+      print_chrome_logs "$profile_dir"
+    else
+      if [[ $duration -lt $SUCCESS_THRESHOLD ]]; then
+        log_warn "Chrome salió después de ${duration}s; código ${exit_code}"
+      fi
+      return "$exit_code"
+    fi
+
+    retry=$((retry + 1))
+    if [[ $retry -ge $MAX_RETRIES ]]; then
+      log_error "Chrome falló después de ${MAX_RETRIES} intentos"
+      return 1
+    fi
+
+    cleanup_orphan_profile_locks "$profile_dir"
+
+    local sleep_time=${backoffs[$backoff_index]:-$MAX_BACKOFF}
+    if [[ $sleep_time -gt $MAX_BACKOFF ]]; then
+      sleep_time=$MAX_BACKOFF
+    fi
+    log_info "Reintentando en ${sleep_time}s (backoff)"
+    sleep "$sleep_time"
+    if [[ $backoff_index -lt ${#backoffs[@]}-1 ]]; then
+      backoff_index=$((backoff_index + 1))
     fi
   done
+
+  return 1
 }
 
 launch_firefox() {
   local binary="$1" url="$2" profile_dir="$3" log_file="$4"
-  local -a cmd
-  cmd=(
+  local -a cmd=(
     "$binary"
     --kiosk
     --new-instance
@@ -404,15 +431,12 @@ launch_firefox() {
   export MOZ_USE_XINPUT2=1
   export MOZ_CRASHREPORTER_DISABLE=1
 
-  log "firefox_bin: ${binary}"
-  log "profile_dir: ${profile_dir}"
-  log "launch: ${cmd[*]}"
-  log "url: ${url}"
+  log_info "firefox_bin: ${binary}"
+  log_info "profile_dir: ${profile_dir}"
+  log_info "launch: ${cmd[*]}"
+  log_info "url: ${url}"
 
-  if ! exec "${cmd[@]}" >>"$log_file" 2>&1; then
-    log "ERROR: fallo al ejecutar Firefox (${binary})"
-    exit 1
-  fi
+  exec "${cmd[@]}" >>"$log_file" 2>&1
 }
 
 main() {
@@ -440,26 +464,24 @@ main() {
   log_dir="${PANTALLA_KIOSK_LOG_DIR:-${DEFAULT_LOG_DIR}}"
   log_file="${log_dir}/browser-kiosk.log"
 
-  # Verificar que los directorios base existen (solo crear logs, no perfiles)
   prepare_log_dir "$log_dir"
-  
-  # Verificar perfiles (NO crear ni modificar permisos - eso se hace en install.sh)
+
   verify_profile_dir "$chromium_profile" "Chrome"
   verify_profile_dir "$firefox_profile" "Firefox"
-
-  kill_existing
 
   local browser
   if browser="$(find_chromium)"; then
     launch_chromium "$browser" "$target_url" "$chromium_profile" "$log_file"
+    return $?
   fi
 
   if browser="$(find_firefox)"; then
     launch_firefox "$browser" "$target_url" "$firefox_profile" "$log_file"
+    return $?
   fi
 
-  log "ERROR: no se encontró un navegador compatible (Chromium/Firefox)"
-  exit 1
+  log_error "No se encontró un navegador compatible (Chromium/Firefox)"
+  return 1
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- make the kiosk wrapper tolerant of orphaned Chrome profile locks with better diagnostics and retry logic
- adjust the systemd unit restart policy and installation scripts, including timestamped logging and new verification tooling
- update README and verify_kiosk.sh to document and check kiosk health and orphaned locks

## Testing
- bash -n usr/local/bin/pantalla-kiosk
- bash -n scripts/verify_kiosk.sh
- bash -n scripts/install.sh
- bash -n scripts/uninstall.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c4c12f4d4832680d6a7c4c75424a6)